### PR TITLE
Feat: 호스트 숙소 등록 페이지 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-date-range": "^1.4.10",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.4",
+        "baseline-browser-mapping": "^2.9.11",
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
@@ -1911,9 +1912,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.14.tgz",
-      "integrity": "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==",
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-date-range": "^1.4.10",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.4",
+    "baseline-browser-mapping": "^2.9.11",
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",

--- a/src/assets/images/hosting_step2.svg
+++ b/src/assets/images/hosting_step2.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="650" viewBox="0 0 900 650" fill="none">
+  <defs>
+    <linearGradient id="floor" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#F3F4F6"/>
+      <stop offset="1" stop-color="#E5E7EB"/>
+    </linearGradient>
+    <linearGradient id="wall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F5F5F5"/>
+    </linearGradient>
+    <linearGradient id="shadow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#000000" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#000000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+
+  <!-- soft shadow -->
+  <ellipse cx="560" cy="520" rx="240" ry="60" fill="url(#shadow)"/>
+
+  <!-- isometric floor -->
+  <path d="M360 470 L610 390 L820 500 L570 585 Z" fill="url(#floor)" stroke="#E5E7EB"/>
+
+  <!-- walls -->
+  <path d="M360 260 L610 180 L610 390 L360 470 Z" fill="url(#wall)" stroke="#E5E7EB"/>
+  <path d="M610 180 L820 290 L820 500 L610 390 Z" fill="url(#wall)" stroke="#E5E7EB"/>
+
+  <!-- window -->
+  <path d="M645 230 L760 292 L760 395 L645 332 Z" fill="#FFFFFF" stroke="#D1D5DB"/>
+  <path d="M702 261 L702 363" stroke="#D1D5DB"/>
+  <path d="M645 282 L760 345" stroke="#D1D5DB"/>
+
+  <!-- bed (simple) -->
+  <path d="M470 350 L560 310 L645 360 L555 400 Z" fill="#FDE68A" stroke="#F59E0B"/>
+  <path d="M470 350 L470 315 L560 275 L560 310 Z" fill="#FFF7ED" stroke="#FDBA74"/>
+  <path d="M560 275 L645 325 L645 360 L560 310 Z" fill="#FFF7ED" stroke="#FDBA74"/>
+
+  <!-- sofa -->
+  <path d="M560 475 L635 440 L700 475 L625 510 Z" fill="#93C5FD" stroke="#60A5FA"/>
+  <path d="M560 475 L560 440 L635 405 L635 440 Z" fill="#BFDBFE" stroke="#60A5FA"/>
+
+  <!-- small decor -->
+  <circle cx="735" cy="260" r="10" fill="#34D399"/>
+  <path d="M735 270 L735 300" stroke="#10B981" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- subtle label -->
+  <text x="560" y="610" text-anchor="middle" font-family="system-ui, -apple-system, Segoe UI, Roboto" font-size="18" fill="#6B7280">(임시 일러스트 — 나중에 에어비앤비 스타일 이미지로 교체 가능)</text>
+</svg>

--- a/src/components/AccommodationCard/AccommodationCard.tsx
+++ b/src/components/AccommodationCard/AccommodationCard.tsx
@@ -51,7 +51,7 @@ const formatNights = (nights: number): string => {
   return `${nights}박`;
 };
 
-const AccommodationCard: React.FC<AccommodationCardProps> = ({
+const AccommodationCard = ({
   image,
   badge,
   title,
@@ -61,7 +61,7 @@ const AccommodationCard: React.FC<AccommodationCardProps> = ({
   rating,
   isFavorite = false,
   onFavoriteClick,
-}) => {
+}: AccommodationCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleHeartClick = (e: React.MouseEvent) => {

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -8,7 +8,7 @@ export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
   left: 0;
   right: 0;
   height: ${({ $isScrolled, theme }) =>
-    $isScrolled ? `${theme.spacing['4xl']}` : `${theme.spacing['5xl']}`};
+    $isScrolled ? `${theme.spacing['5xl']}` : `${theme.spacing['6xl']}`};
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
@@ -16,16 +16,15 @@ export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
   background: ${({ theme }) => theme.colors.common.white};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
   z-index: ${({ theme }) => theme.zIndex.header};
-  transition: height ${({ theme }) => theme.transition.slow},
-    box-shadow ${({ theme }) => theme.transition.slow};
+  transition: all ${({ theme }) => theme.transition.slow};
   box-shadow: ${({ $isScrolled, theme }) =>
-    $isScrolled ? theme.shadow.sm : 'none'};
+    $isScrolled ? theme.shadow.md : 'none'};
 
   ${media.mobile} {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto 1fr;
     padding: 0 ${({ theme }) => theme.spacing.lg};
     height: ${({ $isScrolled, theme }) =>
-      $isScrolled ? `${theme.spacing['3xl']}` : `${theme.spacing['4xl']}`};
+      $isScrolled ? `${theme.spacing['4xl']}` : `${theme.spacing['5xl']}`};
   }
 `;
 
@@ -67,12 +66,6 @@ export const HeaderCenter = styled.nav<{ $isScrolled?: boolean }>`
   gap: ${({ theme }) => theme.spacing['2xl']};
   justify-content: center;
   justify-self: center;
-
-  ${({ $isScrolled }) =>
-    $isScrolled &&
-    `
-    display: none;
-  `}
 
   ${media.mobile} {
     display: none;
@@ -137,23 +130,6 @@ export const HeaderRight = styled.div`
   }
 `;
 
-export const HostModeToggle = styled.button<{ $active?: boolean }>`
-  width: ${({ theme }) => theme.spacing['3xl']};
-  height: ${({ theme }) => theme.spacing.xl};
-  border-radius: ${({ theme }) => theme.radius.full};
-  border: 1px solid ${({ theme }) => theme.colors.border.primary};
-  background: ${({ theme, $active }) =>
-    $active ? theme.colors.primary.main : theme.colors.common.white};
-  color: ${({ theme, $active }) =>
-    $active ? theme.colors.common.white : theme.colors.text.primary};
-  font-size: ${({ theme }) => theme.font.size.xs};
-  font-weight: ${({ theme }) => theme.font.weight.bold};
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: ${({ theme }) => theme.transition.colors.normal};
-`;
 
 export const MenuButton = styled.button`
   width: ${({ theme }) => theme.spacing['3xl']};

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -21,7 +21,7 @@ export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
     $isScrolled ? theme.shadow.md : 'none'};
 
   ${media.mobile} {
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr auto;
     padding: 0 ${({ theme }) => theme.spacing.lg};
     height: ${({ $isScrolled, theme }) =>
       $isScrolled ? `${theme.spacing['4xl']}` : `${theme.spacing['5xl']}`};
@@ -191,5 +191,26 @@ export const LoginButton = styled.button`
   font-family: inherit;
   &:hover {
     text-decoration: underline;
+  }
+`;
+
+export const HostButton = styled.button`
+  background: none;
+  border: none;
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  border-radius: ${({ theme }) => theme.radius.full};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  transition: background-color ${({ theme }) => theme.transition.normal};
+  white-space: nowrap;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  ${media.mobile} {
+    display: none;
   }
 `;

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -1,6 +1,6 @@
-import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import { media } from '@/styles/media';
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+import { media } from "@/styles/media";
 
 export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
   position: fixed;
@@ -8,23 +8,23 @@ export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
   left: 0;
   right: 0;
   height: ${({ $isScrolled, theme }) =>
-    $isScrolled ? `${theme.spacing['5xl']}` : `${theme.spacing['6xl']}`};
+    $isScrolled ? `${theme.spacing["5xl"]}` : `${theme.spacing["6xl"]}`};
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  padding: 0 ${({ theme }) => theme.spacing["3xl"]};
   background: ${({ theme }) => theme.colors.background.default};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
   z-index: ${({ theme }) => theme.zIndex.header};
   transition: all ${({ theme }) => theme.transition.slow};
   box-shadow: ${({ $isScrolled, theme }) =>
-    $isScrolled ? theme.shadow.md : 'none'};
+    $isScrolled ? theme.shadow.md : "none"};
 
   ${media.mobile} {
     grid-template-columns: 1fr auto;
     padding: 0 ${({ theme }) => theme.spacing.lg};
     height: ${({ $isScrolled, theme }) =>
-      $isScrolled ? `${theme.spacing['4xl']}` : `${theme.spacing['5xl']}`};
+      $isScrolled ? `${theme.spacing["4xl"]}` : `${theme.spacing["5xl"]}`};
   }
 `;
 
@@ -46,8 +46,8 @@ export const HeaderLeft = styled(Link)`
 `;
 
 export const Logo = styled.img`
-  width: ${({ theme }) => theme.spacing['2xl']};
-  height: ${({ theme }) => theme.spacing['2xl']};
+  width: ${({ theme }) => theme.spacing["3xl"]};
+  height: ${({ theme }) => theme.spacing["3xl"]};
 `;
 
 export const LogoText = styled.span`
@@ -63,7 +63,7 @@ export const LogoText = styled.span`
 export const HeaderCenter = styled.nav<{ $isScrolled?: boolean }>`
   display: flex;
   align-items: center;
-  gap: ${({ theme }) => theme.spacing['2xl']};
+  gap: ${({ theme }) => theme.spacing["2xl"]};
   justify-content: center;
   justify-self: center;
 
@@ -93,7 +93,7 @@ export const NavItem = styled.button<{ $active?: boolean }>`
   }
 
   &::after {
-    content: '';
+    content: "";
     position: absolute;
     bottom: 0;
     left: ${({ theme }) => theme.spacing.lg};
@@ -130,10 +130,9 @@ export const HeaderRight = styled.div`
   }
 `;
 
-
 export const MenuButton = styled.button`
-  width: ${({ theme }) => theme.spacing['3xl']};
-  height: ${({ theme }) => theme.spacing['3xl']};
+  width: ${({ theme }) => theme.spacing["3xl"]};
+  height: ${({ theme }) => theme.spacing["3xl"]};
   border-radius: ${({ theme }) => theme.radius.md};
   border: 1px solid ${({ theme }) => theme.colors.border.primary};
   background: ${({ theme }) => theme.colors.common.white};

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -13,7 +13,7 @@ export const HeaderContainer = styled.header<{ $isScrolled?: boolean }>`
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   padding: 0 ${({ theme }) => theme.spacing['3xl']};
-  background: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.background.default};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
   z-index: ${({ theme }) => theme.zIndex.header};
   transition: all ${({ theme }) => theme.transition.slow};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   HeaderContainer,
   HeaderLeft,
@@ -28,6 +28,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
   const location = useLocation();
+  const navigate = useNavigate();
   const isMainPage = location.pathname === '/';
   const [isLoginOpen, setIsLoginOpen] = React.useState(false);
   const [isProfileOpen, setIsProfileOpen] = React.useState(false);
@@ -83,13 +84,9 @@ const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
         </HeaderCenter>
 
         <HeaderRight>
-          <HostButton type="button" onClick={() => {}}>
+          <HostButton type="button" onClick={() => navigate('/hosting')}>
             호스트로 등록하기
           </HostButton>
-
-          <ProfileButton type="button" onClick={() => {}}>
-            <User size={20} />
-          </ProfileButton>
 
           {isAuthenticated && user ? (
             <ProfileDropdownWrapper>
@@ -110,9 +107,16 @@ const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
               )}
             </ProfileDropdownWrapper>
           ) : (
-            <LoginButton type="button" onClick={() => setIsLoginOpen(true)}>
-              로그인
-            </LoginButton>
+            <>
+              <ProfileButton type="button" onClick={() => setIsLoginOpen(true)}>
+                <ProfilePlaceholder>
+                  <User size={18} />
+                </ProfilePlaceholder>
+              </ProfileButton>
+              <LoginButton type="button" onClick={() => setIsLoginOpen(true)}>
+                로그인
+              </LoginButton>
+            </>
           )}
         </HeaderRight>
       </HeaderContainer>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -26,7 +26,7 @@ interface HeaderProps {
   isScrolled?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
+const Header = ({ isScrolled = false }: HeaderProps) => {
   const location = useLocation();
   const navigate = useNavigate();
   const isMainPage = location.pathname === '/';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,6 +9,7 @@ import {
   NavItem,
   NavBadge,
   HeaderRight,
+  HostButton,
   ProfileDropdownWrapper,
   ProfileButton,
   ProfilePlaceholder,
@@ -82,6 +83,10 @@ const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
         </HeaderCenter>
 
         <HeaderRight>
+          <HostButton type="button" onClick={() => {}}>
+            호스트로 등록하기
+          </HostButton>
+
           <ProfileButton type="button" onClick={() => {}}>
             <User size={20} />
           </ProfileButton>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -9,17 +9,17 @@ import {
   NavItem,
   NavBadge,
   HeaderRight,
-  HostModeToggle,
   ProfileDropdownWrapper,
   ProfileButton,
   ProfilePlaceholder,
   LoginButton,
 } from './Header.styles';
-import { Home, Sparkles, Bell } from 'lucide-react';
+import { Home, Sparkles, Bell, User } from 'lucide-react';
 import logo from '@/assets/images/logo.svg';
 import LoginModal from '@/pages/auth/LoginPage';
 import ProfileDropdown from '@/components/ProfileDropdown';
 import { useAuth } from '@/contexts/AuthContext';
+import SearchBar from '@/components/SearchBar/SearchBar';
 
 interface HeaderProps {
   isScrolled?: boolean;
@@ -27,7 +27,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
   const location = useLocation();
-  const [hostMode, setHostMode] = React.useState(false);
+  const isMainPage = location.pathname === '/';
   const [isLoginOpen, setIsLoginOpen] = React.useState(false);
   const [isProfileOpen, setIsProfileOpen] = React.useState(false);
   const { isAuthenticated, user } = useAuth();
@@ -52,11 +52,6 @@ const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
     return '숙소'; // 기본값
   }, [location.pathname]);
 
-  const toggleHostMode = React.useCallback(
-    () => setHostMode((prev) => !prev),
-    []
-  );
-
   return (
     <>
       <HeaderContainer $isScrolled={isScrolled}>
@@ -66,26 +61,30 @@ const Header: React.FC<HeaderProps> = ({ isScrolled = false }) => {
         </HeaderLeft>
 
         <HeaderCenter $isScrolled={isScrolled}>
-          <NavItem $active={activeNav === '숙소'}>
-            <Home size={18} />
-            <span>숙소</span>
-          </NavItem>
-          <NavItem $active={activeNav === '체험'}>
-            <Sparkles size={18} />
-            <span>체험</span>
-            <NavBadge>NEW</NavBadge>
-          </NavItem>
-          <NavItem $active={activeNav === '서비스'}>
-            <Bell size={18} />
-            <span>서비스</span>
-            <NavBadge>NEW</NavBadge>
-          </NavItem>
+          {isScrolled && isMainPage ? (
+            <SearchBar isCompact={true} />
+          ) : (
+            <>
+              <NavItem $active={activeNav === '숙소'}>
+                <Home size={18} />
+                <span>숙소</span>
+              </NavItem>
+              <NavItem $active={activeNav === '체험'}>
+                <Sparkles size={18} />
+                <span>체험</span>
+              </NavItem>
+              <NavItem $active={activeNav === '서비스'}>
+                <Bell size={18} />
+                <span>서비스</span>
+              </NavItem>
+            </>
+          )}
         </HeaderCenter>
 
         <HeaderRight>
-          <HostModeToggle $active={hostMode} onClick={toggleHostMode}>
-            {hostMode ? '예' : '아니오'}
-          </HostModeToggle>
+          <ProfileButton type="button" onClick={() => {}}>
+            <User size={20} />
+          </ProfileButton>
 
           {isAuthenticated && user ? (
             <ProfileDropdownWrapper>

--- a/src/components/HostingHeader/HostingHeader.styles.ts
+++ b/src/components/HostingHeader/HostingHeader.styles.ts
@@ -1,0 +1,164 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { media } from '@/styles/media';
+
+export const HeaderContainer = styled.header`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: ${({ theme }) => theme.spacing['6xl']};
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  background: ${({ theme }) => theme.colors.background.default};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+  z-index: ${({ theme }) => theme.zIndex.header};
+
+  ${media.mobile} {
+    grid-template-columns: 1fr auto;
+    padding: 0 ${({ theme }) => theme.spacing.lg};
+    height: ${({ theme }) => theme.spacing['5xl']};
+  }
+`;
+
+export const HeaderLeft = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  justify-self: start;
+`;
+
+export const Logo = styled.img`
+  width: ${({ theme }) => theme.spacing['3xl']};
+  height: ${({ theme }) => theme.spacing['3xl']};
+`;
+
+export const LogoText = styled.span`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.primary.main};
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.md};
+  }
+`;
+
+export const HeaderCenter = styled.nav`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  justify-content: center;
+
+  ${media.mobile} {
+    display: none;
+  }
+`;
+
+export const NavItem = styled.button<{ $active?: boolean }>`
+  background: none;
+  border: none;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme, $active }) => ($active ? theme.font.weight.bold : theme.font.weight.medium)};
+  color: ${({ theme }) => theme.colors.text.primary};
+  position: relative;
+  transition: color ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.common.black};
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: ${({ theme }) => theme.spacing.lg};
+    right: ${({ theme }) => theme.spacing.lg};
+    height: 2px;
+    background: ${({ theme }) => theme.colors.primary.main};
+    opacity: ${({ $active }) => ($active ? 1 : 0)};
+    transition: opacity ${({ theme }) => theme.transition.normal};
+  }
+`;
+
+export const HeaderRight = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  justify-self: end;
+
+  ${media.mobile} {
+    gap: ${({ theme }) => theme.spacing.sm};
+  }
+`;
+
+export const SwitchModeButton = styled.button`
+  background: none;
+  border: none;
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  border-radius: ${({ theme }) => theme.radius.full};
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  transition: background-color ${({ theme }) => theme.transition.normal};
+  white-space: nowrap;
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+
+  ${media.mobile} {
+    display: none;
+  }
+`;
+
+export const ProfileButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  transition: box-shadow 0.15s ease;
+
+  &:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+`;
+
+export const ProfilePlaceholder = styled.div`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const MenuIconButton = styled.button`
+  background: none;
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  width: ${({ theme }) => theme.spacing['3xl']};
+  height: ${({ theme }) => theme.spacing['3xl']};
+  border-radius: ${({ theme }) => theme.radius.full};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &:hover {
+    box-shadow: ${({ theme }) => theme.shadow.sm};
+    background-color: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+

--- a/src/components/HostingHeader/HostingHeader.tsx
+++ b/src/components/HostingHeader/HostingHeader.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Menu, User } from 'lucide-react';
+import logo from '@/assets/images/logo.svg';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  HeaderContainer,
+  HeaderLeft,
+  Logo,
+  LogoText,
+  HeaderCenter,
+  NavItem,
+  HeaderRight,
+  SwitchModeButton,
+  ProfileButton,
+  ProfilePlaceholder,
+  MenuIconButton,
+} from './HostingHeader.styles';
+
+const HostingHeader: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated, user } = useAuth();
+
+  const activeTab = React.useMemo(() => {
+    if (location.pathname === '/hosting') return '투데이';
+    return '투데이';
+  }, [location.pathname]);
+
+  return (
+    <HeaderContainer>
+      <HeaderLeft to="/">
+        <Logo src={logo} alt="CozyStay Logo" />
+        <LogoText>CozyStay</LogoText>
+      </HeaderLeft>
+
+      <HeaderCenter>
+        <NavItem $active={activeTab === '투데이'}>투데이</NavItem>
+        <NavItem $active={activeTab === '달력'}>달력</NavItem>
+        <NavItem $active={activeTab === '리스팅'}>리스팅</NavItem>
+        <NavItem $active={activeTab === '메시지'}>메시지</NavItem>
+      </HeaderCenter>
+
+      <HeaderRight>
+        <SwitchModeButton onClick={() => navigate('/')}>
+          게스트 모드로 전환
+        </SwitchModeButton>
+        
+        {isAuthenticated && user ? (
+          <ProfileButton type="button" onClick={() => {}}>
+            <ProfilePlaceholder>
+              {user.nickname?.charAt(0)?.toUpperCase() || '?'}
+            </ProfilePlaceholder>
+          </ProfileButton>
+        ) : (
+          <ProfileButton type="button" onClick={() => {}}>
+            <ProfilePlaceholder>
+              <User size={18} />
+            </ProfilePlaceholder>
+          </ProfileButton>
+        )}
+
+        <MenuIconButton>
+          <Menu size={20} />
+        </MenuIconButton>
+      </HeaderRight>
+    </HeaderContainer>
+  );
+};
+
+export default HostingHeader;
+

--- a/src/components/HostingHeader/HostingHeader.tsx
+++ b/src/components/HostingHeader/HostingHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Menu, User } from 'lucide-react';
 import logo from '@/assets/images/logo.svg';
 import { useAuth } from '@/contexts/AuthContext';
@@ -19,13 +19,10 @@ import {
 
 const HostingHeader = () => {
   const navigate = useNavigate();
-  const location = useLocation();
   const { isAuthenticated, user } = useAuth();
 
-  const activeTab = React.useMemo(() => {
-    if (location.pathname === '/hosting') return '투데이';
-    return '투데이';
-  }, [location.pathname]);
+  // TODO: 향후 다른 경로에 따라 탭 활성화 로직 추가 필요 (예: /hosting/calendar → '달력', /hosting/listings → '리스팅')
+  const activeTab = '투데이';
 
   return (
     <HeaderContainer>

--- a/src/components/HostingHeader/HostingHeader.tsx
+++ b/src/components/HostingHeader/HostingHeader.tsx
@@ -17,7 +17,7 @@ import {
   MenuIconButton,
 } from './HostingHeader.styles';
 
-const HostingHeader: React.FC = () => {
+const HostingHeader = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { isAuthenticated, user } = useAuth();

--- a/src/components/SearchBar/SearchBar.styles.ts
+++ b/src/components/SearchBar/SearchBar.styles.ts
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { media } from "@/styles/media";
 
-const SEARCH_BAR_MAX_WIDTH_COMPACT = "300px";
+const SEARCH_BAR_MAX_WIDTH_COMPACT = "340px";
 const SEARCH_BAR_MAX_WIDTH = "850px";
-const SEARCH_BAR_MAX_WIDTH_MOBILE = "280px";
+const SEARCH_BAR_MAX_WIDTH_MOBILE = "300px";
 
 export const SearchBarContainer = styled.div<{ $isCompact?: boolean }>`
   display: flex;
@@ -13,7 +13,7 @@ export const SearchBarContainer = styled.div<{ $isCompact?: boolean }>`
   border-radius: ${({ theme }) => theme.radius.full};
   padding: ${({ $isCompact, theme }) =>
     $isCompact
-      ? `${theme.spacing.sm} ${theme.spacing.lg}`
+      ? `${theme.spacing.xs} ${theme.spacing.sm} ${theme.spacing.xs} ${theme.spacing.lg}`
       : `${theme.spacing.md} ${theme.spacing.sm} ${theme.spacing.md} ${theme.spacing.xl}`};
   box-shadow: ${({ theme }) => theme.shadow.md};
   max-width: ${({ $isCompact }) =>
@@ -102,7 +102,7 @@ export const SearchButton = styled.button<{ $isCompact?: boolean }>`
   transition: ${({ theme }) => theme.transition.colors.normal};
   flex-shrink: 0;
   margin-left: ${({ $isCompact, theme }) =>
-    $isCompact ? theme.spacing.md : "0"};
+    $isCompact ? theme.spacing.xs : "0"};
 
   &:hover {
     background: ${({ theme }) => theme.colors.primary.hover};

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -31,8 +31,8 @@ interface GuestCounterRowProps {
   onUpdate: (type: GuestType, delta: number) => void;
 }
 
-const GuestCounterRow: React.FC<GuestCounterRowProps> = React.memo(
-  ({ label, age, count, guestType, onUpdate }) => (
+const GuestCounterRow = React.memo(
+  ({ label, age, count, guestType, onUpdate }: GuestCounterRowProps) => (
     <GuestSection>
       <div>
         <GuestLabel>{label}</GuestLabel>
@@ -62,7 +62,7 @@ const GuestCounterRow: React.FC<GuestCounterRowProps> = React.memo(
   )
 );
 
-const SearchBar: React.FC<SearchBarProps> = ({ isCompact = false }) => {
+const SearchBar = ({ isCompact = false }: SearchBarProps) => {
   const navigate = useNavigate();
   const [showGuestPopup, setShowGuestPopup] = useState(false);
   const [guests, setGuests] = useState({

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -35,7 +35,7 @@ interface SidebarProps {
   isScrolled?: boolean;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, isScrolled = false }) => {
+const Sidebar = ({ isOpen, onClose, isScrolled = false }: SidebarProps) => {
   const menuItems = [
     { icon: Heart, text: "위시리스트" },
     { icon: Plane, text: "여행" },

--- a/src/components/WishlistModal/WishlistModal.tsx
+++ b/src/components/WishlistModal/WishlistModal.tsx
@@ -23,11 +23,11 @@ interface WishlistModalProps {
   onCreate?: (name: string) => void;
 }
 
-const WishlistModal: React.FC<WishlistModalProps> = ({
+const WishlistModal = ({
   isOpen,
   onClose,
   onCreate,
-}) => {
+}: WishlistModalProps) => {
   const [wishlistName, setWishlistName] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const MAX_LENGTH = 50;

--- a/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.styles.ts
+++ b/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.styles.ts
@@ -1,0 +1,161 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+
+export const LayoutContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: ${({ theme }) => theme.colors.background.default};
+`;
+
+export const Header = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing.xl} ${({ theme }) => theme.spacing['3xl']};
+  background-color: ${({ theme }) => theme.colors.background.default};
+
+  ${media.mobile} {
+    padding: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const LogoLink = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+`;
+
+export const LogoImage = styled.img`
+  width: ${({ theme }) => theme.spacing['3xl']};
+  height: ${({ theme }) => theme.spacing['3xl']};
+`;
+
+export const HeaderButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const HeaderButton = styled.button`
+  background: none;
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.xl}`};
+  border-radius: ${({ theme }) => theme.radius.full};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    border-color: ${({ theme }) => theme.colors.primary.main};
+    color: ${({ theme }) => theme.colors.primary.main};
+  }
+`;
+
+export const Main = styled.main`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  margin-bottom: 80px; // Footer height
+
+  ${media.mobile} {
+    padding: 0 ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const Footer = styled.footer`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background-color: ${({ theme }) => theme.colors.background.default};
+  display: flex;
+  flex-direction: column;
+  z-index: ${({ theme }) => theme.zIndex.header};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const ProgressBarContainer = styled.div`
+  display: flex;
+  height: 6px;
+  gap: ${({ theme }) => theme.spacing.xs};
+  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
+
+  ${media.mobile} {
+    padding: 0 ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const ProgressSegment = styled.div<{ $active?: boolean; $completed?: boolean }>`
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.full};
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: ${({ theme }) => theme.colors.primary.main};
+    transform-origin: left center;
+    transform: scaleX(${({ $active, $completed }) => ($completed ? 1 : $active ? 1 : 0)});
+    transition: transform ${({ theme }) => theme.transition.slow};
+    border-radius: ${({ theme }) => theme.radius.full};
+  }
+`;
+
+export const FooterControls = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  height: 100%;
+
+  ${media.mobile} {
+    padding: 0 ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const BackButton = styled.button`
+  background: none;
+  border: none;
+  text-decoration: underline;
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &:disabled {
+    color: ${({ theme }) => theme.colors.border.primary};
+    cursor: not-allowed;
+  }
+`;
+
+export const NextButton = styled.button`
+  background-color: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  border: none;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  transition: opacity ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primary.hover};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.border.light};
+    cursor: not-allowed;
+  }
+`;
+

--- a/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.tsx
+++ b/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.tsx
@@ -29,7 +29,7 @@ interface HostingRegistrationLayoutProps {
   showProgressBar?: boolean;
 }
 
-const HostingRegistrationLayout: React.FC<HostingRegistrationLayoutProps> = ({
+const HostingRegistrationLayout = ({
   children,
   currentStep,
   totalSteps,
@@ -39,7 +39,7 @@ const HostingRegistrationLayout: React.FC<HostingRegistrationLayoutProps> = ({
   backDisabled,
   nextLabel = '다음',
   showProgressBar = true,
-}) => {
+}: HostingRegistrationLayoutProps) => {
   const navigate = useNavigate();
 
   return (

--- a/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.tsx
+++ b/src/layouts/HostingRegistrationLayout/HostingRegistrationLayout.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import logo from '@/assets/images/logo.svg';
+import {
+  LayoutContainer,
+  Header,
+  LogoLink,
+  LogoImage,
+  HeaderButtons,
+  HeaderButton,
+  Main,
+  Footer,
+  ProgressBarContainer,
+  ProgressSegment,
+  FooterControls,
+  BackButton,
+  NextButton,
+} from './HostingRegistrationLayout.styles';
+
+interface HostingRegistrationLayoutProps {
+  children: React.ReactNode;
+  currentStep: number;
+  totalSteps: number;
+  onNext?: () => void;
+  onBack?: () => void;
+  nextDisabled?: boolean;
+  backDisabled?: boolean;
+  nextLabel?: string;
+  showProgressBar?: boolean;
+}
+
+const HostingRegistrationLayout: React.FC<HostingRegistrationLayoutProps> = ({
+  children,
+  currentStep,
+  totalSteps,
+  onNext,
+  onBack,
+  nextDisabled,
+  backDisabled,
+  nextLabel = '다음',
+  showProgressBar = true,
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <LayoutContainer>
+      <Header>
+        <LogoLink onClick={() => navigate('/')}>
+          <LogoImage src={logo} alt="CozyStay Logo" />
+        </LogoLink>
+        <HeaderButtons>
+          <HeaderButton onClick={() => {}}>궁금하신 점이 있나요?</HeaderButton>
+          <HeaderButton onClick={() => navigate('/hosting')}>저장 후 나가기</HeaderButton>
+        </HeaderButtons>
+      </Header>
+
+      <Main>{children}</Main>
+
+      <Footer>
+        {showProgressBar && (
+          <ProgressBarContainer>
+            {Array.from({ length: totalSteps }).map((_, i) => (
+              <ProgressSegment
+                key={i}
+                $active={i === currentStep - 1}
+                $completed={i < currentStep - 1}
+              />
+            ))}
+          </ProgressBarContainer>
+        )}
+        <FooterControls>
+          <BackButton onClick={onBack} disabled={backDisabled}>
+            뒤로
+          </BackButton>
+          <NextButton onClick={onNext} disabled={nextDisabled}>
+            {nextLabel}
+          </NextButton>
+        </FooterControls>
+      </Footer>
+    </LayoutContainer>
+  );
+};
+
+export default HostingRegistrationLayout;
+

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -57,7 +57,7 @@ const STEPS = [
   { component: HostDetails, showProgress: true, nextLabel: '리스팅 만들기' },
 ] as const;
 
-const BecomeHostPage: React.FC = () => {
+const BecomeHostPage = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
   

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import HostingRegistrationLayout from '@/layouts/HostingRegistrationLayout/HostingRegistrationLayout';
+import Overview from './steps/Overview';
+import Phase1Intro from './steps/Phase1Intro';
+import CategorySelect from './steps/CategorySelect';
+import SpaceType from './steps/SpaceType';
+import Location from './steps/Location';
+import GuestCapacity from './steps/GuestCapacity';
+import Bathrooms from './steps/Bathrooms';
+import Occupants from './steps/Occupants';
+import Phase2Intro from './steps/Phase2Intro';
+import Amenities from './steps/Amenities';
+import Photos from './steps/Photos';
+import TitleStep from './steps/Title';
+import Description from './steps/Description';
+import Phase3Intro from './steps/Phase3Intro';
+import BookingSettings from './steps/BookingSettings';
+import GuestRequirements from './steps/GuestRequirements';
+import Pricing from './steps/Pricing';
+import WeekendPricing from './steps/WeekendPricing';
+import Discounts from './steps/Discounts';
+import SafetyInfo from './steps/SafetyInfo';
+import HostDetails from './steps/HostDetails';
+import { saveListing, generateId } from '@/utils/listingStorage';
+import { Listing } from '@/types/listing';
+
+// 스텝 설정 배열 - 순서 변경, 추가/삭제가 쉬움
+const STEPS = [
+  // Phase 0: 시작
+  { component: Overview, showProgress: false, nextLabel: '시작하기' },
+  
+  // Phase 1: 숙소 정보
+  { component: Phase1Intro, showProgress: true },
+  { component: CategorySelect, showProgress: true },
+  { component: SpaceType, showProgress: true },
+  { component: Location, showProgress: true },
+  { component: GuestCapacity, showProgress: true },
+  { component: Bathrooms, showProgress: true },
+  { component: Occupants, showProgress: true },
+  
+  // Phase 2: 매력 어필
+  { component: Phase2Intro, showProgress: true },
+  { component: Amenities, showProgress: true },
+  { component: Photos, showProgress: true },
+  { component: TitleStep, showProgress: true },
+  { component: Description, showProgress: true },
+  
+  // Phase 3: 마무리
+  { component: Phase3Intro, showProgress: true },
+  { component: BookingSettings, showProgress: true },
+  { component: GuestRequirements, showProgress: true },
+  { component: Pricing, showProgress: true },
+  { component: WeekendPricing, showProgress: true },
+  { component: Discounts, showProgress: true },
+  { component: SafetyInfo, showProgress: true },
+  { component: HostDetails, showProgress: true, nextLabel: '리스팅 만들기' },
+] as const;
+
+const BecomeHostPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [currentStep, setCurrentStep] = useState(0);
+  
+  const totalSteps = STEPS.length - 1; // 인덱스 기준
+  const stepConfig = STEPS[currentStep];
+  const StepComponent = stepConfig.component;
+  const isLastStep = currentStep === totalSteps;
+
+  const handleNext = () => {
+    if (isLastStep) {
+      // 마지막 스텝: 리스팅 저장 후 호스팅 페이지로 이동
+      const newListing: Listing = {
+        id: generateId(),
+        title: '나의 새로운 숙소',
+        description: '편안하고 아늑한 공간입니다.',
+        category: '아파트',
+        spaceType: '공간 전체',
+        location: {
+          country: '한국',
+          province: '서울특별시',
+          city: '',
+          district: '강남구',
+          streetAddress: '테헤란로 123',
+          detailAddress: '',
+          postalCode: '06234',
+        },
+        guests: 4,
+        bedrooms: 2,
+        beds: 2,
+        bathrooms: 1,
+        amenities: ['와이파이', '에어컨', '주방'],
+        photos: [],
+        pricing: {
+          basePrice: 80000,
+          weekendPremium: 20,
+        },
+        discounts: {
+          newListing: true,
+          weekly: false,
+          monthly: false,
+        },
+        bookingSettings: 'review',
+        guestRequirements: 'experienced',
+        safetyInfo: {},
+        isBusiness: false,
+        createdAt: new Date().toISOString(),
+        status: 'published',
+      };
+      
+      saveListing(newListing);
+      navigate('/hosting');
+    } else {
+      setCurrentStep(currentStep + 1);
+    }
+  };
+
+  const handleBack = () => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
+    }
+  };
+
+  return (
+    <HostingRegistrationLayout
+      currentStep={currentStep}
+      totalSteps={totalSteps}
+      onNext={handleNext}
+      onBack={handleBack}
+      backDisabled={currentStep === 0}
+      nextLabel={stepConfig.nextLabel ?? '다음'}
+      showProgressBar={stepConfig.showProgress}
+    >
+      <StepComponent />
+    </HostingRegistrationLayout>
+  );
+};
+
+export default BecomeHostPage;

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -69,10 +69,14 @@ const BecomeHostPage = () => {
   const [currentStep, setCurrentStep] = useState(0);
   const [listingData, setListingData] = useState<Partial<Listing>>(defaultListing);
   
-  const totalSteps = STEPS.length - 1; // 인덱스 기준
   const stepConfig = STEPS[currentStep];
   const StepComponent = stepConfig.component;
-  const isLastStep = currentStep === totalSteps;
+  const isLastStep = currentStep === STEPS.length - 1;
+
+  // 프로그레스 바에 표시될 스텝만 필터링하여 계산
+  const totalProgressSteps = STEPS.filter(step => step.showProgress).length;
+  const currentProgressStep = STEPS.slice(0, currentStep + 1)
+    .filter(step => step.showProgress).length;
 
   const handleDataChange = (newData: Partial<Listing>) => {
     setListingData(prev => ({ ...prev, ...newData }));
@@ -134,8 +138,8 @@ const BecomeHostPage = () => {
 
   return (
     <HostingRegistrationLayout
-      currentStep={currentStep}
-      totalSteps={totalSteps}
+      currentStep={currentProgressStep}
+      totalSteps={totalProgressSteps}
       onNext={handleNext}
       onBack={handleBack}
       backDisabled={currentStep === 0}

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -24,90 +24,102 @@ import SafetyInfo from './steps/SafetyInfo';
 import HostDetails from './steps/HostDetails';
 import { saveListing, generateId } from '@/utils/listingStorage';
 import type { Listing } from '@/types/listing';
+import { defaultListing } from '@/types/listing';
+
+// 스텝 props 타입
+export interface StepProps {
+  data: Partial<Listing>;
+  onDataChange: (newData: Partial<Listing>) => void;
+}
 
 // 스텝 설정 배열 - 순서 변경, 추가/삭제가 쉬움
 const STEPS = [
   // Phase 0: 시작
-  { component: Overview, showProgress: false, nextLabel: '시작하기' },
+  { component: Overview, showProgress: false, nextLabel: '시작하기', needsData: false },
   
   // Phase 1: 숙소 정보
-  { component: Phase1Intro, showProgress: true },
-  { component: CategorySelect, showProgress: true },
-  { component: SpaceType, showProgress: true },
-  { component: Location, showProgress: true },
-  { component: GuestCapacity, showProgress: true },
-  { component: Bathrooms, showProgress: true },
-  { component: Occupants, showProgress: true },
+  { component: Phase1Intro, showProgress: true, needsData: false },
+  { component: CategorySelect, showProgress: true, needsData: true },
+  { component: SpaceType, showProgress: true, needsData: true },
+  { component: Location, showProgress: true, needsData: true },
+  { component: GuestCapacity, showProgress: true, needsData: true },
+  { component: Bathrooms, showProgress: true, needsData: true },
+  { component: Occupants, showProgress: true, needsData: true },
   
   // Phase 2: 매력 어필
-  { component: Phase2Intro, showProgress: true },
-  { component: Amenities, showProgress: true },
-  { component: Photos, showProgress: true },
-  { component: TitleStep, showProgress: true },
-  { component: Description, showProgress: true },
+  { component: Phase2Intro, showProgress: true, needsData: false },
+  { component: Amenities, showProgress: true, needsData: true },
+  { component: Photos, showProgress: true, needsData: true },
+  { component: TitleStep, showProgress: true, needsData: true },
+  { component: Description, showProgress: true, needsData: true },
   
   // Phase 3: 마무리
-  { component: Phase3Intro, showProgress: true },
-  { component: BookingSettings, showProgress: true },
-  { component: GuestRequirements, showProgress: true },
-  { component: Pricing, showProgress: true },
-  { component: WeekendPricing, showProgress: true },
-  { component: Discounts, showProgress: true },
-  { component: SafetyInfo, showProgress: true },
-  { component: HostDetails, showProgress: true, nextLabel: '리스팅 만들기' },
+  { component: Phase3Intro, showProgress: true, needsData: false },
+  { component: BookingSettings, showProgress: true, needsData: true },
+  { component: GuestRequirements, showProgress: true, needsData: true },
+  { component: Pricing, showProgress: true, needsData: true },
+  { component: WeekendPricing, showProgress: true, needsData: true },
+  { component: Discounts, showProgress: true, needsData: true },
+  { component: SafetyInfo, showProgress: true, needsData: true },
+  { component: HostDetails, showProgress: true, nextLabel: '리스팅 만들기', needsData: true },
 ] as const;
 
 const BecomeHostPage = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(0);
+  const [listingData, setListingData] = useState<Partial<Listing>>(defaultListing);
   
   const totalSteps = STEPS.length - 1; // 인덱스 기준
   const stepConfig = STEPS[currentStep];
   const StepComponent = stepConfig.component;
   const isLastStep = currentStep === totalSteps;
 
+  const handleDataChange = (newData: Partial<Listing>) => {
+    setListingData(prev => ({ ...prev, ...newData }));
+  };
+
   const handleNext = () => {
     if (isLastStep) {
-      // 마지막 스텝: 리스팅 저장 후 호스팅 페이지로 이동
-      const newListing: Listing = {
+      // 마지막 스텝: 실제 입력된 데이터를 취합하여 저장
+      const finalListing: Listing = {
         id: generateId(),
-        title: '나의 새로운 숙소',
-        description: '편안하고 아늑한 공간입니다.',
-        category: '아파트',
-        spaceType: '공간 전체',
-        location: {
+        title: listingData.title || '새로운 숙소',
+        description: listingData.description || '',
+        category: listingData.category || '',
+        spaceType: listingData.spaceType || '',
+        location: listingData.location || {
           country: '한국',
-          province: '서울특별시',
+          province: '',
           city: '',
-          district: '강남구',
-          streetAddress: '테헤란로 123',
+          district: '',
+          streetAddress: '',
           detailAddress: '',
-          postalCode: '06234',
+          postalCode: '',
         },
-        guests: 4,
-        bedrooms: 2,
-        beds: 2,
-        bathrooms: 1,
-        amenities: ['와이파이', '에어컨', '주방'],
-        photos: [],
-        pricing: {
-          basePrice: 80000,
-          weekendPremium: 20,
+        guests: listingData.guests || 1,
+        bedrooms: listingData.bedrooms || 1,
+        beds: listingData.beds || 1,
+        bathrooms: listingData.bathrooms || 1,
+        amenities: listingData.amenities || [],
+        photos: listingData.photos || [],
+        pricing: listingData.pricing || {
+          basePrice: 50000,
+          weekendPremium: 0,
         },
-        discounts: {
-          newListing: true,
+        discounts: listingData.discounts || {
+          newListing: false,
           weekly: false,
           monthly: false,
         },
-        bookingSettings: 'review',
-        guestRequirements: 'experienced',
-        safetyInfo: {},
-        isBusiness: false,
+        bookingSettings: listingData.bookingSettings || 'review',
+        guestRequirements: listingData.guestRequirements || 'experienced',
+        safetyInfo: listingData.safetyInfo || {},
+        isBusiness: listingData.isBusiness || false,
         createdAt: new Date().toISOString(),
         status: 'published',
       };
       
-      saveListing(newListing);
+      saveListing(finalListing);
       navigate('/hosting');
     } else {
       setCurrentStep(currentStep + 1);
@@ -130,7 +142,11 @@ const BecomeHostPage = () => {
       nextLabel={stepConfig.nextLabel ?? '다음'}
       showProgressBar={stepConfig.showProgress}
     >
-      <StepComponent />
+      {stepConfig.needsData ? (
+        <StepComponent data={listingData} onDataChange={handleDataChange} />
+      ) : (
+        <StepComponent />
+      )}
     </HostingRegistrationLayout>
   );
 };

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -23,7 +23,7 @@ import Discounts from './steps/Discounts';
 import SafetyInfo from './steps/SafetyInfo';
 import HostDetails from './steps/HostDetails';
 import { saveListing, generateId } from '@/utils/listingStorage';
-import { Listing } from '@/types/listing';
+import type { Listing } from '@/types/listing';
 
 // 스텝 설정 배열 - 순서 변경, 추가/삭제가 쉬움
 const STEPS = [

--- a/src/pages/hosting/HostingPage.tsx
+++ b/src/pages/hosting/HostingPage.tsx
@@ -26,7 +26,7 @@ import {
   ListingStatus,
 } from './hosting.styles';
 
-const HostingPage: React.FC = () => {
+const HostingPage = () => {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<'today' | 'upcoming'>('today');
   const [listings, setListings] = useState<Listing[]>([]);

--- a/src/pages/hosting/HostingPage.tsx
+++ b/src/pages/hosting/HostingPage.tsx
@@ -1,0 +1,147 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import HostingHeader from '@/components/HostingHeader/HostingHeader';
+import { getListings } from '@/utils/listingStorage';
+import { Listing } from '@/types/listing';
+import {
+  HostingContainer,
+  TabSection,
+  TabButton,
+  ContentArea,
+  EmptyTitle,
+  EmptyDesc,
+  ActionButton,
+  EmptyIcon,
+  ListingsSection,
+  SectionHeader,
+  SectionTitle,
+  AddListingButton,
+  ListingsGrid,
+  ListingCard,
+  ListingImagePlaceholder,
+  ListingInfo,
+  ListingTitle,
+  ListingLocation,
+  ListingPrice,
+  ListingStatus,
+} from './hosting.styles';
+
+const HostingPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<'today' | 'upcoming'>('today');
+  const [listings, setListings] = useState<Listing[]>([]);
+
+  useEffect(() => {
+    // localStorage에서 리스팅 불러오기
+    const savedListings = getListings();
+    setListings(savedListings);
+  }, []);
+
+  const formatPrice = (price: number) => {
+    return new Intl.NumberFormat('ko-KR').format(price);
+  };
+
+  // 리스팅이 없을 때
+  if (listings.length === 0) {
+    return (
+      <>
+        <HostingHeader />
+        <HostingContainer>
+          <TabSection>
+            <TabButton
+              $active={activeTab === 'today'}
+              onClick={() => setActiveTab('today')}
+            >
+              오늘
+            </TabButton>
+            <TabButton
+              $active={activeTab === 'upcoming'}
+              onClick={() => setActiveTab('upcoming')}
+            >
+              예정
+            </TabButton>
+          </TabSection>
+
+          <ContentArea>
+            <EmptyIcon>📖</EmptyIcon>
+            {activeTab === 'today' ? (
+              <>
+                <EmptyTitle>예약이 없습니다</EmptyTitle>
+                <EmptyDesc>
+                  예약을 받으려면 리스팅 등록을 완료하셔야 합니다.
+                </EmptyDesc>
+              </>
+            ) : (
+              <>
+                <EmptyTitle>예정된 예약이 없습니다</EmptyTitle>
+                <EmptyDesc>
+                  예약을 받으려면 리스팅 등록을 완료하셔야 합니다.
+                </EmptyDesc>
+              </>
+            )}
+            <ActionButton onClick={() => navigate('/hosting/become-a-host')}>
+              리스팅 등록 완료하기
+            </ActionButton>
+          </ContentArea>
+        </HostingContainer>
+      </>
+    );
+  }
+
+  // 리스팅이 있을 때
+  return (
+    <>
+      <HostingHeader />
+      <HostingContainer>
+        <TabSection>
+          <TabButton
+            $active={activeTab === 'today'}
+            onClick={() => setActiveTab('today')}
+          >
+            오늘
+          </TabButton>
+          <TabButton
+            $active={activeTab === 'upcoming'}
+            onClick={() => setActiveTab('upcoming')}
+          >
+            예정
+          </TabButton>
+        </TabSection>
+
+        <ListingsSection>
+          <SectionHeader>
+            <SectionTitle>내 숙소 ({listings.length})</SectionTitle>
+            <AddListingButton onClick={() => navigate('/hosting/become-a-host')}>
+              + 새 숙소 등록
+            </AddListingButton>
+          </SectionHeader>
+
+          <ListingsGrid>
+            {listings.map((listing) => (
+              <ListingCard key={listing.id}>
+                <ListingImagePlaceholder>
+                  🏠
+                </ListingImagePlaceholder>
+                <ListingInfo>
+                  <ListingTitle>{listing.title}</ListingTitle>
+                  <ListingLocation>
+                    {listing.location.province} {listing.location.district}
+                  </ListingLocation>
+                  <ListingPrice>
+                    ₩{formatPrice(listing.pricing.basePrice)} <span>/ 박</span>
+                  </ListingPrice>
+                  <ListingStatus $status={listing.status}>
+                    {listing.status === 'published' ? '게시됨' : '임시저장'}
+                  </ListingStatus>
+                </ListingInfo>
+              </ListingCard>
+            ))}
+          </ListingsGrid>
+        </ListingsSection>
+      </HostingContainer>
+    </>
+  );
+};
+
+export default HostingPage;
+

--- a/src/pages/hosting/HostingPage.tsx
+++ b/src/pages/hosting/HostingPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import HostingHeader from '@/components/HostingHeader/HostingHeader';
 import { getListings } from '@/utils/listingStorage';
-import { Listing } from '@/types/listing';
+import type { Listing } from '@/types/listing';
 import {
   HostingContainer,
   TabSection,

--- a/src/pages/hosting/becomeHost.styles.ts
+++ b/src/pages/hosting/becomeHost.styles.ts
@@ -1,0 +1,118 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+
+export const Container = styled.div`
+  min-height: 100vh;
+  background-color: ${({ theme }) => theme.colors.background.default};
+  display: flex;
+  flex-direction: column;
+`;
+
+export const MainContent = styled.main`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing['6xl']} ${({ theme }) => theme.spacing['3xl']};
+  max-width: 1200px;
+  margin: 0 auto;
+  gap: ${({ theme }) => theme.spacing['6xl']};
+
+  ${media.tablet} {
+    flex-direction: column;
+    padding: ${({ theme }) => theme.spacing['4xl']} ${({ theme }) => theme.spacing.lg};
+    gap: ${({ theme }) => theme.spacing['4xl']};
+    text-align: center;
+  }
+`;
+
+export const LeftSection = styled.div`
+  flex: 1;
+`;
+
+export const Title = styled.h1`
+  font-size: 48px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  line-height: 1.1;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  ${media.mobile} {
+    font-size: 32px;
+  }
+`;
+
+export const RightSection = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const StepItem = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.lg};
+  padding-bottom: ${({ theme }) => theme.spacing.xl};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const StepNumber = styled.span`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const StepContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const StepTitle = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin: 0;
+`;
+
+export const StepDesc = styled.p`
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0;
+`;
+
+export const Footer = styled.footer`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  background-color: ${({ theme }) => theme.colors.common.white};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  z-index: ${({ theme }) => theme.zIndex.header};
+`;
+
+export const NextButton = styled.button`
+  background-color: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  border: none;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing['2xl']};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  transition: background-color ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primary.hover};
+  }
+`;
+
+
+

--- a/src/pages/hosting/hosting.styles.ts
+++ b/src/pages/hosting/hosting.styles.ts
@@ -1,0 +1,208 @@
+import styled from "styled-components";
+import { media } from "@/styles/media";
+
+export const HostingContainer = styled.div`
+  padding-top: ${({ theme }) => theme.spacing["6xl"]};
+  min-height: 100vh;
+  background-color: ${({ theme }) => theme.colors.background.default};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const TabSection = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.md};
+  margin-top: ${({ theme }) => theme.spacing["4xl"]};
+  flex-shrink: 0;
+`;
+
+export const ListingsSection = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  padding: ${({ theme }) => theme.spacing["3xl"]};
+
+  ${media.mobile} {
+    padding: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const SectionTitle = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const AddListingButton = styled.button`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  background-color: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primary.hover};
+  }
+`;
+
+export const ListingsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const ListingCard = styled.div`
+  background-color: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: all ${({ theme }) => theme.transition.normal};
+  cursor: pointer;
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    transform: translateY(-2px);
+  }
+`;
+
+export const ListingImagePlaceholder = styled.div`
+  width: 100%;
+  height: 180px;
+  background: linear-gradient(
+    135deg,
+    ${({ theme }) => theme.colors.background.hover} 0%,
+    ${({ theme }) => theme.colors.background.active} 100%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+`;
+
+export const ListingInfo = styled.div`
+  padding: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const ListingTitle = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const ListingLocation = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ListingPrice = styled.p`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  span {
+    font-weight: ${({ theme }) => theme.font.weight.regular};
+    color: ${({ theme }) => theme.colors.text.secondary};
+  }
+`;
+
+export const ListingStatus = styled.span<{ $status: "draft" | "published" }>`
+  display: inline-block;
+  padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.sm};
+  border-radius: ${({ theme }) => theme.radius.sm};
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  margin-top: ${({ theme }) => theme.spacing.sm};
+
+  ${({ $status, theme }) =>
+    $status === "published"
+      ? `
+    background-color: ${theme.colors.status.success}20;
+    color: ${theme.colors.status.success};
+  `
+      : `
+    background-color: ${theme.colors.status.warning}20;
+    color: ${theme.colors.status.warning};
+  `}
+`;
+
+export const TabButton = styled.button<{ $active?: boolean }>`
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.xl};
+  border-radius: ${({ theme }) => theme.radius.full};
+  border: none;
+  background-color: ${({ theme, $active }) =>
+    $active ? theme.colors.text.primary : theme.colors.background.hover};
+  color: ${({ theme, $active }) =>
+    $active ? theme.colors.common.white : theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme, $active }) =>
+      $active ? theme.colors.text.primary : theme.colors.background.active};
+  }
+`;
+
+export const ContentArea = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  max-width: 600px;
+  width: 100%;
+  padding: 0 ${({ theme }) => theme.spacing.lg};
+  /* 상단바와 버튼 영역만큼의 오프셋을 고려하여 시각적 중앙을 맞춤 */
+  padding-bottom: ${({ theme }) => theme.spacing["6xl"]};
+`;
+
+export const EmptyIcon = styled.div`
+  font-size: 120px;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+  line-height: 1;
+`;
+
+export const EmptyTitle = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const EmptyDesc = styled.p`
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-bottom: ${({ theme }) => theme.spacing["2xl"]};
+`;
+
+export const ActionButton = styled.button`
+  padding: ${({ theme }) => theme.spacing.md}
+    ${({ theme }) => theme.spacing["2xl"]};
+  background-color: ${({ theme }) => theme.colors.background.hover};
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.background.active};
+  }
+`;

--- a/src/pages/hosting/steps/Amenities.styles.ts
+++ b/src/pages/hosting/steps/Amenities.styles.ts
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+  Section as BaseSection,
+  SectionTitle as BaseSectionTitle,
+  SelectableGrid,
+  SelectableCard,
+  CardIcon,
+  CardLabel,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const AmenitiesContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['3xl']};
+`;
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+export const Subtitle = BaseSubtitle;
+export const Section = BaseSection;
+export const SectionTitle = BaseSectionTitle;
+export const AmenityGrid = SelectableGrid;
+export const AmenityItem = SelectableCard;
+export const IconWrapper = CardIcon;
+export const Label = CardLabel;
+

--- a/src/pages/hosting/steps/Amenities.tsx
+++ b/src/pages/hosting/steps/Amenities.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { 
+  Wifi, 
+  Tv, 
+  UtensilsCrossed, 
+  WashingMachine, 
+  Car, 
+  CircleDollarSign,
+  Snowflake,
+  Briefcase,
+  Waves,
+  Bath,
+  TreePalm,
+  Beef,
+  UtensilsCrossed as DiningIcon,
+  Flame
+} from 'lucide-react';
+import {
+  AmenitiesContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  Section,
+  SectionTitle,
+  AmenityGrid,
+  AmenityItem,
+  IconWrapper,
+  Label,
+} from './Amenities.styles';
+
+const popularAmenities = [
+  { id: 'wifi', label: '와이파이', icon: <Wifi size={28} /> },
+  { id: 'tv', label: 'TV', icon: <Tv size={28} /> },
+  { id: 'kitchen', label: '주방', icon: <UtensilsCrossed size={28} /> },
+  { id: 'washer', label: '세탁기', icon: <WashingMachine size={28} /> },
+  { id: 'free_parking', label: '건물 내 무료 주차', icon: <Car size={28} /> },
+  { id: 'paid_parking', label: '건물 부지 내 유료 주차', icon: <CircleDollarSign size={28} /> },
+  { id: 'ac', label: '에어컨', icon: <Snowflake size={28} /> },
+  { id: 'workspace', label: '업무 전용 공간', icon: <Briefcase size={28} /> },
+];
+
+const standoutAmenities = [
+  { id: 'pool', label: '수영장', icon: <Waves size={28} /> },
+  { id: 'hot_tub', label: '대형 욕조', icon: <Bath size={28} /> },
+  { id: 'patio', label: '파티오', icon: <TreePalm size={28} /> },
+  { id: 'bbq', label: '바비큐 그릴', icon: <Beef size={28} /> },
+  { id: 'outdoor_dining', label: '야외 식사 공간', icon: <DiningIcon size={28} /> },
+  { id: 'firepit', label: '화로', icon: <Flame size={28} /> },
+];
+
+const Amenities: React.FC = () => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <AmenitiesContainer>
+      <TitleSection>
+        <Title>숙소 편의시설 정보를 추가하세요</Title>
+        <Subtitle>
+          여기에 추가하려는 편의시설이 보이지 않더라도 걱정하지 마세요! 숙소를 등록한 후에 편의시설을 추가할 수 있습니다.
+        </Subtitle>
+      </TitleSection>
+
+      <Section>
+        <SectionTitle>다음 인기 편의시설이 있나요?</SectionTitle>
+        <AmenityGrid>
+          {popularAmenities.map((amenity) => (
+            <AmenityItem
+              key={amenity.id}
+              $selected={selectedIds.includes(amenity.id)}
+              onClick={() => toggleSelection(amenity.id)}
+            >
+              <IconWrapper>{amenity.icon}</IconWrapper>
+              <Label>{amenity.label}</Label>
+            </AmenityItem>
+          ))}
+        </AmenityGrid>
+      </Section>
+
+      <Section>
+        <SectionTitle>특별히 내세울 만한 편의시설이 있나요?</SectionTitle>
+        <AmenityGrid>
+          {standoutAmenities.map((amenity) => (
+            <AmenityItem
+              key={amenity.id}
+              $selected={selectedIds.includes(amenity.id)}
+              onClick={() => toggleSelection(amenity.id)}
+            >
+              <IconWrapper>{amenity.icon}</IconWrapper>
+              <Label>{amenity.label}</Label>
+            </AmenityItem>
+          ))}
+        </AmenityGrid>
+      </Section>
+    </AmenitiesContainer>
+  );
+};
+
+export default Amenities;
+

--- a/src/pages/hosting/steps/Amenities.tsx
+++ b/src/pages/hosting/steps/Amenities.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { 
   Wifi, 
   Tv, 
@@ -27,6 +27,7 @@ import {
   IconWrapper,
   Label,
 } from './Amenities.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 const popularAmenities = [
   { id: 'wifi', label: '와이파이', icon: <Wifi size={28} /> },
@@ -48,13 +49,14 @@ const standoutAmenities = [
   { id: 'firepit', label: '화로', icon: <Flame size={28} /> },
 ];
 
-const Amenities = () => {
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+const Amenities = ({ data, onDataChange }: StepProps) => {
+  const selectedIds = data.amenities || [];
 
-  const toggleSelection = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
-    );
+  const toggleSelection = (label: string) => {
+    const newSelectedIds = selectedIds.includes(label)
+      ? selectedIds.filter((i) => i !== label)
+      : [...selectedIds, label];
+    onDataChange({ amenities: newSelectedIds });
   };
 
   return (
@@ -72,8 +74,8 @@ const Amenities = () => {
           {popularAmenities.map((amenity) => (
             <AmenityItem
               key={amenity.id}
-              $selected={selectedIds.includes(amenity.id)}
-              onClick={() => toggleSelection(amenity.id)}
+              $selected={selectedIds.includes(amenity.label)}
+              onClick={() => toggleSelection(amenity.label)}
             >
               <IconWrapper>{amenity.icon}</IconWrapper>
               <Label>{amenity.label}</Label>
@@ -88,8 +90,8 @@ const Amenities = () => {
           {standoutAmenities.map((amenity) => (
             <AmenityItem
               key={amenity.id}
-              $selected={selectedIds.includes(amenity.id)}
-              onClick={() => toggleSelection(amenity.id)}
+              $selected={selectedIds.includes(amenity.label)}
+              onClick={() => toggleSelection(amenity.label)}
             >
               <IconWrapper>{amenity.icon}</IconWrapper>
               <Label>{amenity.label}</Label>

--- a/src/pages/hosting/steps/Amenities.tsx
+++ b/src/pages/hosting/steps/Amenities.tsx
@@ -48,7 +48,7 @@ const standoutAmenities = [
   { id: 'firepit', label: '화로', icon: <Flame size={28} /> },
 ];
 
-const Amenities: React.FC = () => {
+const Amenities = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const toggleSelection = (id: string) => {

--- a/src/pages/hosting/steps/Bathrooms.styles.ts
+++ b/src/pages/hosting/steps/Bathrooms.styles.ts
@@ -1,0 +1,25 @@
+import { 
+  StepContainer, 
+  StepTitleLarge,
+  CounterList as BaseCounterList,
+  CounterItem as BaseCounterItem,
+  CounterTextSection,
+  CounterLabel as BaseLabel,
+  CounterDescription,
+  CounterControls as BaseCounterControls,
+  CounterButton,
+  CounterValue as BaseCounterValue,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const BathroomContainer = StepContainer;
+export const Title = StepTitleLarge;
+export const CounterList = BaseCounterList;
+export const CounterItem = BaseCounterItem;
+export const TextSection = CounterTextSection;
+export const Label = BaseLabel;
+export const Description = CounterDescription;
+export const CounterControls = BaseCounterControls;
+export const IconButton = CounterButton;
+export const CounterValue = BaseCounterValue;
+

--- a/src/pages/hosting/steps/Bathrooms.tsx
+++ b/src/pages/hosting/steps/Bathrooms.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Minus, Plus } from 'lucide-react';
 import {
   BathroomContainer,
@@ -12,19 +12,14 @@ import {
   IconButton,
   CounterValue,
 } from './Bathrooms.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const Bathrooms = () => {
-  const [counts, setCounts] = useState({
-    attached: 0,
-    dedicated: 0,
-    shared: 0,
-  });
+const Bathrooms = ({ data, onDataChange }: StepProps) => {
+  // bathrooms 필드를 총 욕실 개수로 사용
+  const bathrooms = data.bathrooms || 0;
 
-  const updateCount = (type: keyof typeof counts, delta: number) => {
-    setCounts((prev) => ({
-      ...prev,
-      [type]: Math.max(0, prev[type] + delta),
-    }));
+  const updateCount = (delta: number) => {
+    onDataChange({ bathrooms: Math.max(0, bathrooms + delta) });
   };
 
   return (
@@ -34,47 +29,15 @@ const Bathrooms = () => {
       <CounterList>
         <CounterItem>
           <TextSection>
-            <Label>침실에 딸린 전용 욕실</Label>
-            <Description>단독으로 사용하며 게스트 침실과 연결되어 있습니다.</Description>
+            <Label>욕실 개수</Label>
+            <Description>게스트가 사용할 수 있는 욕실의 총 개수입니다.</Description>
           </TextSection>
           <CounterControls>
-            <IconButton onClick={() => updateCount('attached', -1)} disabled={counts.attached === 0}>
+            <IconButton onClick={() => updateCount(-1)} disabled={bathrooms === 0}>
               <Minus size={18} />
             </IconButton>
-            <CounterValue>{counts.attached}</CounterValue>
-            <IconButton onClick={() => updateCount('attached', 1)}>
-              <Plus size={18} />
-            </IconButton>
-          </CounterControls>
-        </CounterItem>
-
-        <CounterItem>
-          <TextSection>
-            <Label>전용</Label>
-            <Description>단독으로 사용하지만, 출입하려면 복도와 같은 공용 공간을 지나야 합니다.</Description>
-          </TextSection>
-          <CounterControls>
-            <IconButton onClick={() => updateCount('dedicated', -1)} disabled={counts.dedicated === 0}>
-              <Minus size={18} />
-            </IconButton>
-            <CounterValue>{counts.dedicated}</CounterValue>
-            <IconButton onClick={() => updateCount('dedicated', 1)}>
-              <Plus size={18} />
-            </IconButton>
-          </CounterControls>
-        </CounterItem>
-
-        <CounterItem>
-          <TextSection>
-            <Label>공용</Label>
-            <Description>다른 사람과 공동으로 사용합니다.</Description>
-          </TextSection>
-          <CounterControls>
-            <IconButton onClick={() => updateCount('shared', -1)} disabled={counts.shared === 0}>
-              <Minus size={18} />
-            </IconButton>
-            <CounterValue>{counts.shared}</CounterValue>
-            <IconButton onClick={() => updateCount('shared', 1)}>
+            <CounterValue>{bathrooms}</CounterValue>
+            <IconButton onClick={() => updateCount(1)}>
               <Plus size={18} />
             </IconButton>
           </CounterControls>

--- a/src/pages/hosting/steps/Bathrooms.tsx
+++ b/src/pages/hosting/steps/Bathrooms.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import {
+  BathroomContainer,
+  Title,
+  CounterList,
+  CounterItem,
+  TextSection,
+  Label,
+  Description,
+  CounterControls,
+  IconButton,
+  CounterValue,
+} from './Bathrooms.styles';
+
+const Bathrooms: React.FC = () => {
+  const [counts, setCounts] = useState({
+    attached: 0,
+    dedicated: 0,
+    shared: 0,
+  });
+
+  const updateCount = (type: keyof typeof counts, delta: number) => {
+    setCounts((prev) => ({
+      ...prev,
+      [type]: Math.max(0, prev[type] + delta),
+    }));
+  };
+
+  return (
+    <BathroomContainer>
+      <Title>게스트가 사용하게 될 욕실은 어떤 유형인가요?</Title>
+
+      <CounterList>
+        <CounterItem>
+          <TextSection>
+            <Label>침실에 딸린 전용 욕실</Label>
+            <Description>단독으로 사용하며 게스트 침실과 연결되어 있습니다.</Description>
+          </TextSection>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('attached', -1)} disabled={counts.attached === 0}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{counts.attached}</CounterValue>
+            <IconButton onClick={() => updateCount('attached', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+
+        <CounterItem>
+          <TextSection>
+            <Label>전용</Label>
+            <Description>단독으로 사용하지만, 출입하려면 복도와 같은 공용 공간을 지나야 합니다.</Description>
+          </TextSection>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('dedicated', -1)} disabled={counts.dedicated === 0}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{counts.dedicated}</CounterValue>
+            <IconButton onClick={() => updateCount('dedicated', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+
+        <CounterItem>
+          <TextSection>
+            <Label>공용</Label>
+            <Description>다른 사람과 공동으로 사용합니다.</Description>
+          </TextSection>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('shared', -1)} disabled={counts.shared === 0}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{counts.shared}</CounterValue>
+            <IconButton onClick={() => updateCount('shared', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+      </CounterList>
+    </BathroomContainer>
+  );
+};
+
+export default Bathrooms;
+

--- a/src/pages/hosting/steps/Bathrooms.tsx
+++ b/src/pages/hosting/steps/Bathrooms.tsx
@@ -13,7 +13,7 @@ import {
   CounterValue,
 } from './Bathrooms.styles';
 
-const Bathrooms: React.FC = () => {
+const Bathrooms = () => {
   const [counts, setCounts] = useState({
     attached: 0,
     dedicated: 0,

--- a/src/pages/hosting/steps/BookingSettings.styles.ts
+++ b/src/pages/hosting/steps/BookingSettings.styles.ts
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection,
+  StepTitle,
+  Subtitle,
+  OptionList as BaseOptionList,
+  OptionCard as BaseOptionCard,
+  OptionContent,
+  OptionTitle,
+  OptionDescription,
+  IconWrapper,
+} from './shared.styles';
+
+// 공통 스타일 재export
+export { TitleSection, Subtitle, OptionContent, OptionTitle, OptionDescription, IconWrapper };
+export const Title = StepTitle;
+
+// BookingSettings 전용 스타일
+export const BookingContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing.xl};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const OptionList = BaseOptionList;
+
+export const OptionCard = styled(BaseOptionCard).attrs({ as: 'button' })`
+  justify-content: space-between;
+  text-align: left;
+`;
+
+export const RecommendTag = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.status.success};
+  margin-top: ${({ theme }) => theme.spacing.xs};
+`;

--- a/src/pages/hosting/steps/BookingSettings.tsx
+++ b/src/pages/hosting/steps/BookingSettings.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { CalendarCheck, Zap } from 'lucide-react';
+import {
+  BookingContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  OptionList,
+  OptionCard,
+  OptionContent,
+  OptionTitle,
+  RecommendTag,
+  OptionDescription,
+  IconWrapper,
+} from './BookingSettings.styles';
+
+type BookingOption = 'review' | 'instant';
+
+const BookingSettings: React.FC = () => {
+  const [selected, setSelected] = useState<BookingOption>('review');
+
+  return (
+    <BookingContainer>
+      <TitleSection>
+        <Title>예약 설정 선택</Title>
+        <Subtitle>이 설정은 언제든지 변경하실 수 있습니다.</Subtitle>
+      </TitleSection>
+
+      <OptionList>
+        <OptionCard
+          $selected={selected === 'review'}
+          onClick={() => setSelected('review')}
+        >
+          <OptionContent>
+            <OptionTitle>최초 5건 예약은 직접 검토 후 승인</OptionTitle>
+            <RecommendTag>추천</RecommendTag>
+            <OptionDescription>
+              처음 몇 건의 예약에 대해서는 요청을 직접 검토한 후 승인 여부를 결정하고, 그 이후에는 즉시 예약 기능을 사용해 예약을 자동 확정합니다.
+            </OptionDescription>
+          </OptionContent>
+          <IconWrapper>
+            <CalendarCheck size={32} />
+          </IconWrapper>
+        </OptionCard>
+
+        <OptionCard
+          $selected={selected === 'instant'}
+          onClick={() => setSelected('instant')}
+        >
+          <OptionContent>
+            <OptionTitle>즉시 예약 사용</OptionTitle>
+            <OptionDescription>
+              게스트가 바로 예약할 수 있도록 즉시 예약 기능을 설정해 보세요.
+            </OptionDescription>
+          </OptionContent>
+          <IconWrapper>
+            <Zap size={32} />
+          </IconWrapper>
+        </OptionCard>
+      </OptionList>
+    </BookingContainer>
+  );
+};
+
+export default BookingSettings;
+

--- a/src/pages/hosting/steps/BookingSettings.tsx
+++ b/src/pages/hosting/steps/BookingSettings.tsx
@@ -16,7 +16,7 @@ import {
 
 type BookingOption = 'review' | 'instant';
 
-const BookingSettings: React.FC = () => {
+const BookingSettings = () => {
   const [selected, setSelected] = useState<BookingOption>('review');
 
   return (

--- a/src/pages/hosting/steps/BookingSettings.tsx
+++ b/src/pages/hosting/steps/BookingSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { CalendarCheck, Zap } from 'lucide-react';
 import {
   BookingContainer,
@@ -13,11 +13,16 @@ import {
   OptionDescription,
   IconWrapper,
 } from './BookingSettings.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 type BookingOption = 'review' | 'instant';
 
-const BookingSettings = () => {
-  const [selected, setSelected] = useState<BookingOption>('review');
+const BookingSettings = ({ data, onDataChange }: StepProps) => {
+  const selected: BookingOption = data.bookingSettings || 'review';
+
+  const handleSelect = (option: BookingOption) => {
+    onDataChange({ bookingSettings: option });
+  };
 
   return (
     <BookingContainer>
@@ -29,7 +34,7 @@ const BookingSettings = () => {
       <OptionList>
         <OptionCard
           $selected={selected === 'review'}
-          onClick={() => setSelected('review')}
+          onClick={() => handleSelect('review')}
         >
           <OptionContent>
             <OptionTitle>최초 5건 예약은 직접 검토 후 승인</OptionTitle>
@@ -45,7 +50,7 @@ const BookingSettings = () => {
 
         <OptionCard
           $selected={selected === 'instant'}
-          onClick={() => setSelected('instant')}
+          onClick={() => handleSelect('instant')}
         >
           <OptionContent>
             <OptionTitle>즉시 예약 사용</OptionTitle>

--- a/src/pages/hosting/steps/CategorySelect.styles.ts
+++ b/src/pages/hosting/steps/CategorySelect.styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+import { StepContainer, StepTitleLarge, SelectableGrid, SelectableCardCompact, CardLabel } from './shared.styles';
+
+// 공통 스타일 재사용
+export const CategoryContainer = StepContainer;
+export const CategoryGrid = SelectableGrid;
+export const Label = CardLabel;
+
+// CategorySelect 전용 스타일
+export const Title = styled(StepTitleLarge)`
+  margin-bottom: ${({ theme }) => theme.spacing['4xl']};
+  text-align: center;
+
+  ${media.mobile} {
+    text-align: left;
+  }
+`;
+
+export const CategoryItem = styled(SelectableCardCompact)`
+  border-color: ${({ theme, $selected }) => 
+    $selected ? theme.colors.primary.main : theme.colors.border.primary};
+  outline: ${({ $selected, theme }) => 
+    $selected ? `2px solid ${theme.colors.primary.main}` : 'none'};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.primary.main};
+  }
+`;
+
+export const Icon = styled.div`
+  font-size: 32px;
+`;
+

--- a/src/pages/hosting/steps/CategorySelect.tsx
+++ b/src/pages/hosting/steps/CategorySelect.tsx
@@ -18,7 +18,7 @@ const categories = [
   { id: 'castle', label: '캐슬', icon: <Landmark size={32} /> },
 ];
 
-const CategorySelect: React.FC = () => {
+const CategorySelect = () => {
   const [selected, setSelected] = useState<string | null>(null);
 
   return (

--- a/src/pages/hosting/steps/CategorySelect.tsx
+++ b/src/pages/hosting/steps/CategorySelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   CategoryContainer,
   Title,
@@ -8,6 +8,7 @@ import {
   Label,
 } from './CategorySelect.styles';
 import { Home, Building2, Warehouse, Tent, Ship, Landmark } from 'lucide-react';
+import type { StepProps } from '../BecomeHostPage';
 
 const categories = [
   { id: 'house', label: '주택(예: 펜션, 한옥 등)', icon: <Home size={32} /> },
@@ -18,8 +19,12 @@ const categories = [
   { id: 'castle', label: '캐슬', icon: <Landmark size={32} /> },
 ];
 
-const CategorySelect = () => {
-  const [selected, setSelected] = useState<string | null>(null);
+const CategorySelect = ({ data, onDataChange }: StepProps) => {
+  const selected = data.category || null;
+
+  const handleSelect = (categoryLabel: string) => {
+    onDataChange({ category: categoryLabel });
+  };
 
   return (
     <CategoryContainer>
@@ -28,8 +33,8 @@ const CategorySelect = () => {
         {categories.map((cat) => (
           <CategoryItem
             key={cat.id}
-            $selected={selected === cat.id}
-            onClick={() => setSelected(cat.id)}
+            $selected={selected === cat.label}
+            onClick={() => handleSelect(cat.label)}
           >
             <Icon>{cat.icon}</Icon>
             <Label>{cat.label}</Label>

--- a/src/pages/hosting/steps/CategorySelect.tsx
+++ b/src/pages/hosting/steps/CategorySelect.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import {
+  CategoryContainer,
+  Title,
+  CategoryGrid,
+  CategoryItem,
+  Icon,
+  Label,
+} from './CategorySelect.styles';
+import { Home, Building2, Warehouse, Tent, Ship, Landmark } from 'lucide-react';
+
+const categories = [
+  { id: 'house', label: '주택(예: 펜션, 한옥 등)', icon: <Home size={32} /> },
+  { id: 'apartment', label: '아파트', icon: <Building2 size={32} /> },
+  { id: 'cabin', label: '통나무집', icon: <Warehouse size={32} /> },
+  { id: 'camping', label: '캠핑카', icon: <Tent size={32} /> },
+  { id: 'boat', label: '보트', icon: <Ship size={32} /> },
+  { id: 'castle', label: '캐슬', icon: <Landmark size={32} /> },
+];
+
+const CategorySelect: React.FC = () => {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <CategoryContainer>
+      <Title>다음 중 숙소를 가장 잘 설명하는 것은 무엇인가요?</Title>
+      <CategoryGrid>
+        {categories.map((cat) => (
+          <CategoryItem
+            key={cat.id}
+            $selected={selected === cat.id}
+            onClick={() => setSelected(cat.id)}
+          >
+            <Icon>{cat.icon}</Icon>
+            <Label>{cat.label}</Label>
+          </CategoryItem>
+        ))}
+      </CategoryGrid>
+    </CategoryContainer>
+  );
+};
+
+export default CategorySelect;
+

--- a/src/pages/hosting/steps/Description.styles.ts
+++ b/src/pages/hosting/steps/Description.styles.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection,
+  StepTitle,
+  Subtitle,
+  TextAreaBase,
+  CharCount,
+} from './shared.styles';
+
+// 공통 스타일 재export
+export { TitleSection, Subtitle, CharCount };
+export const Title = StepTitle;
+
+// Description 전용 스타일
+export const DescriptionContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing.xl};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TextArea = styled(TextAreaBase)`
+  min-height: 180px;
+  font-size: ${({ theme }) => theme.font.size.md};
+  line-height: 1.5;
+`;

--- a/src/pages/hosting/steps/Description.tsx
+++ b/src/pages/hosting/steps/Description.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   DescriptionContainer,
   TitleSection,
@@ -7,16 +7,17 @@ import {
   TextArea,
   CharCount,
 } from './Description.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 const MAX_LENGTH = 500;
 
-const Description = () => {
-  const [description, setDescription] = useState('');
+const Description = ({ data, onDataChange }: StepProps) => {
+  const description = data.description || '';
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     if (value.length <= MAX_LENGTH) {
-      setDescription(value);
+      onDataChange({ description: value });
     }
   };
 

--- a/src/pages/hosting/steps/Description.tsx
+++ b/src/pages/hosting/steps/Description.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import {
+  DescriptionContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  TextArea,
+  CharCount,
+} from './Description.styles';
+
+const MAX_LENGTH = 500;
+
+const Description: React.FC = () => {
+  const [description, setDescription] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    if (value.length <= MAX_LENGTH) {
+      setDescription(value);
+    }
+  };
+
+  return (
+    <DescriptionContainer>
+      <TitleSection>
+        <Title>숙소 설명 작성하기</Title>
+        <Subtitle>숙소의 특징과 장점을 알려주세요.</Subtitle>
+      </TitleSection>
+
+      <TextArea
+        value={description}
+        onChange={handleChange}
+        maxLength={MAX_LENGTH}
+      />
+
+      <CharCount>{description.length}/{MAX_LENGTH}</CharCount>
+    </DescriptionContainer>
+  );
+};
+
+export default Description;
+

--- a/src/pages/hosting/steps/Description.tsx
+++ b/src/pages/hosting/steps/Description.tsx
@@ -10,7 +10,7 @@ import {
 
 const MAX_LENGTH = 500;
 
-const Description: React.FC = () => {
+const Description = () => {
   const [description, setDescription] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/pages/hosting/steps/Discounts.styles.ts
+++ b/src/pages/hosting/steps/Discounts.styles.ts
@@ -1,0 +1,98 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const DiscountsContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['2xl']};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+export const Subtitle = BaseSubtitle;
+
+// Discounts 전용 스타일
+export const DiscountList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const DiscountItem = styled.label`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.xl};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  cursor: pointer;
+  transition: background-color ${({ theme }) => theme.transition.fast};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+export const DiscountLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const Checkbox = styled.div<{ $checked?: boolean }>`
+  width: 24px;
+  height: 24px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  border: 2px solid ${({ theme, $checked }) => 
+    $checked ? theme.colors.text.primary : theme.colors.border.primary};
+  background-color: ${({ theme, $checked }) => 
+    $checked ? theme.colors.text.primary : 'transparent'};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all ${({ theme }) => theme.transition.fast};
+  flex-shrink: 0;
+
+  svg {
+    color: ${({ theme }) => theme.colors.common.white};
+  }
+`;
+
+export const HiddenInput = styled.input`
+  display: none;
+`;
+
+export const DiscountInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const DiscountTitle = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const DiscountDescription = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const DiscountPercent = styled.span<{ $active?: boolean }>`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme, $active }) => 
+    $active ? theme.colors.text.primary : theme.colors.text.tertiary};
+  transition: color ${({ theme }) => theme.transition.fast};
+  flex-shrink: 0;
+`;
+

--- a/src/pages/hosting/steps/Discounts.tsx
+++ b/src/pages/hosting/steps/Discounts.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Check } from 'lucide-react';
+import {
+  DiscountsContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  DiscountList,
+  DiscountItem,
+  DiscountLeft,
+  Checkbox,
+  HiddenInput,
+  DiscountInfo,
+  DiscountTitle,
+  DiscountDescription,
+  DiscountPercent,
+} from './Discounts.styles';
+
+interface DiscountOption {
+  id: string;
+  title: string;
+  description: string;
+  percent: number;
+}
+
+const discountOptions: DiscountOption[] = [
+  {
+    id: 'new_listing',
+    title: '신규 숙소 할인',
+    description: '첫 3건의 예약에 20% 할인을 제공합니다.',
+    percent: 20,
+  },
+  {
+    id: 'weekly',
+    title: '주간 할인',
+    description: '7박 이상 예약 시 할인을 제공합니다.',
+    percent: 10,
+  },
+  {
+    id: 'monthly',
+    title: '월간 할인',
+    description: '28박 이상 예약 시 할인을 제공합니다.',
+    percent: 15,
+  },
+];
+
+const Discounts: React.FC = () => {
+  const [selectedIds, setSelectedIds] = useState<string[]>(['new_listing']);
+
+  const toggleDiscount = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id)
+        ? prev.filter((i) => i !== id)
+        : [...prev, id]
+    );
+  };
+
+  return (
+    <DiscountsContainer>
+      <TitleSection>
+        <Title>할인을 추가하여 예약을 늘려보세요</Title>
+        <Subtitle>
+          할인을 제공하면 게스트의 관심을 끌고 예약을 더 빨리 받을 수 있습니다.
+        </Subtitle>
+      </TitleSection>
+
+      <DiscountList>
+        {discountOptions.map((option) => {
+          const isChecked = selectedIds.includes(option.id);
+          return (
+            <DiscountItem key={option.id}>
+              <DiscountLeft>
+                <HiddenInput
+                  type="checkbox"
+                  checked={isChecked}
+                  onChange={() => toggleDiscount(option.id)}
+                />
+                <Checkbox $checked={isChecked}>
+                  {isChecked && <Check size={16} />}
+                </Checkbox>
+                <DiscountInfo>
+                  <DiscountTitle>{option.title}</DiscountTitle>
+                  <DiscountDescription>{option.description}</DiscountDescription>
+                </DiscountInfo>
+              </DiscountLeft>
+              <DiscountPercent $active={isChecked}>
+                {option.percent}%
+              </DiscountPercent>
+            </DiscountItem>
+          );
+        })}
+      </DiscountList>
+    </DiscountsContainer>
+  );
+};
+
+export default Discounts;
+

--- a/src/pages/hosting/steps/Discounts.tsx
+++ b/src/pages/hosting/steps/Discounts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Check } from 'lucide-react';
 import {
   DiscountsContainer,
@@ -15,9 +15,10 @@ import {
   DiscountDescription,
   DiscountPercent,
 } from './Discounts.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 interface DiscountOption {
-  id: string;
+  id: 'newListing' | 'weekly' | 'monthly';
   title: string;
   description: string;
   percent: number;
@@ -25,7 +26,7 @@ interface DiscountOption {
 
 const discountOptions: DiscountOption[] = [
   {
-    id: 'new_listing',
+    id: 'newListing',
     title: '신규 숙소 할인',
     description: '첫 3건의 예약에 20% 할인을 제공합니다.',
     percent: 20,
@@ -44,15 +45,16 @@ const discountOptions: DiscountOption[] = [
   },
 ];
 
-const Discounts = () => {
-  const [selectedIds, setSelectedIds] = useState<string[]>(['new_listing']);
+const Discounts = ({ data, onDataChange }: StepProps) => {
+  const discounts = data.discounts || { newListing: false, weekly: false, monthly: false };
 
-  const toggleDiscount = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id)
-        ? prev.filter((i) => i !== id)
-        : [...prev, id]
-    );
+  const toggleDiscount = (id: 'newListing' | 'weekly' | 'monthly') => {
+    onDataChange({
+      discounts: {
+        ...discounts,
+        [id]: !discounts[id],
+      },
+    });
   };
 
   return (
@@ -66,7 +68,7 @@ const Discounts = () => {
 
       <DiscountList>
         {discountOptions.map((option) => {
-          const isChecked = selectedIds.includes(option.id);
+          const isChecked = discounts[option.id] || false;
           return (
             <DiscountItem key={option.id}>
               <DiscountLeft>

--- a/src/pages/hosting/steps/Discounts.tsx
+++ b/src/pages/hosting/steps/Discounts.tsx
@@ -44,7 +44,7 @@ const discountOptions: DiscountOption[] = [
   },
 ];
 
-const Discounts: React.FC = () => {
+const Discounts = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>(['new_listing']);
 
   const toggleDiscount = (id: string) => {

--- a/src/pages/hosting/steps/GuestCapacity.styles.ts
+++ b/src/pages/hosting/steps/GuestCapacity.styles.ts
@@ -1,0 +1,64 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitleLarge,
+  CounterList as BaseCounterList,
+  CounterItem as BaseCounterItem,
+  CounterControls as BaseCounterControls,
+  CounterButton,
+  CounterValue as BaseCounterValue,
+  CounterLabel as BaseCounterLabel,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const BasicsContainer = StepContainer;
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitleLarge;
+export const CounterList = BaseCounterList;
+export const CounterItem = BaseCounterItem;
+export const CounterControls = BaseCounterControls;
+export const IconButton = CounterButton;
+export const CounterValue = BaseCounterValue;
+export const CounterLabel = BaseCounterLabel;
+
+// GuestCapacity 전용 스타일
+export const Subtitle = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-top: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const QuestionSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.lg};
+  margin-top: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const RadioGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const RadioOption = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  cursor: pointer;
+`;
+
+export const RadioInput = styled.input`
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  accent-color: ${({ theme }) => theme.colors.primary.main};
+`;
+
+export const RadioLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+

--- a/src/pages/hosting/steps/GuestCapacity.tsx
+++ b/src/pages/hosting/steps/GuestCapacity.tsx
@@ -18,7 +18,7 @@ import {
   RadioLabel,
 } from './GuestCapacity.styles';
 
-const GuestCapacity: React.FC = () => {
+const GuestCapacity = () => {
   const [guests, setGuests] = useState(4);
   const [bedrooms, setBedrooms] = useState(1);
   const [beds, setBeds] = useState(1);

--- a/src/pages/hosting/steps/GuestCapacity.tsx
+++ b/src/pages/hosting/steps/GuestCapacity.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import {
+  BasicsContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  CounterList,
+  CounterItem,
+  CounterLabel,
+  CounterControls,
+  IconButton,
+  CounterValue,
+  QuestionSection,
+  RadioGroup,
+  RadioOption,
+  RadioInput,
+  RadioLabel,
+} from './GuestCapacity.styles';
+
+const GuestCapacity: React.FC = () => {
+  const [guests, setGuests] = useState(4);
+  const [bedrooms, setBedrooms] = useState(1);
+  const [beds, setBeds] = useState(1);
+  const [hasLock, setHasLock] = useState<string | null>(null);
+
+  const updateCount = (type: 'guests' | 'bedrooms' | 'beds', delta: number) => {
+    if (type === 'guests') setGuests(Math.max(1, guests + delta));
+    if (type === 'bedrooms') setBedrooms(Math.max(1, bedrooms + delta));
+    if (type === 'beds') setBeds(Math.max(1, beds + delta));
+  };
+
+  return (
+    <BasicsContainer>
+      <TitleSection>
+        <Title>기본 사항 작성하기</Title>
+        <Subtitle>숙박 가능한 인원은 몇 명인가요?</Subtitle>
+      </TitleSection>
+
+      <CounterList>
+        <CounterItem>
+          <CounterLabel>게스트</CounterLabel>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('guests', -1)} disabled={guests <= 1}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{guests}</CounterValue>
+            <IconButton onClick={() => updateCount('guests', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+
+        <CounterItem>
+          <CounterLabel>침실</CounterLabel>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('bedrooms', -1)} disabled={bedrooms <= 1}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{bedrooms}</CounterValue>
+            <IconButton onClick={() => updateCount('bedrooms', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+
+        <CounterItem>
+          <CounterLabel>침대</CounterLabel>
+          <CounterControls>
+            <IconButton onClick={() => updateCount('beds', -1)} disabled={beds <= 1}>
+              <Minus size={18} />
+            </IconButton>
+            <CounterValue>{beds}</CounterValue>
+            <IconButton onClick={() => updateCount('beds', 1)}>
+              <Plus size={18} />
+            </IconButton>
+          </CounterControls>
+        </CounterItem>
+      </CounterList>
+
+      <QuestionSection>
+        <Subtitle>모든 침실에 잠금 장치가 설치되어 있나요?</Subtitle>
+        <RadioGroup>
+          <RadioOption>
+            <RadioInput 
+              type="radio" 
+              name="lock" 
+              value="yes" 
+              checked={hasLock === 'yes'} 
+              onChange={(e) => setHasLock(e.target.value)} 
+            />
+            <RadioLabel>예</RadioLabel>
+          </RadioOption>
+          <RadioOption>
+            <RadioInput 
+              type="radio" 
+              name="lock" 
+              value="no" 
+              checked={hasLock === 'no'} 
+              onChange={(e) => setHasLock(e.target.value)} 
+            />
+            <RadioLabel>아니요</RadioLabel>
+          </RadioOption>
+        </RadioGroup>
+      </QuestionSection>
+    </BasicsContainer>
+  );
+};
+
+export default GuestCapacity;
+

--- a/src/pages/hosting/steps/GuestCapacity.tsx
+++ b/src/pages/hosting/steps/GuestCapacity.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Minus, Plus } from 'lucide-react';
 import {
   BasicsContainer,
@@ -17,17 +17,23 @@ import {
   RadioInput,
   RadioLabel,
 } from './GuestCapacity.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const GuestCapacity = () => {
-  const [guests, setGuests] = useState(4);
-  const [bedrooms, setBedrooms] = useState(1);
-  const [beds, setBeds] = useState(1);
-  const [hasLock, setHasLock] = useState<string | null>(null);
+const GuestCapacity = ({ data, onDataChange }: StepProps) => {
+  const guests = data.guests || 1;
+  const bedrooms = data.bedrooms || 1;
+  const beds = data.beds || 1;
 
   const updateCount = (type: 'guests' | 'bedrooms' | 'beds', delta: number) => {
-    if (type === 'guests') setGuests(Math.max(1, guests + delta));
-    if (type === 'bedrooms') setBedrooms(Math.max(1, bedrooms + delta));
-    if (type === 'beds') setBeds(Math.max(1, beds + delta));
+    if (type === 'guests') {
+      onDataChange({ guests: Math.max(1, guests + delta) });
+    }
+    if (type === 'bedrooms') {
+      onDataChange({ bedrooms: Math.max(1, bedrooms + delta) });
+    }
+    if (type === 'beds') {
+      onDataChange({ beds: Math.max(1, beds + delta) });
+    }
   };
 
   return (
@@ -86,8 +92,6 @@ const GuestCapacity = () => {
               type="radio" 
               name="lock" 
               value="yes" 
-              checked={hasLock === 'yes'} 
-              onChange={(e) => setHasLock(e.target.value)} 
             />
             <RadioLabel>예</RadioLabel>
           </RadioOption>
@@ -96,8 +100,6 @@ const GuestCapacity = () => {
               type="radio" 
               name="lock" 
               value="no" 
-              checked={hasLock === 'no'} 
-              onChange={(e) => setHasLock(e.target.value)} 
             />
             <RadioLabel>아니요</RadioLabel>
           </RadioOption>

--- a/src/pages/hosting/steps/GuestRequirements.styles.ts
+++ b/src/pages/hosting/steps/GuestRequirements.styles.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection,
+  StepTitle,
+  Subtitle,
+  OptionList,
+  OptionCard as BaseOptionCard,
+  OptionContent,
+  OptionTitle,
+  OptionDescription,
+  RadioButton,
+  HiddenInput,
+} from './shared.styles';
+
+// 공통 스타일 재export
+export { 
+  TitleSection, 
+  Subtitle, 
+  OptionList, 
+  OptionContent, 
+  OptionTitle, 
+  OptionDescription, 
+  RadioButton,
+  HiddenInput as HiddenRadio,
+};
+export const Title = StepTitle;
+
+// GuestRequirements 전용 스타일
+export const GuestContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing.xl};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const OptionCard = styled(BaseOptionCard).attrs({ as: 'label' })``;

--- a/src/pages/hosting/steps/GuestRequirements.tsx
+++ b/src/pages/hosting/steps/GuestRequirements.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import {
+  GuestContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  OptionList,
+  OptionCard,
+  RadioButton,
+  HiddenRadio,
+  OptionContent,
+  OptionTitle,
+  OptionDescription,
+} from './GuestRequirements.styles';
+
+type GuestOption = 'all' | 'experienced';
+
+const GuestRequirements: React.FC = () => {
+  const [selected, setSelected] = useState<GuestOption>('all');
+
+  return (
+    <GuestContainer>
+      <TitleSection>
+        <Title>첫 예약의 게스트 조건을 선택해주세요</Title>
+        <Subtitle>첫 번째 게스트의 예약을 받은 후에는 누구나 숙소를 예약할 수 있습니다.</Subtitle>
+      </TitleSection>
+
+      <OptionList>
+        <OptionCard $selected={selected === 'all'}>
+          <HiddenRadio
+            type="radio"
+            name="guestRequirement"
+            value="all"
+            checked={selected === 'all'}
+            onChange={() => setSelected('all')}
+          />
+          <RadioButton $selected={selected === 'all'} />
+          <OptionContent>
+            <OptionTitle>모든 CozyStay 게스트</OptionTitle>
+            <OptionDescription>
+              모든 CozyStay 게스트를 맞이하겠다고 설정하면 예약을 더 빨리 받으실 수 있습니다.
+            </OptionDescription>
+          </OptionContent>
+        </OptionCard>
+
+        <OptionCard $selected={selected === 'experienced'}>
+          <HiddenRadio
+            type="radio"
+            name="guestRequirement"
+            value="experienced"
+            checked={selected === 'experienced'}
+            onChange={() => setSelected('experienced')}
+          />
+          <RadioButton $selected={selected === 'experienced'} />
+          <OptionContent>
+            <OptionTitle>경험이 풍부한 게스트</OptionTitle>
+            <OptionDescription>
+              CozyStay 이용 실적이 우수하며, 유용한 호스팅 팁도 제공할 수 있는 사람을 첫 번째 게스트로 수락하세요.
+            </OptionDescription>
+          </OptionContent>
+        </OptionCard>
+      </OptionList>
+    </GuestContainer>
+  );
+};
+
+export default GuestRequirements;
+

--- a/src/pages/hosting/steps/GuestRequirements.tsx
+++ b/src/pages/hosting/steps/GuestRequirements.tsx
@@ -15,7 +15,7 @@ import {
 
 type GuestOption = 'all' | 'experienced';
 
-const GuestRequirements: React.FC = () => {
+const GuestRequirements = () => {
   const [selected, setSelected] = useState<GuestOption>('all');
 
   return (

--- a/src/pages/hosting/steps/GuestRequirements.tsx
+++ b/src/pages/hosting/steps/GuestRequirements.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   GuestContainer,
   TitleSection,
@@ -12,11 +12,16 @@ import {
   OptionTitle,
   OptionDescription,
 } from './GuestRequirements.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-type GuestOption = 'all' | 'experienced';
+type GuestOption = 'anyone' | 'experienced';
 
-const GuestRequirements = () => {
-  const [selected, setSelected] = useState<GuestOption>('all');
+const GuestRequirements = ({ data, onDataChange }: StepProps) => {
+  const selected: GuestOption = data.guestRequirements || 'anyone';
+
+  const handleSelect = (option: GuestOption) => {
+    onDataChange({ guestRequirements: option });
+  };
 
   return (
     <GuestContainer>
@@ -26,15 +31,15 @@ const GuestRequirements = () => {
       </TitleSection>
 
       <OptionList>
-        <OptionCard $selected={selected === 'all'}>
+        <OptionCard $selected={selected === 'anyone'}>
           <HiddenRadio
             type="radio"
             name="guestRequirement"
-            value="all"
-            checked={selected === 'all'}
-            onChange={() => setSelected('all')}
+            value="anyone"
+            checked={selected === 'anyone'}
+            onChange={() => handleSelect('anyone')}
           />
-          <RadioButton $selected={selected === 'all'} />
+          <RadioButton $selected={selected === 'anyone'} />
           <OptionContent>
             <OptionTitle>모든 CozyStay 게스트</OptionTitle>
             <OptionDescription>
@@ -49,7 +54,7 @@ const GuestRequirements = () => {
             name="guestRequirement"
             value="experienced"
             checked={selected === 'experienced'}
-            onChange={() => setSelected('experienced')}
+            onChange={() => handleSelect('experienced')}
           />
           <RadioButton $selected={selected === 'experienced'} />
           <OptionContent>

--- a/src/pages/hosting/steps/HostDetails.styles.ts
+++ b/src/pages/hosting/steps/HostDetails.styles.ts
@@ -1,0 +1,175 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+import {
+  StepContainer,
+  TitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+} from './shared.styles';
+
+// 공통 스타일 재export
+export { TitleSection };
+export const Title = StepTitle;
+
+export const DetailsContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['2xl']};
+  align-items: flex-start;
+  max-width: 560px;
+`;
+
+export const Subtitle = styled(BaseSubtitle)`
+  text-align: left;
+`;
+
+// 섹션 스타일 (거주지 정보, 사업자 정보 공통)
+export const Section = styled.section`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const SectionTitle = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const SectionDescription = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0;
+
+  a {
+    color: ${({ theme }) => theme.colors.text.primary};
+    font-weight: ${({ theme }) => theme.font.weight.bold};
+    text-decoration: underline;
+    cursor: pointer;
+
+    &:hover {
+      color: ${({ theme }) => theme.colors.primary.main};
+    }
+  }
+`;
+
+// 폼 관련 스타일
+export const FormGroup = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const SelectWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const SelectLabel = styled.span`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.sm};
+  left: ${({ theme }) => theme.spacing.lg};
+  font-size: ${({ theme }) => theme.font.size.xs};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  pointer-events: none;
+`;
+
+export const Select = styled.select`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing['2xl']} ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.md};
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-family: inherit;
+  color: ${({ theme }) => theme.colors.text.primary};
+  background-color: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+  appearance: none;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.text.primary};
+    border-width: 2px;
+  }
+`;
+
+export const SelectIcon = styled.div`
+  position: absolute;
+  right: ${({ theme }) => theme.spacing.lg};
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const InputGroup = styled.div`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  overflow: hidden;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: none;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-family: inherit;
+  color: ${({ theme }) => theme.colors.text.primary};
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.secondary};
+  }
+
+  &:focus {
+    outline: none;
+    background-color: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+export const Divider = styled.hr`
+  width: 100%;
+  border: none;
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+  margin: ${({ theme }) => theme.spacing.lg} 0;
+`;
+
+// 버튼 그룹
+export const ButtonGroup = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.md};
+  width: 100%;
+
+  ${media.mobile} {
+    flex-direction: column;
+  }
+`;
+
+export const OptionButton = styled.button<{ $selected?: boolean }>`
+  flex: 1;
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme, $selected }) => 
+    $selected ? theme.colors.text.primary : theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  background-color: ${({ theme }) => theme.colors.common.white};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  ${({ $selected, theme }) => $selected && `
+    border-width: 2px;
+    background-color: ${theme.colors.background.hover};
+  `}
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.text.primary};
+  }
+`;

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { ChevronDown } from 'lucide-react';
 import {
   DetailsContainer,
@@ -19,16 +19,28 @@ import {
   ButtonGroup,
   OptionButton,
 } from './HostDetails.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const HostDetails = () => {
-  const [country, setCountry] = useState('한국');
-  const [province, setProvince] = useState('');
-  const [city, setCity] = useState('');
-  const [district, setDistrict] = useState('');
-  const [streetAddress, setStreetAddress] = useState('');
-  const [detailAddress, setDetailAddress] = useState('');
-  const [postalCode, setPostalCode] = useState('');
-  const [isBusiness, setIsBusiness] = useState<boolean | null>(null);
+const HostDetails = ({ data, onDataChange }: StepProps) => {
+  const location = data.location || {
+    country: '한국',
+    province: '',
+    city: '',
+    district: '',
+    streetAddress: '',
+    detailAddress: '',
+    postalCode: '',
+  };
+  const isBusiness = data.isBusiness;
+
+  const updateLocation = (field: string, value: string) => {
+    onDataChange({
+      location: {
+        ...location,
+        [field]: value,
+      },
+    });
+  };
 
   return (
     <DetailsContainer>
@@ -44,7 +56,7 @@ const HostDetails = () => {
         <FormGroup>
           <SelectWrapper>
             <SelectLabel>국가/지역</SelectLabel>
-            <Select value={country} onChange={(e) => setCountry(e.target.value)}>
+            <Select value={location.country} onChange={(e) => updateLocation('country', e.target.value)}>
               <option value="한국">한국</option>
               <option value="미국">미국</option>
               <option value="일본">일본</option>
@@ -61,38 +73,38 @@ const HostDetails = () => {
             <Input
               type="text"
               placeholder="도/특별·광역시"
-              value={province}
-              onChange={(e) => setProvince(e.target.value)}
+              value={location.province}
+              onChange={(e) => updateLocation('province', e.target.value)}
             />
             <Input
               type="text"
               placeholder="도시(해당하는 경우)"
-              value={city}
-              onChange={(e) => setCity(e.target.value)}
+              value={location.city}
+              onChange={(e) => updateLocation('city', e.target.value)}
             />
             <Input
               type="text"
               placeholder="군/구(해당하는 경우)"
-              value={district}
-              onChange={(e) => setDistrict(e.target.value)}
+              value={location.district}
+              onChange={(e) => updateLocation('district', e.target.value)}
             />
             <Input
               type="text"
               placeholder="도로명 주소"
-              value={streetAddress}
-              onChange={(e) => setStreetAddress(e.target.value)}
+              value={location.streetAddress}
+              onChange={(e) => updateLocation('streetAddress', e.target.value)}
             />
             <Input
               type="text"
               placeholder="아파트 층수/호수, 건물명(해당하는 경우)"
-              value={detailAddress}
-              onChange={(e) => setDetailAddress(e.target.value)}
+              value={location.detailAddress}
+              onChange={(e) => updateLocation('detailAddress', e.target.value)}
             />
             <Input
               type="text"
               placeholder="우편번호(해당하는 경우)"
-              value={postalCode}
-              onChange={(e) => setPostalCode(e.target.value)}
+              value={location.postalCode}
+              onChange={(e) => updateLocation('postalCode', e.target.value)}
             />
           </InputGroup>
         </FormGroup>
@@ -109,13 +121,13 @@ const HostDetails = () => {
         <ButtonGroup>
           <OptionButton
             $selected={isBusiness === true}
-            onClick={() => setIsBusiness(true)}
+            onClick={() => onDataChange({ isBusiness: true })}
           >
             예
           </OptionButton>
           <OptionButton
             $selected={isBusiness === false}
-            onClick={() => setIsBusiness(false)}
+            onClick={() => onDataChange({ isBusiness: false })}
           >
             아니요
           </OptionButton>

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -20,7 +20,7 @@ import {
   OptionButton,
 } from './HostDetails.styles';
 
-const HostDetails: React.FC = () => {
+const HostDetails = () => {
   const [country, setCountry] = useState('한국');
   const [province, setProvince] = useState('');
   const [city, setCity] = useState('');

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -1,0 +1,129 @@
+import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import {
+  DetailsContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  Section,
+  SectionTitle,
+  SectionDescription,
+  FormGroup,
+  SelectWrapper,
+  SelectLabel,
+  Select,
+  SelectIcon,
+  InputGroup,
+  Input,
+  Divider,
+  ButtonGroup,
+  OptionButton,
+} from './HostDetails.styles';
+
+const HostDetails: React.FC = () => {
+  const [country, setCountry] = useState('한국');
+  const [province, setProvince] = useState('');
+  const [city, setCity] = useState('');
+  const [district, setDistrict] = useState('');
+  const [streetAddress, setStreetAddress] = useState('');
+  const [detailAddress, setDetailAddress] = useState('');
+  const [postalCode, setPostalCode] = useState('');
+  const [isBusiness, setIsBusiness] = useState<boolean | null>(null);
+
+  return (
+    <DetailsContainer>
+      <TitleSection>
+        <Title>몇 가지 세부사항을 입력해 주세요</Title>
+        <Subtitle>금융 규정 준수와 사기 방지를 위해 필요한 절차입니다.</Subtitle>
+      </TitleSection>
+
+      <Section>
+        <SectionTitle>거주지 주소 정보</SectionTitle>
+        <SectionDescription>이 정보는 게스트에게 공개되지 않습니다.</SectionDescription>
+
+        <FormGroup>
+          <SelectWrapper>
+            <SelectLabel>국가/지역</SelectLabel>
+            <Select value={country} onChange={(e) => setCountry(e.target.value)}>
+              <option value="한국">한국</option>
+              <option value="미국">미국</option>
+              <option value="일본">일본</option>
+              <option value="중국">중국</option>
+            </Select>
+            <SelectIcon>
+              <ChevronDown size={20} />
+            </SelectIcon>
+          </SelectWrapper>
+        </FormGroup>
+
+        <FormGroup>
+          <InputGroup>
+            <Input
+              type="text"
+              placeholder="도/특별·광역시"
+              value={province}
+              onChange={(e) => setProvince(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="도시(해당하는 경우)"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="군/구(해당하는 경우)"
+              value={district}
+              onChange={(e) => setDistrict(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="도로명 주소"
+              value={streetAddress}
+              onChange={(e) => setStreetAddress(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="아파트 층수/호수, 건물명(해당하는 경우)"
+              value={detailAddress}
+              onChange={(e) => setDetailAddress(e.target.value)}
+            />
+            <Input
+              type="text"
+              placeholder="우편번호(해당하는 경우)"
+              value={postalCode}
+              onChange={(e) => setPostalCode(e.target.value)}
+            />
+          </InputGroup>
+        </FormGroup>
+      </Section>
+
+      <Divider />
+
+      <Section>
+        <SectionTitle>사업자로 호스팅하시나요?</SectionTitle>
+        <SectionDescription>
+          관할 세무서에 사업자로 등록하신 경우를 말합니다. <a href="#">자세히 알아보기</a>
+        </SectionDescription>
+
+        <ButtonGroup>
+          <OptionButton
+            $selected={isBusiness === true}
+            onClick={() => setIsBusiness(true)}
+          >
+            예
+          </OptionButton>
+          <OptionButton
+            $selected={isBusiness === false}
+            onClick={() => setIsBusiness(false)}
+          >
+            아니요
+          </OptionButton>
+        </ButtonGroup>
+      </Section>
+    </DetailsContainer>
+  );
+};
+
+export default HostDetails;
+

--- a/src/pages/hosting/steps/Location.styles.ts
+++ b/src/pages/hosting/steps/Location.styles.ts
@@ -1,0 +1,90 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+
+export const LocationContainer = styled.div`
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+export const HeaderSection = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing['2xl']};
+`;
+
+export const Title = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.xl};
+  }
+`;
+
+export const Subtitle = styled.p`
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const MapWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: ${({ theme }) => theme.colors.background.hover};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  overflow: hidden;
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+
+  ${media.mobile} {
+    aspect-ratio: 4 / 3;
+  }
+`;
+
+export const SearchInputWrapper = styled.div`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.lg};
+  left: 50%;
+  transform: translateX(-50%);
+  width: 90%;
+  max-width: 400px;
+  z-index: 1;
+`;
+
+export const SearchInput = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  background-color: ${({ theme }) => theme.colors.common.white};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  border-radius: ${({ theme }) => theme.radius.full};
+  box-shadow: ${({ theme }) => theme.shadow.md};
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.primary.main};
+  }
+`;
+
+export const SearchText = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+`;
+
+export const PlaceholderMap = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-image: url('https://maps.googleapis.com/maps/api/staticmap?center=37.5665,126.9780&zoom=13&size=800x450&scale=2&key=YOUR_API_KEY_MOCK');
+  background-size: cover;
+  background-position: center;
+`;
+

--- a/src/pages/hosting/steps/Location.tsx
+++ b/src/pages/hosting/steps/Location.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MapPin } from 'lucide-react';
 import {
   LocationContainer,
@@ -11,8 +11,28 @@ import {
   SearchText,
   PlaceholderMap,
 } from './Location.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const Location = () => {
+const Location = ({ data, onDataChange }: StepProps) => {
+  const [addressInput, setAddressInput] = useState(data.location?.streetAddress || '');
+
+  const handleAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setAddressInput(value);
+    onDataChange({
+      location: {
+        ...data.location,
+        country: data.location?.country || '한국',
+        province: data.location?.province || '',
+        city: data.location?.city || '',
+        district: data.location?.district || '',
+        streetAddress: value,
+        detailAddress: data.location?.detailAddress || '',
+        postalCode: data.location?.postalCode || '',
+      },
+    });
+  };
+
   return (
     <LocationContainer>
       <HeaderSection>
@@ -22,9 +42,22 @@ const Location = () => {
 
       <MapWrapper>
         <SearchInputWrapper>
-          <SearchInput>
+          <SearchInput as="label">
             <MapPin size={20} />
-            <SearchText>주소를 입력하세요.</SearchText>
+            <input
+              type="text"
+              value={addressInput}
+              onChange={handleAddressChange}
+              placeholder="주소를 입력하세요."
+              style={{
+                border: 'none',
+                background: 'transparent',
+                outline: 'none',
+                flex: 1,
+                fontSize: 'inherit',
+                fontFamily: 'inherit',
+              }}
+            />
           </SearchInput>
         </SearchInputWrapper>
         

--- a/src/pages/hosting/steps/Location.tsx
+++ b/src/pages/hosting/steps/Location.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { MapPin } from 'lucide-react';
+import {
+  LocationContainer,
+  HeaderSection,
+  Title,
+  Subtitle,
+  MapWrapper,
+  SearchInputWrapper,
+  SearchInput,
+  SearchText,
+  PlaceholderMap,
+} from './Location.styles';
+
+const Location: React.FC = () => {
+  return (
+    <LocationContainer>
+      <HeaderSection>
+        <Title>숙소 위치는 어디인가요?</Title>
+        <Subtitle>주소는 게스트의 예약이 확정된 이후에 공개됩니다.</Subtitle>
+      </HeaderSection>
+
+      <MapWrapper>
+        <SearchInputWrapper>
+          <SearchInput>
+            <MapPin size={20} />
+            <SearchText>주소를 입력하세요.</SearchText>
+          </SearchInput>
+        </SearchInputWrapper>
+        
+        {/* 나중에 실제 구글 맵 컴포넌트로 교체될 영역입니다 */}
+        <PlaceholderMap />
+      </MapWrapper>
+    </LocationContainer>
+  );
+};
+
+export default Location;
+

--- a/src/pages/hosting/steps/Location.tsx
+++ b/src/pages/hosting/steps/Location.tsx
@@ -12,7 +12,7 @@ import {
   PlaceholderMap,
 } from './Location.styles';
 
-const Location: React.FC = () => {
+const Location = () => {
   return (
     <LocationContainer>
       <HeaderSection>

--- a/src/pages/hosting/steps/Occupants.styles.ts
+++ b/src/pages/hosting/steps/Occupants.styles.ts
@@ -1,0 +1,23 @@
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitleLarge,
+  Subtitle as BaseSubtitle,
+  SelectableGrid,
+  SelectableCardCompact,
+  CardIcon,
+  CardLabel,
+  FooterText as BaseFooterText,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const OccupantsContainer = StepContainer;
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitleLarge;
+export const Subtitle = BaseSubtitle;
+export const OccupantGrid = SelectableGrid;
+export const OccupantItem = SelectableCardCompact;
+export const IconWrapper = CardIcon;
+export const Label = CardLabel;
+export const FooterText = BaseFooterText;
+

--- a/src/pages/hosting/steps/Occupants.tsx
+++ b/src/pages/hosting/steps/Occupants.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { User, Users, UserPlus } from 'lucide-react';
 import {
   OccupantsContainer,
@@ -11,6 +11,7 @@ import {
   Label,
   FooterText,
 } from './Occupants.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 const occupantTypes = [
   { id: 'host', label: '호스트', icon: <User size={32} /> },
@@ -19,13 +20,17 @@ const occupantTypes = [
   { id: 'roommate', label: '룸메이트', icon: <Users size={32} /> },
 ];
 
-const Occupants = () => {
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+const Occupants = ({ data, onDataChange }: StepProps) => {
+  // occupants를 amenities와 같이 배열로 저장하거나, 별도 필드로 관리할 수 있음
+  // 여기서는 Listing 타입에 occupants가 없으므로, 임시로 내부 상태를 유지
+  // 추후 Listing 타입 확장 시 수정 필요
+  const selectedIds = (data as { occupants?: string[] }).occupants || [];
 
   const toggleSelection = (id: string) => {
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
-    );
+    const newSelectedIds = selectedIds.includes(id)
+      ? selectedIds.filter((i) => i !== id)
+      : [...selectedIds, id];
+    onDataChange({ occupants: newSelectedIds } as Partial<typeof data>);
   };
 
   return (

--- a/src/pages/hosting/steps/Occupants.tsx
+++ b/src/pages/hosting/steps/Occupants.tsx
@@ -19,7 +19,7 @@ const occupantTypes = [
   { id: 'roommate', label: '룸메이트', icon: <Users size={32} /> },
 ];
 
-const Occupants: React.FC = () => {
+const Occupants = () => {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
 
   const toggleSelection = (id: string) => {

--- a/src/pages/hosting/steps/Occupants.tsx
+++ b/src/pages/hosting/steps/Occupants.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { User, Users, UserPlus } from 'lucide-react';
+import {
+  OccupantsContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  OccupantGrid,
+  OccupantItem,
+  IconWrapper,
+  Label,
+  FooterText,
+} from './Occupants.styles';
+
+const occupantTypes = [
+  { id: 'host', label: '호스트', icon: <User size={32} /> },
+  { id: 'family', label: '호스트의 가족', icon: <Users size={32} /> },
+  { id: 'other_guests', label: '다른 게스트', icon: <UserPlus size={32} /> },
+  { id: 'roommate', label: '룸메이트', icon: <Users size={32} /> },
+];
+
+const Occupants: React.FC = () => {
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <OccupantsContainer>
+      <TitleSection>
+        <Title>게스트 외에 숙소에 있을 수 있는 사람은 누구인가요?</Title>
+        <Subtitle>숙박 중 다른 사람과 마주치는지 여부를 게스트에게 알려야 합니다.</Subtitle>
+      </TitleSection>
+
+      <OccupantGrid>
+        {occupantTypes.map((type) => (
+          <OccupantItem
+            key={type.id}
+            $selected={selectedIds.includes(type.id)}
+            onClick={() => toggleSelection(type.id)}
+          >
+            <IconWrapper>{type.icon}</IconWrapper>
+            <Label>{type.label}</Label>
+          </OccupantItem>
+        ))}
+      </OccupantGrid>
+
+      <FooterText>이 정보는 리스팅 페이지와 검색 결과에 표시됩니다.</FooterText>
+    </OccupantsContainer>
+  );
+};
+
+export default Occupants;
+

--- a/src/pages/hosting/steps/Overview.tsx
+++ b/src/pages/hosting/steps/Overview.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+  MainContent,
+  LeftSection,
+  Title,
+  RightSection,
+  StepItem,
+  StepNumber,
+  StepContent,
+  StepTitle,
+  StepDesc,
+} from '../becomeHost.styles';
+
+const Overview: React.FC = () => {
+  return (
+    <MainContent style={{ paddingBottom: 0, marginTop: 0 }}>
+      <LeftSection>
+        <Title>CozyStay 호스트가 되는 방법은 간단합니다</Title>
+      </LeftSection>
+      
+      <RightSection>
+        <StepItem>
+          <StepNumber>1</StepNumber>
+          <StepContent>
+            <StepTitle>숙소 정보를 입력하세요</StepTitle>
+            <StepDesc>위치, 숙박 가능 인원 등 기본 정보를 공유해 주세요.</StepDesc>
+          </StepContent>
+        </StepItem>
+        
+        <StepItem>
+          <StepNumber>2</StepNumber>
+          <StepContent>
+            <StepTitle>돋보이는 숙소를 만드세요</StepTitle>
+            <StepDesc>사진 5장 이상과 제목, 설명을 추가하세요.</StepDesc>
+          </StepContent>
+        </StepItem>
+        
+        <StepItem>
+          <StepNumber>3</StepNumber>
+          <StepContent>
+            <StepTitle>등록을 완료하세요</StepTitle>
+            <StepDesc>요금을 설정하고 리스팅을 게시하세요.</StepDesc>
+          </StepContent>
+        </StepItem>
+      </RightSection>
+    </MainContent>
+  );
+};
+
+export default Overview;
+

--- a/src/pages/hosting/steps/Overview.tsx
+++ b/src/pages/hosting/steps/Overview.tsx
@@ -11,7 +11,7 @@ import {
   StepDesc,
 } from '../becomeHost.styles';
 
-const Overview: React.FC = () => {
+const Overview = () => {
   return (
     <MainContent style={{ paddingBottom: 0, marginTop: 0 }}>
       <LeftSection>

--- a/src/pages/hosting/steps/Phase1Intro.styles.ts
+++ b/src/pages/hosting/steps/Phase1Intro.styles.ts
@@ -1,0 +1,19 @@
+import { 
+  IntroContainer,
+  IntroTextSection,
+  StepLabel,
+  IntroTitle,
+  IntroDescription,
+  IntroImageSection,
+  IntroIllustration,
+} from './shared.styles';
+
+// 공통 스타일 재사용 (이름만 매핑)
+export { IntroContainer };
+export const TextSection = IntroTextSection;
+export { StepLabel };
+export const Title = IntroTitle;
+export const Description = IntroDescription;
+export const ImageSection = IntroImageSection;
+export const Illustration = IntroIllustration;
+

--- a/src/pages/hosting/steps/Phase1Intro.tsx
+++ b/src/pages/hosting/steps/Phase1Intro.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {
+  IntroContainer,
+  TextSection,
+  StepLabel,
+  Title,
+  Description,
+  ImageSection,
+  Illustration,
+} from './Phase1Intro.styles';
+
+const Phase1Intro: React.FC = () => {
+  return (
+    <IntroContainer>
+      <TextSection>
+        <StepLabel>1단계</StepLabel>
+        <Title>숙소 정보를 알려주세요</Title>
+        <Description>
+          먼저 숙소 유형을 선택하고, 게스트가 예약할 수 있는 숙소가 공간 전체인지 개인실 또는 다인실인지 알려주세요. 그런 다음 숙소 위치와 수용 가능 인원을 알려주세요.
+        </Description>
+      </TextSection>
+      <ImageSection>
+        <Illustration src="https://a0.muscache.com/im/pictures/content-listing-assets/72002598-a00e-436f-8012-680f4f780879/original/8701918a-f509-4828-89f4-18080a25694b.png" alt="Step 1 Illustration" />
+      </ImageSection>
+    </IntroContainer>
+  );
+};
+
+export default Phase1Intro;
+

--- a/src/pages/hosting/steps/Phase1Intro.tsx
+++ b/src/pages/hosting/steps/Phase1Intro.tsx
@@ -9,7 +9,7 @@ import {
   Illustration,
 } from './Phase1Intro.styles';
 
-const Phase1Intro: React.FC = () => {
+const Phase1Intro = () => {
   return (
     <IntroContainer>
       <TextSection>

--- a/src/pages/hosting/steps/Phase2Intro.styles.ts
+++ b/src/pages/hosting/steps/Phase2Intro.styles.ts
@@ -1,0 +1,19 @@
+import { 
+  IntroContainer,
+  IntroTextSection,
+  StepLabel,
+  IntroTitle,
+  IntroDescription,
+  IntroImageSection,
+  IntroIllustration,
+} from './shared.styles';
+
+// 공통 스타일 재사용 (이름만 매핑)
+export { IntroContainer };
+export const TextSection = IntroTextSection;
+export { StepLabel };
+export const Title = IntroTitle;
+export const Description = IntroDescription;
+export const ImageSection = IntroImageSection;
+export const Illustration = IntroIllustration;
+

--- a/src/pages/hosting/steps/Phase2Intro.tsx
+++ b/src/pages/hosting/steps/Phase2Intro.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  IntroContainer,
+  TextSection,
+  StepLabel,
+  Title,
+  Description,
+  ImageSection,
+  Illustration,
+} from './Phase2Intro.styles';
+import hostingStep2Image from '@/assets/images/hosting_step2.svg';
+
+const Phase2Intro: React.FC = () => {
+  return (
+    <IntroContainer>
+      <TextSection>
+        <StepLabel>2단계</StepLabel>
+        <Title>숙소의 매력을{'\n'}돋보이게 하세요</Title>
+        <Description>
+          이 단계에서는 숙소에 갖춰진 편의시설과 사진 5장 이상을 추가한 후 숙소 이름과 설명을 작성하시면 됩니다.
+        </Description>
+      </TextSection>
+      <ImageSection>
+        <Illustration 
+          src={hostingStep2Image} 
+          alt="Step 2 Illustration" 
+        />
+      </ImageSection>
+    </IntroContainer>
+  );
+};
+
+export default Phase2Intro;
+

--- a/src/pages/hosting/steps/Phase2Intro.tsx
+++ b/src/pages/hosting/steps/Phase2Intro.tsx
@@ -10,7 +10,7 @@ import {
 } from './Phase2Intro.styles';
 import hostingStep2Image from '@/assets/images/hosting_step2.svg';
 
-const Phase2Intro: React.FC = () => {
+const Phase2Intro = () => {
   return (
     <IntroContainer>
       <TextSection>

--- a/src/pages/hosting/steps/Phase3Intro.styles.ts
+++ b/src/pages/hosting/steps/Phase3Intro.styles.ts
@@ -1,0 +1,19 @@
+import { 
+  IntroContainer,
+  IntroTextSection,
+  StepLabel,
+  IntroTitle,
+  IntroDescription,
+  IntroImageSection,
+  IntroIllustration,
+} from './shared.styles';
+
+// 공통 스타일 재사용 (이름만 매핑)
+export { IntroContainer };
+export const TextSection = IntroTextSection;
+export { StepLabel };
+export const Title = IntroTitle;
+export const Description = IntroDescription;
+export const ImageSection = IntroImageSection;
+export const Illustration = IntroIllustration;
+

--- a/src/pages/hosting/steps/Phase3Intro.tsx
+++ b/src/pages/hosting/steps/Phase3Intro.tsx
@@ -9,7 +9,7 @@ import {
   Illustration,
 } from './Phase3Intro.styles';
 
-const Phase3Intro: React.FC = () => {
+const Phase3Intro = () => {
   return (
     <IntroContainer>
       <TextSection>

--- a/src/pages/hosting/steps/Phase3Intro.tsx
+++ b/src/pages/hosting/steps/Phase3Intro.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  IntroContainer,
+  TextSection,
+  StepLabel,
+  Title,
+  Description,
+  ImageSection,
+  Illustration,
+} from './Phase3Intro.styles';
+
+const Phase3Intro: React.FC = () => {
+  return (
+    <IntroContainer>
+      <TextSection>
+        <StepLabel>3단계</StepLabel>
+        <Title>등록을 완료하세요</Title>
+        <Description>
+          마지막으로, 예약 설정을 선택하고 요금을 설정한 후 숙소 등록을 완료할 차례입니다.
+        </Description>
+      </TextSection>
+      <ImageSection>
+        <Illustration 
+          src="https://a0.muscache.com/im/pictures/65ec27a0-2900-41e7-8cf0-908042739983.jpg" 
+          alt="Step 3 Illustration" 
+        />
+      </ImageSection>
+    </IntroContainer>
+  );
+};
+
+export default Phase3Intro;
+

--- a/src/pages/hosting/steps/Photos.styles.ts
+++ b/src/pages/hosting/steps/Photos.styles.ts
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+  SelectableGrid,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const PhotosContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+export const Subtitle = BaseSubtitle;
+export const PhotoGrid = SelectableGrid;
+
+// Photos 전용 스타일
+export const DropZone = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  background-color: ${({ theme }) => theme.colors.background.hover};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.background.active};
+  }
+`;
+
+export const CameraImage = styled.img`
+  width: 120px;
+  height: auto;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const AddButton = styled.button`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  background-color: ${({ theme }) => theme.colors.common.white};
+  border: 1px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+export const HiddenInput = styled.input`
+  display: none;
+`;
+
+export const PhotoItem = styled.div`
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: ${({ theme }) => theme.radius.md};
+  overflow: hidden;
+  background-color: ${({ theme }) => theme.colors.background.hover};
+`;
+
+export const PhotoPreview = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+export const RemoveButton = styled.button`
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${({ theme }) => theme.colors.common.white};
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:hover {
+    transform: scale(1.1);
+  }
+`;
+

--- a/src/pages/hosting/steps/Photos.tsx
+++ b/src/pages/hosting/steps/Photos.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import { X } from 'lucide-react';
 import {
   PhotosContainer,
@@ -14,9 +14,10 @@ import {
   PhotoPreview,
   RemoveButton,
 } from './Photos.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const Photos = () => {
-  const [photos, setPhotos] = useState<string[]>([]);
+const Photos = ({ data, onDataChange }: StepProps) => {
+  const photos = data.photos || [];
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleAddClick = () => {
@@ -34,7 +35,7 @@ const Photos = () => {
         if (event.target?.result) {
           newPhotos.push(event.target.result as string);
           if (newPhotos.length === files.length) {
-            setPhotos((prev) => [...prev, ...newPhotos]);
+            onDataChange({ photos: [...photos, ...newPhotos] });
           }
         }
       };
@@ -48,7 +49,7 @@ const Photos = () => {
   };
 
   const handleRemovePhoto = (index: number) => {
-    setPhotos((prev) => prev.filter((_, i) => i !== index));
+    onDataChange({ photos: photos.filter((_, i) => i !== index) });
   };
 
   return (

--- a/src/pages/hosting/steps/Photos.tsx
+++ b/src/pages/hosting/steps/Photos.tsx
@@ -15,7 +15,7 @@ import {
   RemoveButton,
 } from './Photos.styles';
 
-const Photos: React.FC = () => {
+const Photos = () => {
   const [photos, setPhotos] = useState<string[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 

--- a/src/pages/hosting/steps/Photos.tsx
+++ b/src/pages/hosting/steps/Photos.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useRef } from 'react';
+import { X } from 'lucide-react';
+import {
+  PhotosContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  DropZone,
+  CameraImage,
+  AddButton,
+  HiddenInput,
+  PhotoGrid,
+  PhotoItem,
+  PhotoPreview,
+  RemoveButton,
+} from './Photos.styles';
+
+const Photos: React.FC = () => {
+  const [photos, setPhotos] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleAddClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+
+    const newPhotos: string[] = [];
+    Array.from(files).forEach((file) => {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        if (event.target?.result) {
+          newPhotos.push(event.target.result as string);
+          if (newPhotos.length === files.length) {
+            setPhotos((prev) => [...prev, ...newPhotos]);
+          }
+        }
+      };
+      reader.readAsDataURL(file);
+    });
+
+    // Reset input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleRemovePhoto = (index: number) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <PhotosContainer>
+      <TitleSection>
+        <Title>숙소 사진 추가하기</Title>
+        <Subtitle>
+          숙소 등록을 시작하려면 사진 5장을 제출하셔야 합니다. 나중에 추가하거나 변경하실 수 있습니다.
+        </Subtitle>
+      </TitleSection>
+
+      {photos.length === 0 ? (
+        <DropZone onClick={handleAddClick}>
+          <CameraImage 
+            src="https://a0.muscache.com/im/pictures/mediaverse/mys-camera-light/original/f5418259-0bbc-42ea-8bc3-4c6fa4792c03.png" 
+            alt="Camera" 
+          />
+          <AddButton type="button">사진 추가하기</AddButton>
+        </DropZone>
+      ) : (
+        <>
+          <PhotoGrid>
+            {photos.map((photo, index) => (
+              <PhotoItem key={index}>
+                <PhotoPreview src={photo} alt={`Photo ${index + 1}`} />
+                <RemoveButton onClick={() => handleRemovePhoto(index)}>
+                  <X size={16} />
+                </RemoveButton>
+              </PhotoItem>
+            ))}
+          </PhotoGrid>
+          <AddButton type="button" onClick={handleAddClick}>
+            사진 더 추가하기
+          </AddButton>
+        </>
+      )}
+
+      <HiddenInput
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleFileChange}
+      />
+    </PhotosContainer>
+  );
+};
+
+export default Photos;
+

--- a/src/pages/hosting/steps/Pricing.styles.ts
+++ b/src/pages/hosting/steps/Pricing.styles.ts
@@ -1,0 +1,154 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const PricingContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['3xl']};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+export const Subtitle = BaseSubtitle;
+
+// Pricing 전용 스타일
+export const PriceInputSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const PriceInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  width: 100%;
+`;
+
+export const PriceInput = styled.input`
+  width: 100%;
+  max-width: 280px;
+  padding: ${({ theme }) => theme.spacing.xl};
+  border: 2px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  font-size: 48px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text.primary};
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary.main};
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.tertiary};
+  }
+
+  /* 숫자 입력 스피너 제거 */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  -moz-appearance: textfield;
+`;
+
+export const CurrencyLabel = styled.span`
+  font-size: 32px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const PriceHint = styled.p`
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  text-align: center;
+`;
+
+export const QuickPriceButtons = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.sm};
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+
+export const QuickPriceButton = styled.button<{ $active?: boolean }>`
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme, $active }) => 
+    $active ? theme.colors.text.primary : theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.full};
+  background-color: ${({ theme, $active }) => 
+    $active ? theme.colors.text.primary : theme.colors.common.white};
+  color: ${({ theme, $active }) => 
+    $active ? theme.colors.common.white : theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.text.primary};
+  }
+`;
+
+export const InfoCard = styled.div`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg};
+  background-color: ${({ theme }) => theme.colors.background.hover};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const InfoTitle = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const InfoText = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.5;
+  margin: 0;
+`;
+
+export const PriceBreakdown = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding-top: ${({ theme }) => theme.spacing.lg};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const BreakdownRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const BreakdownLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const BreakdownValue = styled.span<{ $highlight?: boolean }>`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme, $highlight }) => 
+    $highlight ? theme.font.weight.bold : theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+

--- a/src/pages/hosting/steps/Pricing.tsx
+++ b/src/pages/hosting/steps/Pricing.tsx
@@ -27,7 +27,7 @@ const formatPrice = (price: number): string => {
   return price.toLocaleString('ko-KR');
 };
 
-const Pricing: React.FC = () => {
+const Pricing = () => {
   const [price, setPrice] = useState<number>(50000);
 
   const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/hosting/steps/Pricing.tsx
+++ b/src/pages/hosting/steps/Pricing.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import {
+  PricingContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  PriceInputSection,
+  PriceInputWrapper,
+  PriceInput,
+  CurrencyLabel,
+  PriceHint,
+  QuickPriceButtons,
+  QuickPriceButton,
+  InfoCard,
+  InfoTitle,
+  InfoText,
+  PriceBreakdown,
+  BreakdownRow,
+  BreakdownLabel,
+  BreakdownValue,
+} from './Pricing.styles';
+
+const QUICK_PRICES = [30000, 50000, 70000, 100000, 150000];
+const SERVICE_FEE_RATE = 0.03; // 3% 서비스 수수료
+
+const formatPrice = (price: number): string => {
+  return price.toLocaleString('ko-KR');
+};
+
+const Pricing: React.FC = () => {
+  const [price, setPrice] = useState<number>(50000);
+
+  const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, '');
+    const numValue = parseInt(value, 10);
+    if (!isNaN(numValue)) {
+      setPrice(numValue);
+    } else if (value === '') {
+      setPrice(0);
+    }
+  };
+
+  const serviceFee = Math.round(price * SERVICE_FEE_RATE);
+  const hostEarnings = price - serviceFee;
+
+  return (
+    <PricingContainer>
+      <TitleSection>
+        <Title>주중 기본 요금 설정</Title>
+        <Subtitle>
+          게스트가 1박당 지불할 금액을 설정하세요. 나중에 언제든지 변경할 수 있습니다.
+        </Subtitle>
+      </TitleSection>
+
+      <PriceInputSection>
+        <PriceInputWrapper>
+          <CurrencyLabel>₩</CurrencyLabel>
+          <PriceInput
+            type="text"
+            value={formatPrice(price)}
+            onChange={handlePriceChange}
+            placeholder="0"
+          />
+        </PriceInputWrapper>
+
+        <PriceHint>1박 기준 가격</PriceHint>
+
+        <QuickPriceButtons>
+          {QUICK_PRICES.map((quickPrice) => (
+            <QuickPriceButton
+              key={quickPrice}
+              $active={price === quickPrice}
+              onClick={() => setPrice(quickPrice)}
+            >
+              ₩{formatPrice(quickPrice)}
+            </QuickPriceButton>
+          ))}
+        </QuickPriceButtons>
+      </PriceInputSection>
+
+      <InfoCard>
+        <InfoTitle>💡 비슷한 숙소의 평균 가격</InfoTitle>
+        <InfoText>
+          이 지역의 비슷한 숙소는 평균 ₩55,000 ~ ₩85,000의 가격대로 운영되고 있습니다.
+        </InfoText>
+
+        <PriceBreakdown>
+          <BreakdownRow>
+            <BreakdownLabel>기본 요금</BreakdownLabel>
+            <BreakdownValue>₩{formatPrice(price)}</BreakdownValue>
+          </BreakdownRow>
+          <BreakdownRow>
+            <BreakdownLabel>서비스 수수료 (3%)</BreakdownLabel>
+            <BreakdownValue>-₩{formatPrice(serviceFee)}</BreakdownValue>
+          </BreakdownRow>
+          <BreakdownRow>
+            <BreakdownLabel>예상 수익</BreakdownLabel>
+            <BreakdownValue $highlight>₩{formatPrice(hostEarnings)}</BreakdownValue>
+          </BreakdownRow>
+        </PriceBreakdown>
+      </InfoCard>
+    </PricingContainer>
+  );
+};
+
+export default Pricing;
+

--- a/src/pages/hosting/steps/Pricing.tsx
+++ b/src/pages/hosting/steps/Pricing.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   PricingContainer,
   TitleSection,
@@ -19,6 +19,7 @@ import {
   BreakdownLabel,
   BreakdownValue,
 } from './Pricing.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 const QUICK_PRICES = [30000, 50000, 70000, 100000, 150000];
 const SERVICE_FEE_RATE = 0.03; // 3% 서비스 수수료
@@ -27,17 +28,21 @@ const formatPrice = (price: number): string => {
   return price.toLocaleString('ko-KR');
 };
 
-const Pricing = () => {
-  const [price, setPrice] = useState<number>(50000);
+const Pricing = ({ data, onDataChange }: StepProps) => {
+  const price = data.pricing?.basePrice || 50000;
 
   const handlePriceChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/[^0-9]/g, '');
     const numValue = parseInt(value, 10);
     if (!isNaN(numValue)) {
-      setPrice(numValue);
+      onDataChange({ pricing: { ...data.pricing, basePrice: numValue, weekendPremium: data.pricing?.weekendPremium || 0 } });
     } else if (value === '') {
-      setPrice(0);
+      onDataChange({ pricing: { ...data.pricing, basePrice: 0, weekendPremium: data.pricing?.weekendPremium || 0 } });
     }
+  };
+
+  const setPrice = (newPrice: number) => {
+    onDataChange({ pricing: { ...data.pricing, basePrice: newPrice, weekendPremium: data.pricing?.weekendPremium || 0 } });
   };
 
   const serviceFee = Math.round(price * SERVICE_FEE_RATE);

--- a/src/pages/hosting/steps/SafetyInfo.styles.ts
+++ b/src/pages/hosting/steps/SafetyInfo.styles.ts
@@ -1,0 +1,202 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const SafetyContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['2xl']};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+
+// SafetyInfo 전용 스타일
+export const SectionTitle = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+`;
+
+export const CheckboxList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const CheckboxItem = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing['3xl']};
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg} 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+  cursor: pointer;
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+export const CheckboxLabel = styled.span`
+  flex: 1;
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const Checkbox = styled.div<{ $checked?: boolean }>`
+  width: 24px;
+  height: 24px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  border: 2px solid ${({ theme, $checked }) => 
+    $checked ? theme.colors.text.primary : theme.colors.border.primary};
+  background-color: ${({ theme, $checked }) => 
+    $checked ? theme.colors.text.primary : 'transparent'};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all ${({ theme }) => theme.transition.fast};
+  flex-shrink: 0;
+  margin-left: auto;
+
+  svg {
+    color: ${({ theme }) => theme.colors.common.white};
+  }
+`;
+
+export const HiddenInput = styled.input`
+  display: none;
+`;
+
+export const NoticeSection = styled.div`
+  width: 100%;
+  padding-top: ${({ theme }) => theme.spacing.xl};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const NoticeTitle = styled.h4`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+`;
+
+export const NoticeText = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.6;
+  margin: 0;
+`;
+
+// 모달 스타일
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.colors.overlay.default};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: ${({ theme }) => theme.zIndex.modalOverlay};
+`;
+
+export const ModalContent = styled.div`
+  background-color: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.xl};
+  width: 90%;
+  max-width: 560px;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: ${({ theme }) => theme.spacing.xl};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const ModalHeader = styled.div`
+  display: flex;
+  justify-content: flex-start;
+`;
+
+export const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: ${({ theme }) => theme.spacing.sm};
+  margin: -${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+  
+  &:hover {
+    opacity: 0.7;
+  }
+`;
+
+export const ModalTitle = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  line-height: 1.3;
+`;
+
+export const ModalDescription = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.5;
+  margin: 0;
+`;
+
+export const ModalTextArea = styled.textarea`
+  width: 100%;
+  min-height: 120px;
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:focus {
+    outline: none;
+    border-width: 2px;
+    padding: calc(${({ theme }) => theme.spacing.lg} - 1px);
+  }
+`;
+
+export const CharCount = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  text-align: right;
+`;
+
+export const ModalButton = styled.button`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg};
+  background-color: ${({ theme }) => theme.colors.text.primary};
+  color: ${({ theme }) => theme.colors.common.white};
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.border.primary};
+    cursor: not-allowed;
+  }
+`;
+

--- a/src/pages/hosting/steps/SafetyInfo.tsx
+++ b/src/pages/hosting/steps/SafetyInfo.tsx
@@ -54,7 +54,7 @@ const safetyOptions: SafetyOption[] = [
 
 const MAX_LENGTH = 300;
 
-const SafetyInfo: React.FC = () => {
+const SafetyInfo = () => {
   const [selectedItems, setSelectedItems] = useState<Record<string, { checked: boolean; description: string }>>({});
   const [modalOpen, setModalOpen] = useState<string | null>(null);
   const [tempDescription, setTempDescription] = useState('');

--- a/src/pages/hosting/steps/SafetyInfo.tsx
+++ b/src/pages/hosting/steps/SafetyInfo.tsx
@@ -1,0 +1,164 @@
+import React, { useState } from 'react';
+import { Check, X } from 'lucide-react';
+import {
+  SafetyContainer,
+  TitleSection,
+  Title,
+  SectionTitle,
+  CheckboxList,
+  CheckboxItem,
+  CheckboxLabel,
+  Checkbox,
+  HiddenInput,
+  NoticeSection,
+  NoticeTitle,
+  NoticeText,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  CloseButton,
+  ModalTitle,
+  ModalDescription,
+  ModalTextArea,
+  CharCount,
+  ModalButton,
+} from './SafetyInfo.styles';
+
+interface SafetyOption {
+  id: string;
+  label: string;
+  modalTitle: string;
+  modalDescription: string;
+}
+
+const safetyOptions: SafetyOption[] = [
+  {
+    id: 'camera',
+    label: '숙소 실외 공간을 모니터링하는 보안 카메라 있음',
+    modalTitle: '숙소의 실외 공간을 모니터링하는 보안 카메라에 대해 게스트에게 알려주세요',
+    modalDescription: '각 카메라가 모니터링하는 공간이 어디인지 알려주세요(예: 뒷마당, 수영장 등).',
+  },
+  {
+    id: 'noise',
+    label: '소음 측정기 있음',
+    modalTitle: '소음 측정기에 대해 게스트에게 알려주세요',
+    modalDescription: '소음 측정기의 위치와 작동 방식을 알려주세요.',
+  },
+  {
+    id: 'weapon',
+    label: '숙소에 무기가 있음',
+    modalTitle: '숙소에 있는 무기에 대해 게스트에게 알려주세요',
+    modalDescription: '무기의 종류와 보관 위치를 알려주세요.',
+  },
+];
+
+const MAX_LENGTH = 300;
+
+const SafetyInfo: React.FC = () => {
+  const [selectedItems, setSelectedItems] = useState<Record<string, { checked: boolean; description: string }>>({});
+  const [modalOpen, setModalOpen] = useState<string | null>(null);
+  const [tempDescription, setTempDescription] = useState('');
+
+  const handleCheckboxClick = (id: string) => {
+    const currentItem = selectedItems[id];
+    
+    if (currentItem?.checked) {
+      // 체크 해제
+      setSelectedItems((prev) => ({
+        ...prev,
+        [id]: { checked: false, description: '' },
+      }));
+    } else {
+      // 체크 시 모달 열기
+      setModalOpen(id);
+      setTempDescription(currentItem?.description || '');
+    }
+  };
+
+  const handleModalClose = () => {
+    setModalOpen(null);
+    setTempDescription('');
+  };
+
+  const handleModalSubmit = () => {
+    if (modalOpen) {
+      setSelectedItems((prev) => ({
+        ...prev,
+        [modalOpen]: { checked: true, description: tempDescription },
+      }));
+      setModalOpen(null);
+      setTempDescription('');
+    }
+  };
+
+  const currentModalOption = safetyOptions.find((opt) => opt.id === modalOpen);
+
+  return (
+    <SafetyContainer>
+      <TitleSection>
+        <Title>안전 관련 정보 공유하기</Title>
+      </TitleSection>
+
+      <div>
+        <SectionTitle>숙소에 다음 사항이 있나요?</SectionTitle>
+        <CheckboxList>
+          {safetyOptions.map((option) => {
+            const isChecked = selectedItems[option.id]?.checked || false;
+            return (
+              <CheckboxItem key={option.id} onClick={() => handleCheckboxClick(option.id)}>
+                <CheckboxLabel>{option.label}</CheckboxLabel>
+                <HiddenInput type="checkbox" checked={isChecked} readOnly />
+                <Checkbox $checked={isChecked}>
+                  {isChecked && <Check size={16} />}
+                </Checkbox>
+              </CheckboxItem>
+            );
+          })}
+        </CheckboxList>
+      </div>
+
+      <NoticeSection>
+        <NoticeTitle>중요사항</NoticeTitle>
+        <NoticeText>
+          실내 공간을 모니터링하는 보안 카메라는 전원이 꺼져 있어도 허용되지 않습니다. 
+          실외 공간을 모니터링하는 보안 카메라는 설치 위치를 모두 공개해야 합니다.
+        </NoticeText>
+      </NoticeSection>
+
+      {/* 모달 */}
+      {modalOpen && currentModalOption && (
+        <ModalOverlay onClick={handleModalClose}>
+          <ModalContent onClick={(e) => e.stopPropagation()}>
+            <ModalHeader>
+              <CloseButton onClick={handleModalClose}>
+                <X size={24} />
+              </CloseButton>
+            </ModalHeader>
+            
+            <ModalTitle>{currentModalOption.modalTitle}</ModalTitle>
+            <ModalDescription>{currentModalOption.modalDescription}</ModalDescription>
+            
+            <ModalTextArea
+              value={tempDescription}
+              onChange={(e) => {
+                if (e.target.value.length <= MAX_LENGTH) {
+                  setTempDescription(e.target.value);
+                }
+              }}
+              placeholder="내용을 입력하세요..."
+              maxLength={MAX_LENGTH}
+            />
+            <CharCount>{MAX_LENGTH - tempDescription.length}자 남음</CharCount>
+            
+            <ModalButton onClick={handleModalSubmit}>
+              계속
+            </ModalButton>
+          </ModalContent>
+        </ModalOverlay>
+      )}
+    </SafetyContainer>
+  );
+};
+
+export default SafetyInfo;
+

--- a/src/pages/hosting/steps/SafetyInfo.tsx
+++ b/src/pages/hosting/steps/SafetyInfo.tsx
@@ -23,6 +23,7 @@ import {
   CharCount,
   ModalButton,
 } from './SafetyInfo.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 interface SafetyOption {
   id: string;
@@ -54,8 +55,8 @@ const safetyOptions: SafetyOption[] = [
 
 const MAX_LENGTH = 300;
 
-const SafetyInfo = () => {
-  const [selectedItems, setSelectedItems] = useState<Record<string, { checked: boolean; description: string }>>({});
+const SafetyInfo = ({ data, onDataChange }: StepProps) => {
+  const selectedItems = data.safetyInfo || {};
   const [modalOpen, setModalOpen] = useState<string | null>(null);
   const [tempDescription, setTempDescription] = useState('');
 
@@ -64,10 +65,12 @@ const SafetyInfo = () => {
     
     if (currentItem?.checked) {
       // 체크 해제
-      setSelectedItems((prev) => ({
-        ...prev,
-        [id]: { checked: false, description: '' },
-      }));
+      onDataChange({
+        safetyInfo: {
+          ...selectedItems,
+          [id]: { checked: false, description: '' },
+        },
+      });
     } else {
       // 체크 시 모달 열기
       setModalOpen(id);
@@ -82,10 +85,12 @@ const SafetyInfo = () => {
 
   const handleModalSubmit = () => {
     if (modalOpen) {
-      setSelectedItems((prev) => ({
-        ...prev,
-        [modalOpen]: { checked: true, description: tempDescription },
-      }));
+      onDataChange({
+        safetyInfo: {
+          ...selectedItems,
+          [modalOpen]: { checked: true, description: tempDescription },
+        },
+      });
       setModalOpen(null);
       setTempDescription('');
     }

--- a/src/pages/hosting/steps/SpaceType.styles.ts
+++ b/src/pages/hosting/steps/SpaceType.styles.ts
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+
+export const TypeContainer = styled.div`
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+`;
+
+export const Title = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin-bottom: ${({ theme }) => theme.spacing['4xl']};
+  text-align: center;
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.xl};
+    text-align: left;
+  }
+`;
+
+export const TypeList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const TypeItem = styled.button<{ $selected?: boolean }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${({ theme, $selected }) =>
+    $selected ? `calc(${theme.spacing.xl} - 1px)` : theme.spacing.xl};
+  border: ${({ theme, $selected }) =>
+    $selected
+      ? `2px solid ${theme.colors.primary.main}`
+      : `1px solid ${theme.colors.border.primary}`};
+  border-radius: ${({ theme }) => theme.radius.md};
+  background-color: ${({ theme, $selected }) => ($selected ? theme.colors.background.hover : theme.colors.common.white)};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+  text-align: left;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.primary.main};
+    border-width: 3px;
+    padding: calc(${({ theme }) => theme.spacing.xl} - 2px);
+  }
+`;
+
+export const TextContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const Label = styled.span`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const Description = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0;
+`;
+
+export const IconWrapper = styled.div`
+  font-size: 32px;
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+

--- a/src/pages/hosting/steps/SpaceType.tsx
+++ b/src/pages/hosting/steps/SpaceType.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import {
+  TypeContainer,
+  Title,
+  TypeList,
+  TypeItem,
+  TextContent,
+  Label,
+  Description,
+  IconWrapper,
+} from './SpaceType.styles';
+import { Home, DoorOpen, Users } from 'lucide-react';
+
+const types = [
+  {
+    id: 'entire',
+    label: '공간 전체',
+    description: '게스트가 숙소 전체를 단독으로 사용합니다.',
+    icon: <Home size={32} />,
+  },
+  {
+    id: 'room',
+    label: '방',
+    description: '단독으로 사용하는 개인실이 있고, 공용 공간도 있는 형태입니다.',
+    icon: <DoorOpen size={32} />,
+  },
+  {
+    id: 'hostel',
+    label: '호스텔 내 다인실',
+    description: '게스트는 연중무휴 직원이 상주하는 전문 숙박시설인 호스텔 내부 다인실에서 머무릅니다.',
+    icon: <Users size={32} />,
+  },
+];
+
+const SpaceType: React.FC = () => {
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <TypeContainer>
+      <Title>게스트가 사용할 숙소 유형</Title>
+      <TypeList>
+        {types.map((type) => (
+          <TypeItem
+            key={type.id}
+            $selected={selected === type.id}
+            onClick={() => setSelected(type.id)}
+          >
+            <TextContent>
+              <Label>{type.label}</Label>
+              <Description>{type.description}</Description>
+            </TextContent>
+            <IconWrapper>{type.icon}</IconWrapper>
+          </TypeItem>
+        ))}
+      </TypeList>
+    </TypeContainer>
+  );
+};
+
+export default SpaceType;
+

--- a/src/pages/hosting/steps/SpaceType.tsx
+++ b/src/pages/hosting/steps/SpaceType.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   TypeContainer,
   Title,
@@ -10,6 +10,7 @@ import {
   IconWrapper,
 } from './SpaceType.styles';
 import { Home, DoorOpen, Users } from 'lucide-react';
+import type { StepProps } from '../BecomeHostPage';
 
 const types = [
   {
@@ -32,8 +33,12 @@ const types = [
   },
 ];
 
-const SpaceType = () => {
-  const [selected, setSelected] = useState<string | null>(null);
+const SpaceType = ({ data, onDataChange }: StepProps) => {
+  const selected = data.spaceType || null;
+
+  const handleSelect = (spaceTypeLabel: string) => {
+    onDataChange({ spaceType: spaceTypeLabel });
+  };
 
   return (
     <TypeContainer>
@@ -42,8 +47,8 @@ const SpaceType = () => {
         {types.map((type) => (
           <TypeItem
             key={type.id}
-            $selected={selected === type.id}
-            onClick={() => setSelected(type.id)}
+            $selected={selected === type.label}
+            onClick={() => handleSelect(type.label)}
           >
             <TextContent>
               <Label>{type.label}</Label>

--- a/src/pages/hosting/steps/SpaceType.tsx
+++ b/src/pages/hosting/steps/SpaceType.tsx
@@ -32,7 +32,7 @@ const types = [
   },
 ];
 
-const SpaceType: React.FC = () => {
+const SpaceType = () => {
   const [selected, setSelected] = useState<string | null>(null);
 
   return (

--- a/src/pages/hosting/steps/Title.styles.ts
+++ b/src/pages/hosting/steps/Title.styles.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection,
+  StepTitle,
+  Subtitle,
+  TextAreaBase,
+  CharCount,
+} from './shared.styles';
+
+// 공통 스타일 재export
+export { TitleSection, Subtitle, CharCount };
+export const Title = StepTitle;
+
+// Title 전용 스타일
+export const TitleContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing.xl};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TextArea = styled(TextAreaBase)`
+  min-height: 140px;
+  font-size: ${({ theme }) => theme.font.size.lg};
+`;

--- a/src/pages/hosting/steps/Title.tsx
+++ b/src/pages/hosting/steps/Title.tsx
@@ -10,7 +10,7 @@ import {
 
 const MAX_LENGTH = 50;
 
-const TitleStep: React.FC = () => {
+const TitleStep = () => {
   const [name, setName] = useState('');
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/pages/hosting/steps/Title.tsx
+++ b/src/pages/hosting/steps/Title.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   TitleContainer,
   TitleSection,
@@ -7,16 +7,17 @@ import {
   TextArea,
   CharCount,
 } from './Title.styles';
+import type { StepProps } from '../BecomeHostPage';
 
 const MAX_LENGTH = 50;
 
-const TitleStep = () => {
-  const [name, setName] = useState('');
+const TitleStep = ({ data, onDataChange }: StepProps) => {
+  const name = data.title || '';
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     if (value.length <= MAX_LENGTH) {
-      setName(value);
+      onDataChange({ title: value });
     }
   };
 

--- a/src/pages/hosting/steps/Title.tsx
+++ b/src/pages/hosting/steps/Title.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import {
+  TitleContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  TextArea,
+  CharCount,
+} from './Title.styles';
+
+const MAX_LENGTH = 50;
+
+const TitleStep: React.FC = () => {
+  const [name, setName] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    if (value.length <= MAX_LENGTH) {
+      setName(value);
+    }
+  };
+
+  return (
+    <TitleContainer>
+      <TitleSection>
+        <Title>이제 숙소에 이름을 지어주세요</Title>
+        <Subtitle>
+          숙소 이름은 짧을수록 효과적입니다. 나중에 언제든지 변경할 수 있으니, 너무 걱정하지 마세요.
+        </Subtitle>
+      </TitleSection>
+
+      <TextArea
+        value={name}
+        onChange={handleChange}
+        maxLength={MAX_LENGTH}
+      />
+
+      <CharCount>{name.length}/{MAX_LENGTH}</CharCount>
+    </TitleContainer>
+  );
+};
+
+export default TitleStep;
+

--- a/src/pages/hosting/steps/WeekendPricing.styles.ts
+++ b/src/pages/hosting/steps/WeekendPricing.styles.ts
@@ -1,0 +1,154 @@
+import styled from 'styled-components';
+import { 
+  StepContainer, 
+  TitleSection as BaseTitleSection,
+  StepTitle,
+  Subtitle as BaseSubtitle,
+} from './shared.styles';
+
+// 공통 스타일 재사용
+export const WeekendContainer = styled(StepContainer)`
+  gap: ${({ theme }) => theme.spacing['3xl']};
+  align-items: flex-start;
+  justify-content: center;
+`;
+
+export const TitleSection = BaseTitleSection;
+export const Title = StepTitle;
+export const Subtitle = BaseSubtitle;
+
+// WeekendPricing 전용 스타일
+export const PriceDisplaySection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg};
+  padding: ${({ theme }) => theme.spacing['3xl']} 0;
+`;
+
+export const BigPrice = styled.div`
+  font-size: 64px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  letter-spacing: -2px;
+`;
+
+export const GuestPrice = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const SliderSection = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const SliderHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+`;
+
+export const SliderLabel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const SliderTitle = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const SliderHint = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const PercentBadge = styled.div`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  border: 2px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.full};
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const SliderWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const SliderInput = styled.input`
+  width: 100%;
+  height: 6px;
+  border-radius: 3px;
+  background: linear-gradient(
+    to right,
+    ${({ theme }) => theme.colors.text.primary} 0%,
+    ${({ theme }) => theme.colors.text.primary} var(--progress, 29%),
+    ${({ theme }) => theme.colors.border.light} var(--progress, 29%),
+    ${({ theme }) => theme.colors.border.light} 100%
+  );
+  outline: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.colors.text.primary};
+    cursor: pointer;
+    border: 4px solid ${({ theme }) => theme.colors.common.white};
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  }
+
+  &::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: ${({ theme }) => theme.colors.text.primary};
+    cursor: pointer;
+    border: 4px solid ${({ theme }) => theme.colors.common.white};
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  }
+`;
+
+export const SliderRange = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const InfoCard = styled.div`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg};
+  background-color: ${({ theme }) => theme.colors.background.hover};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const InfoIcon = styled.span`
+  font-size: 24px;
+`;
+
+export const InfoText = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.5;
+  margin: 0;
+`;

--- a/src/pages/hosting/steps/WeekendPricing.tsx
+++ b/src/pages/hosting/steps/WeekendPricing.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   WeekendContainer,
   TitleSection,
@@ -20,22 +20,24 @@ import {
   InfoIcon,
   InfoText,
 } from './WeekendPricing.styles';
+import type { StepProps } from '../BecomeHostPage';
 
-const BASE_PRICE = 60000; // 기본 주중 요금 (실제로는 이전 페이지에서 가져와야 함)
 const SERVICE_FEE_RATE = 0.14; // 게스트 서비스 수수료 14%
 
 const formatPrice = (price: number): string => {
   return price.toLocaleString('ko-KR');
 };
 
-const WeekendPricing = () => {
-  const [premium, setPremium] = useState(29);
+const WeekendPricing = ({ data, onDataChange }: StepProps) => {
+  const basePrice = data.pricing?.basePrice || 50000;
+  const premium = data.pricing?.weekendPremium || 0;
 
-  const weekendPrice = Math.round(BASE_PRICE * (1 + premium / 100));
+  const weekendPrice = Math.round(basePrice * (1 + premium / 100));
   const guestPrice = Math.round(weekendPrice * (1 + SERVICE_FEE_RATE));
 
   const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setPremium(parseInt(e.target.value, 10));
+    const newPremium = parseInt(e.target.value, 10);
+    onDataChange({ pricing: { ...data.pricing, basePrice, weekendPremium: newPremium } });
   };
 
   return (

--- a/src/pages/hosting/steps/WeekendPricing.tsx
+++ b/src/pages/hosting/steps/WeekendPricing.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import {
+  WeekendContainer,
+  TitleSection,
+  Title,
+  Subtitle,
+  PriceDisplaySection,
+  BigPrice,
+  GuestPrice,
+  SliderSection,
+  SliderHeader,
+  SliderLabel,
+  SliderTitle,
+  SliderHint,
+  PercentBadge,
+  SliderWrapper,
+  SliderInput,
+  SliderRange,
+  InfoCard,
+  InfoIcon,
+  InfoText,
+} from './WeekendPricing.styles';
+
+const BASE_PRICE = 60000; // 기본 주중 요금 (실제로는 이전 페이지에서 가져와야 함)
+const SERVICE_FEE_RATE = 0.14; // 게스트 서비스 수수료 14%
+
+const formatPrice = (price: number): string => {
+  return price.toLocaleString('ko-KR');
+};
+
+const WeekendPricing: React.FC = () => {
+  const [premium, setPremium] = useState(29);
+
+  const weekendPrice = Math.round(BASE_PRICE * (1 + premium / 100));
+  const guestPrice = Math.round(weekendPrice * (1 + SERVICE_FEE_RATE));
+
+  const handleSliderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPremium(parseInt(e.target.value, 10));
+  };
+
+  return (
+    <WeekendContainer>
+      <TitleSection>
+        <Title>주말 요금을 설정하세요</Title>
+        <Subtitle>금요일과 토요일에는 주말 할증을 추가하세요.</Subtitle>
+      </TitleSection>
+
+      <PriceDisplaySection>
+        <BigPrice>₩{formatPrice(weekendPrice)}</BigPrice>
+        <GuestPrice>
+          게스트 지불 요금: ₩{formatPrice(guestPrice)}
+        </GuestPrice>
+      </PriceDisplaySection>
+
+      <SliderSection>
+        <SliderHeader>
+          <SliderLabel>
+            <SliderTitle>주말 프리미엄</SliderTitle>
+            <SliderHint>제안 할증률: 29%</SliderHint>
+          </SliderLabel>
+          <PercentBadge>{premium}%</PercentBadge>
+        </SliderHeader>
+
+        <SliderWrapper>
+          <SliderInput
+            type="range"
+            min="0"
+            max="99"
+            value={premium}
+            onChange={handleSliderChange}
+            style={{ '--progress': `${premium}%` } as React.CSSProperties}
+          />
+          <SliderRange>
+            <span>0%</span>
+            <span>99%</span>
+          </SliderRange>
+        </SliderWrapper>
+      </SliderSection>
+
+      <InfoCard>
+        <InfoIcon>💡</InfoIcon>
+        <InfoText>
+          주말에는 수요가 높아 평균 20~30% 더 높은 가격을 책정할 수 있습니다.
+          금요일과 토요일 밤에 적용됩니다.
+        </InfoText>
+      </InfoCard>
+    </WeekendContainer>
+  );
+};
+
+export default WeekendPricing;

--- a/src/pages/hosting/steps/WeekendPricing.tsx
+++ b/src/pages/hosting/steps/WeekendPricing.tsx
@@ -28,7 +28,7 @@ const formatPrice = (price: number): string => {
   return price.toLocaleString('ko-KR');
 };
 
-const WeekendPricing: React.FC = () => {
+const WeekendPricing = () => {
   const [premium, setPremium] = useState(29);
 
   const weekendPrice = Math.round(BASE_PRICE * (1 + premium / 100));

--- a/src/pages/hosting/steps/shared.styles.ts
+++ b/src/pages/hosting/steps/shared.styles.ts
@@ -1,0 +1,436 @@
+import styled, { css } from 'styled-components';
+import { media } from '@/styles/media';
+
+/**
+ * 호스팅 등록 스텝 공통 스타일
+ * - 모든 스텝에서 재사용되는 컴포넌트들
+ */
+
+// ============================================
+// 컨테이너
+// ============================================
+
+/** 스텝 기본 컨테이너 (max-width: 640px) */
+export const StepContainer = styled.div`
+  width: 100%;
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing['4xl']};
+`;
+
+/** 인트로 페이지용 컨테이너 (max-width: 1000px, 좌우 분할) */
+export const IntroContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 1000px;
+  gap: ${({ theme }) => theme.spacing['6xl']};
+
+  ${media.tablet} {
+    flex-direction: column;
+    text-align: left;
+    gap: ${({ theme }) => theme.spacing['4xl']};
+  }
+`;
+
+// ============================================
+// 타이틀 섹션
+// ============================================
+
+/** 타이틀 + 서브타이틀 래퍼 */
+export const TitleSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+/** 메인 타이틀 (h1, 32px) */
+export const StepTitle = styled.h1`
+  font-size: 32px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  line-height: 1.2;
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  ${media.mobile} {
+    font-size: 26px;
+  }
+`;
+
+/** 큰 타이틀 (h2, xxl) - 선택 화면용 */
+export const StepTitleLarge = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.xl};
+  }
+`;
+
+/** 인트로용 초대형 타이틀 (48px) */
+export const IntroTitle = styled.h1`
+  font-size: 48px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  line-height: 1.1;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+
+  ${media.mobile} {
+    font-size: 32px;
+  }
+`;
+
+/** 서브타이틀/설명 텍스트 */
+export const Subtitle = styled.p`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.5;
+  word-break: keep-all;
+  margin: 0;
+`;
+
+/** 단계 라벨 (1단계, 2단계 등) */
+export const StepLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
+  display: block;
+`;
+
+/** 섹션 타이틀 (카테고리 내 소제목) */
+export const SectionTitle = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+`;
+
+// ============================================
+// 선택 가능한 그리드/카드
+// ============================================
+
+/** 3열 그리드 (모바일: 2열) */
+export const SelectableGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${({ theme }) => theme.spacing.md};
+
+  ${media.tablet} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  ${media.mobile} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+`;
+
+/** 선택 가능한 카드 기본 스타일 */
+const selectableCardBase = css<{ $selected?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme, $selected }) => 
+    $selected ? theme.colors.text.primary : theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  background-color: ${({ theme, $selected }) => 
+    $selected ? theme.colors.background.hover : theme.colors.common.white};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.fast};
+  text-align: left;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.text.primary};
+  }
+`;
+
+/** 선택 가능한 카드 (아이콘 + 라벨) */
+export const SelectableCard = styled.button<{ $selected?: boolean }>`
+  ${selectableCardBase}
+  gap: ${({ theme }) => theme.spacing.sm};
+  min-height: 100px;
+  justify-content: space-between;
+`;
+
+/** 선택 가능한 카드 - 컴팩트 버전 */
+export const SelectableCardCompact = styled.button<{ $selected?: boolean }>`
+  ${selectableCardBase}
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+/** 카드 내 아이콘 래퍼 */
+export const CardIcon = styled.div`
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: ${({ theme }) => theme.spacing.xs};
+`;
+
+/** 카드 내 라벨 */
+export const CardLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+// ============================================
+// 카운터 컨트롤
+// ============================================
+
+/** 카운터 리스트 컨테이너 */
+export const CounterList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+/** 카운터 아이템 행 */
+export const CounterItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${({ theme }) => theme.spacing.xl} 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+/** 카운터 텍스트 섹션 */
+export const CounterTextSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+  flex: 1;
+`;
+
+/** 카운터 라벨 */
+export const CounterLabel = styled.span`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+/** 카운터 설명 */
+export const CounterDescription = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin: 0;
+`;
+
+/** 카운터 컨트롤 래퍼 */
+export const CounterControls = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg};
+  margin-left: ${({ theme }) => theme.spacing.xl};
+`;
+
+/** +/- 버튼 */
+export const CounterButton = styled.button`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  background-color: ${({ theme }) => theme.colors.common.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+  color: ${({ theme }) => theme.colors.text.secondary};
+
+  &:hover:not(:disabled) {
+    border-color: ${({ theme }) => theme.colors.primary.main};
+    color: ${({ theme }) => theme.colors.primary.main};
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+`;
+
+/** 카운터 값 */
+export const CounterValue = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  min-width: 20px;
+  text-align: center;
+`;
+
+// ============================================
+// 인트로 페이지 전용
+// ============================================
+
+/** 인트로 텍스트 섹션 */
+export const IntroTextSection = styled.div`
+  flex: 1;
+`;
+
+/** 인트로 이미지 섹션 */
+export const IntroImageSection = styled.div`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+`;
+
+/** 인트로 일러스트 이미지 */
+export const IntroIllustration = styled.img`
+  width: 100%;
+  max-width: 500px;
+  height: auto;
+`;
+
+/** 인트로 설명 텍스트 */
+export const IntroDescription = styled.p`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  color: ${({ theme }) => theme.colors.text.primary};
+  line-height: 1.5;
+  word-break: keep-all;
+`;
+
+// ============================================
+// 기타 유틸리티
+// ============================================
+
+/** 섹션 래퍼 */
+export const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.lg};
+`;
+
+/** 푸터 텍스트 */
+export const FooterText = styled.p`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-top: ${({ theme }) => theme.spacing.xl};
+`;
+
+// ============================================
+// 옵션 선택 카드 (라디오/체크박스 스타일)
+// ============================================
+
+/** 옵션 리스트 컨테이너 */
+export const OptionList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+  width: 100%;
+`;
+
+/** 옵션 카드 기본 스타일 */
+export const OptionCard = styled.div<{ $selected?: boolean }>`
+  display: flex;
+  align-items: flex-start;
+  gap: ${({ theme }) => theme.spacing.lg};
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.xl};
+  border: ${({ theme, $selected }) =>
+    $selected
+      ? `2px solid ${theme.colors.text.primary}`
+      : `1px solid ${theme.colors.border.primary}`};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  background-color: ${({ theme, $selected }) => 
+    $selected ? theme.colors.background.hover : theme.colors.common.white};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.colors.text.primary};
+  }
+`;
+
+/** 옵션 카드 내용 래퍼 */
+export const OptionContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+  flex: 1;
+`;
+
+/** 옵션 타이틀 */
+export const OptionTitle = styled.span`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+/** 옵션 설명 */
+export const OptionDescription = styled.p`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.5;
+  margin: 0;
+`;
+
+/** 라디오 버튼 */
+export const RadioButton = styled.div<{ $selected?: boolean }>`
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  border-radius: 50%;
+  border: 2px solid ${({ theme, $selected }) => 
+    $selected ? theme.colors.text.primary : theme.colors.border.primary};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 2px;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &::after {
+    content: '';
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: ${({ theme, $selected }) => 
+      $selected ? theme.colors.text.primary : 'transparent'};
+    transition: all ${({ theme }) => theme.transition.fast};
+  }
+`;
+
+/** 숨겨진 라디오/체크박스 인풋 */
+export const HiddenInput = styled.input`
+  display: none;
+`;
+
+/** 아이콘 래퍼 */
+export const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+// ============================================
+// 텍스트 입력 (TextArea, CharCount)
+// ============================================
+
+/** 텍스트 영역 기본 스타일 */
+export const TextAreaBase = styled.textarea`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-family: inherit;
+  resize: none;
+  transition: all ${({ theme }) => theme.transition.fast};
+
+  &:focus {
+    outline: none;
+    border-width: 2px;
+    padding: calc(${({ theme }) => theme.spacing.lg} - 1px);
+  }
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.tertiary};
+  }
+`;
+
+/** 글자 수 카운터 */
+export const CharCount = styled.span`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  align-self: flex-start;
+`;
+

--- a/src/pages/landing/LandingPage.tsx
+++ b/src/pages/landing/LandingPage.tsx
@@ -91,7 +91,7 @@ const FaqItemWithState = ({ q, a }: { q: string; a: string }) => {
   );
 };
 
-const LandingPage: React.FC = () => {
+const LandingPage = () => {
   const navigate = useNavigate();
 
   const handleSearch = (e: React.FormEvent) => {

--- a/src/pages/main/AccommodationSection.tsx
+++ b/src/pages/main/AccommodationSection.tsx
@@ -70,20 +70,6 @@ const AccommodationSection: React.FC<AccommodationSectionProps> = ({
         <SectionTitle>{title}</SectionTitle>
       </SectionHeader>
       <CardListWrapper>
-        <CardList ref={listRef}>
-          {accommodations.map((accommodation) => (
-            <AccommodationCard
-              key={accommodation.id}
-              image={accommodation.image}
-              badge={accommodation.badge}
-              title={accommodation.title}
-              date={accommodation.date}
-              price={accommodation.price}
-              nights={accommodation.nights}
-              rating={accommodation.rating}
-            />
-          ))}
-        </CardList>
         <ScrollButtonGroup>
           <ScrollButton
             $position="left"
@@ -102,6 +88,20 @@ const AccommodationSection: React.FC<AccommodationSectionProps> = ({
             <ChevronRight size={16} />
           </ScrollButton>
         </ScrollButtonGroup>
+        <CardList ref={listRef}>
+          {accommodations.map((accommodation) => (
+            <AccommodationCard
+              key={accommodation.id}
+              image={accommodation.image}
+              badge={accommodation.badge}
+              title={accommodation.title}
+              date={accommodation.date}
+              price={accommodation.price}
+              nights={accommodation.nights}
+              rating={accommodation.rating}
+            />
+          ))}
+        </CardList>
       </CardListWrapper>
     </Section>
   );

--- a/src/pages/main/AccommodationSection.tsx
+++ b/src/pages/main/AccommodationSection.tsx
@@ -17,10 +17,10 @@ interface AccommodationSectionProps {
   accommodations: Accommodation[];
 }
 
-const AccommodationSection: React.FC<AccommodationSectionProps> = ({
+const AccommodationSection = ({
   title,
   accommodations,
-}) => {
+}: AccommodationSectionProps) => {
   const listRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(true);

--- a/src/pages/main/MainPage.styles.ts
+++ b/src/pages/main/MainPage.styles.ts
@@ -1,60 +1,36 @@
-import styled from 'styled-components';
-import { media } from '@/styles/media';
+import styled from "styled-components";
+import { media } from "@/styles/media";
 
 export const MainContainer = styled.div`
-  padding-top: ${({ theme }) => theme.spacing['6xl']};
+  padding-top: ${({ theme }) => theme.spacing["6xl"]};
   background: ${({ theme }) => theme.colors.common.white};
 
   ${media.mobile} {
-    padding-top: ${({ theme }) => theme.spacing['5xl']};
+    padding-top: ${({ theme }) => theme.spacing["5xl"]};
   }
 `;
 
-export const SearchBarWrapper = styled.div<{ $isScrolled?: boolean }>`
+export const SearchBarWrapper = styled.div`
   display: flex;
   justify-content: center;
-  padding: ${({ $isScrolled, theme }) =>
-    $isScrolled
-      ? theme.spacing.sm
-      : `${theme.spacing.xl} ${theme.spacing['3xl']}`};
-  background: ${({ $isScrolled, theme }) =>
-    $isScrolled ? 'transparent' : theme.colors.common.white};
-  position: ${({ $isScrolled }) => ($isScrolled ? 'fixed' : 'static')};
-  top: ${({ $isScrolled }) => ($isScrolled ? '0' : 'auto')};
-  left: ${({ $isScrolled }) => ($isScrolled ? '50%' : 'auto')};
-  transform: ${({ $isScrolled }) =>
-    $isScrolled ? 'translateX(-50%)' : 'none'};
-  z-index: ${({ $isScrolled, theme }) =>
-    $isScrolled ? theme.zIndex.header + 1 : 'auto'};
-  width: ${({ $isScrolled }) => ($isScrolled ? 'auto' : '100%')};
-  transition: ${({ theme }) => theme.transition.all.slow};
-  height: ${({ $isScrolled, theme }) =>
-    $isScrolled ? theme.spacing['5xl'] : 'auto'};
+  padding: ${({ theme }) => `${theme.spacing.xl} ${theme.spacing["3xl"]}`};
+  background: ${({ theme }) => theme.colors.common.white};
+  width: 100%;
   align-items: center;
-  pointer-events: ${({ $isScrolled }) => ($isScrolled ? 'none' : 'auto')};
-
-  > * {
-    pointer-events: auto;
-  }
 
   ${media.mobile} {
-    padding: ${({ $isScrolled, theme }) =>
-      $isScrolled
-        ? `${theme.spacing.xs} ${theme.spacing.lg}`
-        : theme.spacing.lg};
-    top: ${({ $isScrolled, theme }) =>
-      $isScrolled ? `${theme.spacing['3xl']}` : 'auto'};
+    padding: ${({ theme }) => theme.spacing.lg};
   }
 `;
 
 export const Section = styled.section`
   max-width: ${({ theme }) => theme.layout.maxWidth};
-  margin: 0 auto ${({ theme }) => theme.spacing['5xl']};
-  padding: 0 ${({ theme }) => theme.spacing['3xl']};
+  margin: 0 auto ${({ theme }) => theme.spacing["5xl"]};
+  padding: 0 ${({ theme }) => theme.spacing["3xl"]};
 
   ${media.mobile} {
     padding: 0 ${({ theme }) => theme.spacing.lg};
-    margin-bottom: ${({ theme }) => theme.spacing['4xl']};
+    margin-bottom: ${({ theme }) => theme.spacing["4xl"]};
   }
 `;
 
@@ -80,8 +56,8 @@ export const CardListWrapper = styled.div`
   position: relative;
 `;
 
-export const CARD_WIDTH = '300px';
-const CARD_WIDTH_MOBILE = '260px';
+export const CARD_WIDTH = "300px";
+const CARD_WIDTH_MOBILE = "260px";
 
 export const CardList = styled.div`
   display: flex;
@@ -115,7 +91,7 @@ export const CardList = styled.div`
 export const ScrollButtonGroup = styled.div`
   position: absolute;
   right: ${({ theme }) => theme.spacing.md};
-  top: -${({ theme }) => theme.spacing['2xl']};
+  top: -${({ theme }) => theme.spacing["2xl"]};
   display: flex;
   gap: ${({ theme }) => theme.spacing.xs};
   z-index: ${({ theme }) => theme.zIndex.fixed};
@@ -126,23 +102,23 @@ export const ScrollButtonGroup = styled.div`
 `;
 
 export const ScrollButton = styled.button<{
-  $position: 'left' | 'right';
+  $position: "left" | "right";
   $disabled?: boolean;
 }>`
   position: absolute;
   ${({ $position, theme }) =>
-    $position === 'left'
+    $position === "left"
       ? `left: -${theme.spacing.xl}`
       : `right: -${theme.spacing.xl}`};
   top: 50%;
   transform: translateY(-50%);
-  width: ${({ theme }) => theme.spacing['3xl']};
-  height: ${({ theme }) => theme.spacing['3xl']};
+  width: ${({ theme }) => theme.spacing["3xl"]};
+  height: ${({ theme }) => theme.spacing["3xl"]};
   border-radius: ${({ theme }) => theme.radius.full};
   border: 1px solid ${({ theme }) => theme.colors.border.primary};
   background: ${({ theme }) => theme.colors.common.white};
   box-shadow: ${({ theme }) => theme.shadow.md};
-  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -173,13 +149,13 @@ export const Footer = styled.footer`
   color: ${({ theme }) => theme.colors.text.primary};
   opacity: 0.7;
   font-size: ${({ theme }) => theme.font.size.xs};
-  padding: ${({ theme }) => theme.spacing['3xl']} 0;
-  margin-top: ${({ theme }) => theme.spacing['6xl']};
+  padding: ${({ theme }) => theme.spacing["3xl"]} 0;
+  margin-top: ${({ theme }) => theme.spacing["6xl"]};
   background: ${({ theme }) => theme.colors.common.white};
 
   ${media.mobile} {
     padding: ${({ theme }) => theme.spacing.xl} 0;
-    margin-top: ${({ theme }) => theme.spacing['4xl']};
+    margin-top: ${({ theme }) => theme.spacing["4xl"]};
     font-size: ${({ theme }) => theme.font.size.xs};
   }
 `;

--- a/src/pages/main/MainPage.styles.ts
+++ b/src/pages/main/MainPage.styles.ts
@@ -3,7 +3,7 @@ import { media } from "@/styles/media";
 
 export const MainContainer = styled.div`
   padding-top: ${({ theme }) => theme.spacing["6xl"]};
-  background: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.background.default};
 
   ${media.mobile} {
     padding-top: ${({ theme }) => theme.spacing["5xl"]};
@@ -14,7 +14,7 @@ export const SearchBarWrapper = styled.div`
   display: flex;
   justify-content: center;
   padding: ${({ theme }) => `${theme.spacing.xl} ${theme.spacing["3xl"]}`};
-  background: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.background.default};
   width: 100%;
   align-items: center;
 
@@ -90,11 +90,12 @@ export const CardList = styled.div`
 
 export const ScrollButtonGroup = styled.div`
   position: absolute;
-  right: ${({ theme }) => theme.spacing.md};
-  top: -${({ theme }) => theme.spacing["2xl"]};
+  top: -${({ theme }) => theme.spacing["4xl"]};
+  right: 0;
   display: flex;
-  gap: ${({ theme }) => theme.spacing.xs};
-  z-index: ${({ theme }) => theme.zIndex.fixed};
+  gap: ${({ theme }) => theme.spacing.sm};
+  align-items: center;
+  z-index: 10;
 
   ${media.mobile} {
     display: none;
@@ -105,19 +106,12 @@ export const ScrollButton = styled.button<{
   $position: "left" | "right";
   $disabled?: boolean;
 }>`
-  position: absolute;
-  ${({ $position, theme }) =>
-    $position === "left"
-      ? `left: -${theme.spacing.xl}`
-      : `right: -${theme.spacing.xl}`};
-  top: 50%;
-  transform: translateY(-50%);
   width: ${({ theme }) => theme.spacing["3xl"]};
   height: ${({ theme }) => theme.spacing["3xl"]};
   border-radius: ${({ theme }) => theme.radius.full};
   border: 1px solid ${({ theme }) => theme.colors.border.primary};
   background: ${({ theme }) => theme.colors.common.white};
-  box-shadow: ${({ theme }) => theme.shadow.md};
+  box-shadow: ${({ theme }) => theme.shadow.sm};
   cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
   display: flex;
   align-items: center;
@@ -125,11 +119,11 @@ export const ScrollButton = styled.button<{
   transition: ${({ theme }) => theme.transition.all.normal};
   color: ${({ theme, $disabled }) =>
     $disabled ? theme.colors.text.secondary : theme.colors.text.primary};
-  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
+  opacity: ${({ $disabled }) => ($disabled ? 0.4 : 1)};
 
   &:hover:not(:disabled) {
-    box-shadow: ${({ theme }) => theme.shadow.lg};
-    transform: scale(1.1);
+    box-shadow: ${({ theme }) => theme.shadow.md};
+    transform: scale(1.05);
     border-color: ${({ theme }) => theme.colors.primary.main};
     color: ${({ theme }) => theme.colors.primary.main};
   }
@@ -151,7 +145,7 @@ export const Footer = styled.footer`
   font-size: ${({ theme }) => theme.font.size.xs};
   padding: ${({ theme }) => theme.spacing["3xl"]} 0;
   margin-top: ${({ theme }) => theme.spacing["6xl"]};
-  background: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.background.default};
 
   ${media.mobile} {
     padding: ${({ theme }) => theme.spacing.xl} 0;

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -11,7 +11,7 @@ import {
 import { MainContainer, SearchBarWrapper, Footer } from "./MainPage.styles";
 import { sumSpacingValues } from "@/utils/spacing";
 
-const MainPage: React.FC = () => {
+const MainPage = () => {
   const theme = useTheme();
   const [isScrolled, setIsScrolled] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -35,8 +35,8 @@ const MainPage: React.FC = () => {
 
   return (
     <MainContainer ref={containerRef}>
-      <SearchBarWrapper $isScrolled={isScrolled}>
-        <SearchBar isCompact={isScrolled} />
+      <SearchBarWrapper>
+        <SearchBar />
       </SearchBarWrapper>
 
       <AccommodationSection

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,6 +4,8 @@ import LandingPage from "../pages/landing/LandingPage";
 import MainPage from "../pages/main/MainPage";
 import AccommodationDetailPage from "../pages/accommodation/AccommodationDetailPage.tsx";
 import SearchPage from "../pages/search/SearchPage";
+import HostingPage from "../pages/hosting/HostingPage";
+import BecomeHostPage from "../pages/hosting/BecomeHostPage";
 
 export const router = createBrowserRouter([
   {
@@ -15,6 +17,14 @@ export const router = createBrowserRouter([
       { path: "accommodation/:id", element: <AccommodationDetailPage /> },
       { path: "search", element: <SearchPage /> },
     ],
+  },
+  {
+    path: "/hosting",
+    element: <HostingPage />,
+  },
+  {
+    path: "/hosting/become-a-host",
+    element: <BecomeHostPage />,
   },
 ]);
 

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -12,6 +12,7 @@ declare module "styled-components" {
       text: {
         primary: string;
         secondary: string;
+        tertiary: string;
       };
       border: {
         primary: string;
@@ -28,6 +29,11 @@ declare module "styled-components" {
       };
       overlay: {
         default: string;
+      };
+      status: {
+        error: string;
+        warning: string;
+        success: string;
       };
     };
     radius: {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -20,6 +20,7 @@ export const theme = {
     text: {
       primary: "#222",
       secondary: "#7b7b7bff",
+      tertiary: "#b0b0b0",
     },
     // Border(경계선) 계열
     border: {
@@ -42,12 +43,12 @@ export const theme = {
     overlay: {
       default: "rgba(0, 0, 0, 0.5)",
     },
-    // 상태별 색상 (추후 필요시 확장)
-    // status: {
-    //   error: "#d32f2f",
-    //   warning: "#ffa000",
-    //   success: "#388e3c",
-    // }
+    // 상태별 색상
+    status: {
+      error: "#d32f2f",
+      warning: "#ffa000",
+      success: "#388e3c",
+    },
   },
   radius,
   shadow,

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -1,0 +1,76 @@
+// 숙소 리스팅 타입 정의
+export interface Listing {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  spaceType: string;
+  location: {
+    country: string;
+    province: string;
+    city: string;
+    district: string;
+    streetAddress: string;
+    detailAddress: string;
+    postalCode: string;
+  };
+  guests: number;
+  bedrooms: number;
+  beds: number;
+  bathrooms: number;
+  amenities: string[];
+  photos: string[];
+  pricing: {
+    basePrice: number;
+    weekendPremium: number;
+  };
+  discounts: {
+    newListing: boolean;
+    weekly: boolean;
+    monthly: boolean;
+  };
+  bookingSettings: 'review' | 'instant';
+  guestRequirements: 'experienced' | 'anyone';
+  safetyInfo: Record<string, { checked: boolean; description: string }>;
+  isBusiness: boolean;
+  createdAt: string;
+  status: 'draft' | 'published';
+}
+
+// 기본 숙소 데이터 (빈 상태)
+export const defaultListing: Omit<Listing, 'id' | 'createdAt'> = {
+  title: '',
+  description: '',
+  category: '',
+  spaceType: '',
+  location: {
+    country: '한국',
+    province: '',
+    city: '',
+    district: '',
+    streetAddress: '',
+    detailAddress: '',
+    postalCode: '',
+  },
+  guests: 1,
+  bedrooms: 1,
+  beds: 1,
+  bathrooms: 1,
+  amenities: [],
+  photos: [],
+  pricing: {
+    basePrice: 50000,
+    weekendPremium: 0,
+  },
+  discounts: {
+    newListing: false,
+    weekly: false,
+    monthly: false,
+  },
+  bookingSettings: 'review',
+  guestRequirements: 'experienced',
+  safetyInfo: {},
+  isBusiness: false,
+  status: 'draft',
+};
+

--- a/src/utils/listingStorage.ts
+++ b/src/utils/listingStorage.ts
@@ -1,4 +1,4 @@
-import { Listing } from '@/types/listing';
+import type { Listing } from '@/types/listing';
 
 const LISTINGS_KEY = 'cozy_listings';
 const DRAFT_KEY = 'cozy_listing_draft';

--- a/src/utils/listingStorage.ts
+++ b/src/utils/listingStorage.ts
@@ -1,0 +1,61 @@
+import { Listing } from '@/types/listing';
+
+const LISTINGS_KEY = 'cozy_listings';
+const DRAFT_KEY = 'cozy_listing_draft';
+
+// 모든 리스팅 가져오기
+export const getListings = (): Listing[] => {
+  try {
+    const data = localStorage.getItem(LISTINGS_KEY);
+    return data ? JSON.parse(data) : [];
+  } catch {
+    return [];
+  }
+};
+
+// 리스팅 저장하기
+export const saveListing = (listing: Listing): void => {
+  const listings = getListings();
+  const existingIndex = listings.findIndex((l) => l.id === listing.id);
+  
+  if (existingIndex >= 0) {
+    listings[existingIndex] = listing;
+  } else {
+    listings.push(listing);
+  }
+  
+  localStorage.setItem(LISTINGS_KEY, JSON.stringify(listings));
+};
+
+// 리스팅 삭제하기
+export const deleteListing = (id: string): void => {
+  const listings = getListings();
+  const filtered = listings.filter((l) => l.id !== id);
+  localStorage.setItem(LISTINGS_KEY, JSON.stringify(filtered));
+};
+
+// 임시 저장 (드래프트)
+export const saveDraft = (data: Partial<Listing>): void => {
+  localStorage.setItem(DRAFT_KEY, JSON.stringify(data));
+};
+
+// 드래프트 가져오기
+export const getDraft = (): Partial<Listing> | null => {
+  try {
+    const data = localStorage.getItem(DRAFT_KEY);
+    return data ? JSON.parse(data) : null;
+  } catch {
+    return null;
+  }
+};
+
+// 드래프트 삭제
+export const clearDraft = (): void => {
+  localStorage.removeItem(DRAFT_KEY);
+};
+
+// 고유 ID 생성
+export const generateId = (): string => {
+  return `listing_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+};
+

--- a/src/utils/listingStorage.ts
+++ b/src/utils/listingStorage.ts
@@ -56,6 +56,6 @@ export const clearDraft = (): void => {
 
 // 고유 ID 생성
 export const generateId = (): string => {
-  return `listing_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  return crypto.randomUUID();
 };
 


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #13 
- `feature/hosting-page → dev`

## 📝 작업 내용
- 호스팅 3단계 입력 부분 UI 구현
- `React.FC` 타입 제거
    - 현재 구현된 모든 코드 리팩토링 
    - **React 18에서 children 자동 포함 제거됨**
    - `React.FC`가 더 이상 이점이 없음
    - (변경 방식) 타입 추론이 더 유연해짐 

**[실행 화면]**
- 호스팅 페이지가 너무 많아서 처음 화면만 첨부함
- 메인화면에서 호스트로 등록하기 버튼 or `/hosting` 페이지로 접속시 확인 가능
<img width="1702" height="1024" alt="스크린샷 2026-01-07 오후 10 23 04" src="https://github.com/user-attachments/assets/6366e428-aa32-41c3-b282-17ffe876c460" />

## 💬 리뷰 요구사항(선택 사항)
- 에어비앤비와 동일하게 모든 질문사항 넣어두긴 했으나 API 설계 고려하여 항목 수정 가능성 있음
- 지도 개발해야 하는 부분이 있는데 Google Map의 경우 국내 숙소를 잘 인지하지 못하는 경우가 있어서 Tmap 이나 다른 후보군 생각해보기
- 실행 시 의존성 문제 발생할 경우 >> `npm install`  
