### PR TITLE
Feat: 리뷰 페이지 구현

### DIFF
--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -3,9 +3,8 @@ import type {
   AccommodationDetailDTO,
   HostelReviewDTO,
   ReviewListResponse,
-  ApiResponse,
 } from "./types";
-import { fetchComment } from "./comment";
+
 
 // 숙소 상세 조회
 export async function fetchAccommodationDetail(

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -55,28 +55,35 @@ export async function fetchAccommodationReviews(
   }
 
   const count = reviewsToUse.length;
-  const average =
-    count > 0
-      ? reviewsToUse.reduce((acc, r) => acc + Number(r.ratingOverall), 0) / count
-      : 0;
+  // 단일 reduce로 모든 항목의 합계 계산
+  const sums = reviewsToUse.reduce(
+    (acc, r) => ({
+      overall: acc.overall + Number(r.ratingOverall || 0),
+      cleanliness: acc.cleanliness + Number(r.ratingCleanliness || 0),
+      accuracy: acc.accuracy + Number(r.ratingAccuracy || 0),
+      communication: acc.communication + Number(r.ratingCommunication || 0),
+      location: acc.location + Number(r.ratingLocation || 0),
+      checkIn: acc.checkIn + Number(r.ratingCheckin || 0),
+    }),
+    {
+      overall: 0,
+      cleanliness: 0,
+      accuracy: 0,
+      communication: 0,
+      location: 0,
+      checkIn: 0,
+    }
+  );
+
+  const average = count > 0 ? sums.overall / count : 0;
 
   // 항목별 평균 계산
   const breakdown = {
-    cleanliness:
-      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCleanliness || 0), 0) /
-      count || 0,
-    accuracy:
-      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingAccuracy || 0), 0) /
-      count || 0,
-    communication:
-      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCommunication || 0), 0) /
-      count || 0,
-    location:
-      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingLocation || 0), 0) /
-      count || 0,
-    checkIn:
-      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCheckin || 0), 0) /
-      count || 0,
+    cleanliness: count > 0 ? sums.cleanliness / count : 0,
+    accuracy: count > 0 ? sums.accuracy / count : 0,
+    communication: count > 0 ? sums.communication / count : 0,
+    location: count > 0 ? sums.location / count : 0,
+    checkIn: count > 0 ? sums.checkIn / count : 0,
     value: average,
   };
 

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -3,13 +3,15 @@ import type {
   AccommodationDetailDTO,
   HostelReviewDTO,
   ReviewListResponse,
+  ApiResponse,
 } from "./types";
+import { fetchComment } from "./comment";
 
 // 숙소 상세 조회
 export async function fetchAccommodationDetail(
   id: string
 ): Promise<AccommodationDetailDTO> {
-  // 실제 연동 (추측 베이스 URL이 다르거나 엔드포인트가 다를 수 있음)
+  // 실제 연동
   const data = await client.get<any, AccommodationDetailDTO>(
     `/api/accommodations/${id}`
   );
@@ -18,27 +20,34 @@ export async function fetchAccommodationDetail(
 
 // 숙소 리뷰 조회
 export async function fetchAccommodationReviews(
-  id: string
+  accId: string
 ): Promise<ReviewListResponse> {
+  // client.ts의 인터셉터가 response.data를 반환하므로, payload 자체가 배열임
   const reviews = await client.get<any, HostelReviewDTO[]>(
-    `/api/review/hostel/${id}`
+    `/api/review/hostel/${accId}`
   );
 
-  // 백엔드 데이터를 UI 타입으로 매핑
+  if (!Array.isArray(reviews)) {
+    console.error("Expected array but got:", reviews);
+    return { summary: { average: 0, count: 0 }, reviews: [] };
+  }
+
   const count = reviews.length;
+  // ratingOverall은 BigDecimal로 넘어오므로 숫자 취급 (JS/TS에서는 자동으로 숫자 혹은 문자열)
+  // 안전하게 Number() 변환 권장
   const average =
     count > 0
-      ? reviews.reduce((acc, r) => acc + r.ratingOverall, 0) / count
+      ? reviews.reduce((acc, r) => acc + Number(r.ratingOverall), 0) / count
       : 0;
 
   // 항목별 평균 계산
   const breakdown = {
-    cleanliness: reviews.reduce((acc, r) => acc + r.ratingCleanliness, 0) / count || 0,
-    accuracy: reviews.reduce((acc, r) => acc + r.ratingAccuracy, 0) / count || 0,
-    communication: reviews.reduce((acc, r) => acc + r.ratingCommunication, 0) / count || 0,
-    location: reviews.reduce((acc, r) => acc + r.ratingLocation, 0) / count || 0,
-    checkIn: reviews.reduce((acc, r) => acc + r.ratingCheckin, 0) / count || 0,
-    value: average, // 백엔드에 value(가성비) 항목이 없어서 전체 평점으로 대체
+    cleanliness: reviews.reduce((acc, r) => acc + Number(r.ratingCleanliness || 0), 0) / count || 0,
+    accuracy: reviews.reduce((acc, r) => acc + Number(r.ratingAccuracy || 0), 0) / count || 0,
+    communication: reviews.reduce((acc, r) => acc + Number(r.ratingCommunication || 0), 0) / count || 0,
+    location: reviews.reduce((acc, r) => acc + Number(r.ratingLocation || 0), 0) / count || 0,
+    checkIn: reviews.reduce((acc, r) => acc + Number(r.ratingCheckin || 0), 0) / count || 0,
+    value: average,
   };
 
   return {
@@ -46,14 +55,15 @@ export async function fetchAccommodationReviews(
     breakdown,
     reviews: reviews.map((r) => ({
       reviewId: r.id,
-      author: r.author || {
-        userId: 0,
+      author: {
+        userId: 0, // 백엔드 DTO에 사용자 정보가 아직 없음
         nickName: "알 수 없는 사용자",
         profileImageUrl: null,
       },
-      rating: r.ratingOverall,
+      rating: Number(r.ratingOverall),
       content: r.reviewComment,
-      createdAt: "2024-01-01", // 백엔드 응답에 날짜가 없어서 임시 처리
+      createdAt: "2024-01-01",
+      reply: r.comment,
     })),
   };
 }

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -1,4 +1,4 @@
-import type { AccommodationDetailDTO } from "./types";
+import type { AccommodationDetailDTO, ReviewListResponse } from "./types";
 
 // 숙소 상세 조회 (현재 : 목업)
 export async function fetchAccommodationDetail(
@@ -73,7 +73,43 @@ export async function fetchAccommodationDetail(
     host: {
       userId: 101,
       nickName: "Jisu",
-      profileImageUrl: null,
+      profileImageUrl: "https://i.pravatar.cc/300?img=5",
     },
+  };
+}
+
+// 숙소 리뷰 조회 (Mock)
+export async function fetchAccommodationReviews(
+  id: string
+): Promise<ReviewListResponse> {
+  await new Promise((r) => setTimeout(r, 400));
+  return {
+    summary: {
+      average: 4.87,
+      count: 126,
+    },
+    breakdown: {
+      cleanliness: 4.9,
+      accuracy: 4.8,
+      communication: 4.9,
+      location: 4.5,
+      checkIn: 5.0,
+      value: 4.7,
+    },
+    reviews: Array.from({ length: 10 }).map((_, i) => ({
+      reviewId: i + 100,
+      author: {
+        userId: 2000 + i,
+        nickName: `Traveler ${i + 1}`,
+        profileImageUrl: `https://i.pravatar.cc/150?img=${30 + i}`,
+      },
+      rating: 5,
+      content:
+        i % 2 === 0
+          ? "뷰가 정말 끝내줍니다! 야경 보면서 와인 한잔하기 딱 좋아요."
+          : "침구가 너무 편해서 꿀잠 잤습니다. 청결 상태도 최상이었어요.",
+      createdAt: `2024-02-${10 + (i % 20)}`,
+      accommodationId: Number(id),
+    })),
   };
 }

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -11,7 +11,6 @@ import { fetchComment } from "./comment";
 export async function fetchAccommodationDetail(
   id: string
 ): Promise<AccommodationDetailDTO> {
-  // 실제 연동
   const data = await client.get<any, AccommodationDetailDTO>(
     `/api/accommodations/${id}`
   );
@@ -22,47 +21,78 @@ export async function fetchAccommodationDetail(
 export async function fetchAccommodationReviews(
   accId: string
 ): Promise<ReviewListResponse> {
-  // client.ts의 인터셉터가 response.data를 반환하므로, payload 자체가 배열임
-  const reviews = await client.get<any, HostelReviewDTO[]>(
-    `/api/review/hostel/${accId}`
-  );
+  let reviewsToUse: HostelReviewDTO[] = [];
 
-  if (!Array.isArray(reviews)) {
-    console.error("Expected array but got:", reviews);
-    return { summary: { average: 0, count: 0 }, reviews: [] };
+  // 더미 데이터 정의
+  const MOCK_REVIEWS: HostelReviewDTO[] = Array.from({ length: 3 }).map((_, i) => ({
+    id: 100 + i,
+    bookingId: 200 + i,
+    ratingOverall: 4.5 + (i * 0.1),
+    ratingCleanliness: 5,
+    ratingAccuracy: 4,
+    ratingCheckin: 5,
+    ratingCommunication: 5,
+    ratingLocation: 4,
+    reviewComment: `정말 멋진 숙소였습니다! (테스트 후기 ${i + 1})`,
+    comment: null,
+  }));
+
+  try {
+    // client.ts의 인터셉터가 response.data를 반환하므로, payload 자체가 배열임
+    const reviews = await client.get<any, HostelReviewDTO[]>(
+      `/api/review/hostel/${accId}`
+    );
+
+    if (Array.isArray(reviews)) {
+      reviewsToUse = reviews;
+    } else {
+      console.warn("Expected array but got:", reviews);
+      reviewsToUse = MOCK_REVIEWS; // 데이터 형식이 다르면 더미 사용
+    }
+  } catch (error) {
+    console.error("Failed to fetch reviews (using mock data):", error);
+    reviewsToUse = MOCK_REVIEWS; // 에러(401 등) 발생 시 더미 사용
   }
 
-  const count = reviews.length;
-  // ratingOverall은 BigDecimal로 넘어오므로 숫자 취급 (JS/TS에서는 자동으로 숫자 혹은 문자열)
-  // 안전하게 Number() 변환 권장
+  const count = reviewsToUse.length;
   const average =
     count > 0
-      ? reviews.reduce((acc, r) => acc + Number(r.ratingOverall), 0) / count
+      ? reviewsToUse.reduce((acc, r) => acc + Number(r.ratingOverall), 0) / count
       : 0;
 
   // 항목별 평균 계산
   const breakdown = {
-    cleanliness: reviews.reduce((acc, r) => acc + Number(r.ratingCleanliness || 0), 0) / count || 0,
-    accuracy: reviews.reduce((acc, r) => acc + Number(r.ratingAccuracy || 0), 0) / count || 0,
-    communication: reviews.reduce((acc, r) => acc + Number(r.ratingCommunication || 0), 0) / count || 0,
-    location: reviews.reduce((acc, r) => acc + Number(r.ratingLocation || 0), 0) / count || 0,
-    checkIn: reviews.reduce((acc, r) => acc + Number(r.ratingCheckin || 0), 0) / count || 0,
+    cleanliness:
+      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCleanliness || 0), 0) /
+      count || 0,
+    accuracy:
+      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingAccuracy || 0), 0) /
+      count || 0,
+    communication:
+      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCommunication || 0), 0) /
+      count || 0,
+    location:
+      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingLocation || 0), 0) /
+      count || 0,
+    checkIn:
+      reviewsToUse.reduce((acc, r) => acc + Number(r.ratingCheckin || 0), 0) /
+      count || 0,
     value: average,
   };
 
   return {
     summary: { average, count },
     breakdown,
-    reviews: reviews.map((r) => ({
+    reviews: reviewsToUse.map((r) => ({
       reviewId: r.id,
       author: {
-        userId: 0, // 백엔드 DTO에 사용자 정보가 아직 없음
-        nickName: "알 수 없는 사용자",
-        profileImageUrl: null,
+        userId: 0,
+        nickName: `게스트 ${r.id}`,
+        profileImageUrl: `https://i.pravatar.cc/150?u=${r.id}`,
       },
       rating: Number(r.ratingOverall),
       content: r.reviewComment,
-      createdAt: "2024-01-01",
+      createdAt: "2024-02-02",
       reply: r.comment,
     })),
   };

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -1,115 +1,59 @@
-import type { AccommodationDetailDTO, ReviewListResponse } from "./types";
+import client from "./client";
+import type {
+  AccommodationDetailDTO,
+  HostelReviewDTO,
+  ReviewListResponse,
+} from "./types";
 
-// 숙소 상세 조회 (현재 : 목업)
+// 숙소 상세 조회
 export async function fetchAccommodationDetail(
   id: string
 ): Promise<AccommodationDetailDTO> {
-  // 임시 목업
-  await new Promise((r) => setTimeout(r, 300)); // 로딩 지연 시뮬
-  return {
-    // AccommodationDetailDTO 형태의 객체 반환
-    // 실제 연동 시 :
-    // const { data } = await axios.get(`/accommodations/${id}`);
-    // return data;
-    accommodationId: Number(id),
-    hostId: 101,
-    title: "한강 뷰 모던 스튜디오",
-    description:
-      "한강이 내려다보이는 모던 스튜디오입니다. 2호선 역 5분 거리, 와이파이와 넷플릭스를 제공합니다. 넓은 창과 조용한 분위기로 휴식을 즐기세요.",
-    accommodationType: "entire_place",
-    address: "서울 영등포구 여의대로 50",
-    city: "서울",
-    state: null,
-    country: "대한민국",
-    postalCode: "07200",
-    latitude: 37.525,
-    longitude: 126.925,
-    maxGuests: 4,
-    bedrooms: 1,
-    beds: 2,
-    bathrooms: 1,
-    pricePerNight: 158000,
-    cleaningFee: 20000,
-    serviceFeePercentage: 12,
-    instantBooking: true,
-    checkInTime: "15:00:00",
-    checkOutTime: "11:00:00",
-    images: [
-      {
-        imageId: 1,
-        imageUrl: "https://picsum.photos/seed/accommodation1/1200/800",
-        isPrimary: true,
-        displayOrder: 0,
-      },
-      {
-        imageId: 2,
-        imageUrl: "https://picsum.photos/seed/accommodation2/800/800",
-        isPrimary: false,
-        displayOrder: 1,
-      },
-      {
-        imageId: 3,
-        imageUrl: "https://picsum.photos/seed/accommodation3/800/800",
-        isPrimary: false,
-        displayOrder: 2,
-      },
-      {
-        imageId: 4,
-        imageUrl: "https://picsum.photos/seed/accommodation4/800/800",
-        isPrimary: false,
-        displayOrder: 3,
-      },
-    ],
-    amenities: [
-      { amenityId: 1, name: "무선 인터넷" },
-      { amenityId: 2, name: "에어컨" },
-      { amenityId: 3, name: "주방" },
-      { amenityId: 4, name: "세탁기" },
-    ],
-    reviewSummary: {
-      average: 4.87,
-      count: 126,
-    },
-    host: {
-      userId: 101,
-      nickName: "Jisu",
-      profileImageUrl: "https://i.pravatar.cc/300?img=5",
-    },
-  };
+  // 실제 연동 (추측 베이스 URL이 다르거나 엔드포인트가 다를 수 있음)
+  const data = await client.get<any, AccommodationDetailDTO>(
+    `/api/accommodations/${id}`
+  );
+  return data;
 }
 
-// 숙소 리뷰 조회 (Mock)
+// 숙소 리뷰 조회
 export async function fetchAccommodationReviews(
   id: string
 ): Promise<ReviewListResponse> {
-  await new Promise((r) => setTimeout(r, 400));
+  const reviews = await client.get<any, HostelReviewDTO[]>(
+    `/api/review/hostel/${id}`
+  );
+
+  // 백엔드 데이터를 UI 타입으로 매핑
+  const count = reviews.length;
+  const average =
+    count > 0
+      ? reviews.reduce((acc, r) => acc + r.ratingOverall, 0) / count
+      : 0;
+
+  // 항목별 평균 계산
+  const breakdown = {
+    cleanliness: reviews.reduce((acc, r) => acc + r.ratingCleanliness, 0) / count || 0,
+    accuracy: reviews.reduce((acc, r) => acc + r.ratingAccuracy, 0) / count || 0,
+    communication: reviews.reduce((acc, r) => acc + r.ratingCommunication, 0) / count || 0,
+    location: reviews.reduce((acc, r) => acc + r.ratingLocation, 0) / count || 0,
+    checkIn: reviews.reduce((acc, r) => acc + r.ratingCheckin, 0) / count || 0,
+    value: average, // 백엔드에 value(가성비) 항목이 없어서 전체 평점으로 대체
+  };
+
   return {
-    summary: {
-      average: 4.87,
-      count: 126,
-    },
-    breakdown: {
-      cleanliness: 4.9,
-      accuracy: 4.8,
-      communication: 4.9,
-      location: 4.5,
-      checkIn: 5.0,
-      value: 4.7,
-    },
-    reviews: Array.from({ length: 10 }).map((_, i) => ({
-      reviewId: i + 100,
-      author: {
-        userId: 2000 + i,
-        nickName: `Traveler ${i + 1}`,
-        profileImageUrl: `https://i.pravatar.cc/150?img=${30 + i}`,
+    summary: { average, count },
+    breakdown,
+    reviews: reviews.map((r) => ({
+      reviewId: r.id,
+      author: r.author || {
+        userId: 0,
+        nickName: "알 수 없는 사용자",
+        profileImageUrl: null,
       },
-      rating: 5,
-      content:
-        i % 2 === 0
-          ? "뷰가 정말 끝내줍니다! 야경 보면서 와인 한잔하기 딱 좋아요."
-          : "침구가 너무 편해서 꿀잠 잤습니다. 청결 상태도 최상이었어요.",
-      createdAt: `2024-02-${10 + (i % 20)}`,
-      accommodationId: Number(id),
+      rating: r.ratingOverall,
+      content: r.reviewComment,
+      createdAt: "2024-01-01", // 백엔드 응답에 날짜가 없어서 임시 처리
     })),
   };
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const client = axios.create({
-    baseURL: "http://localhost:8080",
+    baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:8080",
     headers: {
         "Content-Type": "application/json",
     },

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,36 @@
+import axios from "axios";
+
+const client = axios.create({
+    baseURL: "http://localhost:8080",
+    headers: {
+        "Content-Type": "application/json",
+    },
+});
+
+// Request Interceptor: 헤더에 Bearer 토큰 추가
+client.interceptors.request.use(
+    (config) => {
+        const token = localStorage.getItem("accessToken"); // 또는 세션 스토리지 등
+        if (token) {
+            config.headers.Authorization = `Bearer ${token}`;
+        }
+        return config;
+    },
+    (error) => {
+        return Promise.reject(error);
+    }
+);
+
+// Response Interceptor: 에러 처리 및 데이터 가공
+client.interceptors.response.use(
+    (response) => response.data,
+    (error) => {
+        // 401 Unauthorized 처리 등
+        if (error.response?.status === 401) {
+            console.error("인증 에러: 로그인이 필요합니다.");
+        }
+        return Promise.reject(error);
+    }
+);
+
+export default client;

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,15 @@
+import client from "./client";
+import type { ApiResponse, CommentDTO } from "./types";
+
+// 단일 댓글(답글) 조회
+export async function fetchComment(commentId: number): Promise<CommentDTO | null> {
+    try {
+        const { data } = await client.get<any, ApiResponse<CommentDTO>>(
+            `/api/comments/${commentId}`
+        );
+        return data;
+    } catch (error) {
+        console.error(`Failed to fetch comment ${commentId}`, error);
+        return null;
+    }
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -142,12 +142,5 @@ export type ReviewListResponse = {
     average: number;
     count: number;
   };
-  breakdown?: {
-    cleanliness: number;
-    accuracy: number;
-    communication: number;
-    location: number;
-    checkIn: number;
-    value: number;
-  };
+  breakdown?: ReviewRatingBreakdown;
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -53,3 +53,45 @@ export type AccommodationDetailDTO = {
   reviewSummary: ReviewSummaryDTO;
   host: HostDTO;
 };
+
+export type UserProfileDTO = HostDTO & {
+  about?: string | null;
+  joinedDate: string;
+  isVerified: boolean;
+  isSuperhost: boolean;
+  listingsCount: number;
+  reviewCount: number;
+  averageRating: number;
+  location?: string | null;
+  work?: string | null;
+  languages?: string[];
+};
+
+export type ReviewDTO = {
+  reviewId: number;
+  author: {
+    userId: number;
+    nickName: string;
+    profileImageUrl?: string | null;
+  };
+  rating: number; // 1 ~ 5
+  content: string;
+  createdAt: string;
+  accommodationId?: number; // Optional: If review is linked to an accommodation
+  accommodationName?: string; // For reviews on user profile
+};
+
+export type ReviewRatingBreakdown = {
+  cleanliness: number;
+  accuracy: number;
+  communication: number;
+  location: number;
+  checkIn: number;
+  value: number;
+};
+
+export type ReviewListResponse = {
+  reviews: ReviewDTO[];
+  summary: ReviewSummaryDTO;
+  breakdown?: ReviewRatingBreakdown;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -70,6 +70,18 @@ export type PublicUserProfileResponse = {
   reviewCount: number;
 };
 
+export type AccommodationDetailInfoDTO = {
+  summary?: string;
+  space?: string;
+  access?: string;
+  notes?: string;
+  // Assuming these numeric fields are inside detail info based on typical patterns, 
+  // as they are missing from the top-level DTO provided by the user.
+  bedrooms?: number;
+  beds?: number;
+  bathrooms?: number;
+};
+
 export type AccommodationDetailDTO = {
   accommodationId: number;
   hostId: number;
@@ -84,22 +96,20 @@ export type AccommodationDetailDTO = {
   latitude?: number | null;
   longitude?: number | null;
   maxGuests: number;
-  bedrooms: number;
-  beds: number;
-  bathrooms: number;
   pricePerNight: number;
   cleaningFee: number;
   serviceFeePercentage: number;
   instantBooking: boolean;
   checkInTime?: string | null;
   checkOutTime?: string | null;
+
+  detail?: AccommodationDetailInfoDTO | null;
+
   images: AccommodationImageDTO[];
   amenities: AmenityDTO[];
-  reviewSummary: {
-    average: number;
-    count: number;
-  };
-  host: HostDTO;
+
+  // Frontend specific or optional fields if needed for compatibility (e.g. from reviews)
+  // host: HostDTO; // Removing this as backend only sends hostId
 };
 
 export type ReviewRatingBreakdown = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -19,12 +19,52 @@ export type ReviewSummaryDTO = {
   count: number;
 };
 
+export type ApiResponse<T> = {
+  success: boolean;
+  message: string | null;
+  data: T;
+};
+
 export type HostDTO = {
   userId: number;
   nickName: string;
   profileImageUrl?: string | null;
 };
 
+export type HostelReviewDTO = {
+  id: number;
+  bookingId: number;
+  ratingOverall: number;
+  ratingCleanliness: number;
+  ratingAccuracy: number;
+  ratingCheckin: number;
+  ratingCommunication: number;
+  ratingLocation: number;
+  reviewComment: string;
+  // Note: Backend sample doesn't include author info yet, but we'll keep it for UI if added later
+  author?: {
+    userId: number;
+    nickName: string;
+    profileImageUrl?: string | null;
+  };
+};
+
+export type UserReviewDTO = {
+  targetGuestId: number;
+  bookingId: number;
+  rating: number;
+  reviewComment: string;
+};
+
+export type PublicUserProfileResponse = {
+  id: number;
+  nickName: string;
+  profileImageUrl: string | null;
+  grade: string;
+  reviewCount: number;
+};
+
+// Existing types preserved or adapted
 export type AccommodationDetailDTO = {
   accommodationId: number;
   hostId: number;
@@ -50,23 +90,14 @@ export type AccommodationDetailDTO = {
   checkOutTime?: string | null;
   images: AccommodationImageDTO[];
   amenities: AmenityDTO[];
-  reviewSummary: ReviewSummaryDTO;
+  reviewSummary: {
+    average: number;
+    count: number;
+  };
   host: HostDTO;
 };
 
-export type UserProfileDTO = HostDTO & {
-  about?: string | null;
-  joinedDate: string;
-  isVerified: boolean;
-  isSuperhost: boolean;
-  listingsCount: number;
-  reviewCount: number;
-  averageRating: number;
-  location?: string | null;
-  work?: string | null;
-  languages?: string[];
-};
-
+// UI legacy compatibility (will be refactored)
 export type ReviewDTO = {
   reviewId: number;
   author: {
@@ -74,24 +105,24 @@ export type ReviewDTO = {
     nickName: string;
     profileImageUrl?: string | null;
   };
-  rating: number; // 1 ~ 5
+  rating: number;
   content: string;
   createdAt: string;
-  accommodationId?: number; // Optional: If review is linked to an accommodation
-  accommodationName?: string; // For reviews on user profile
-};
-
-export type ReviewRatingBreakdown = {
-  cleanliness: number;
-  accuracy: number;
-  communication: number;
-  location: number;
-  checkIn: number;
-  value: number;
+  accommodationName?: string;
 };
 
 export type ReviewListResponse = {
   reviews: ReviewDTO[];
-  summary: ReviewSummaryDTO;
-  breakdown?: ReviewRatingBreakdown;
+  summary: {
+    average: number;
+    count: number;
+  };
+  breakdown?: {
+    cleanliness: number;
+    accuracy: number;
+    communication: number;
+    location: number;
+    checkIn: number;
+    value: number;
+  };
 };

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -31,6 +31,16 @@ export type HostDTO = {
   profileImageUrl?: string | null;
 };
 
+export type CommentDTO = {
+  commentId: number;
+  content: string;
+  authorId: number;
+  authorNickname: string;
+  authorProfileImage: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type HostelReviewDTO = {
   id: number;
   bookingId: number;
@@ -41,12 +51,7 @@ export type HostelReviewDTO = {
   ratingCommunication: number;
   ratingLocation: number;
   reviewComment: string;
-  // Note: Backend sample doesn't include author info yet, but we'll keep it for UI if added later
-  author?: {
-    userId: number;
-    nickName: string;
-    profileImageUrl?: string | null;
-  };
+  comment?: CommentDTO | null;
 };
 
 export type UserReviewDTO = {
@@ -54,6 +59,7 @@ export type UserReviewDTO = {
   bookingId: number;
   rating: number;
   reviewComment: string;
+  comment?: CommentDTO | null;
 };
 
 export type PublicUserProfileResponse = {
@@ -64,7 +70,6 @@ export type PublicUserProfileResponse = {
   reviewCount: number;
 };
 
-// Existing types preserved or adapted
 export type AccommodationDetailDTO = {
   accommodationId: number;
   hostId: number;
@@ -97,6 +102,15 @@ export type AccommodationDetailDTO = {
   host: HostDTO;
 };
 
+export type ReviewRatingBreakdown = {
+  cleanliness: number;
+  accuracy: number;
+  communication: number;
+  location: number;
+  checkIn: number;
+  value: number;
+};
+
 // UI legacy compatibility (will be refactored)
 export type ReviewDTO = {
   reviewId: number;
@@ -109,6 +123,7 @@ export type ReviewDTO = {
   content: string;
   createdAt: string;
   accommodationName?: string;
+  reply?: CommentDTO | null; // 답글 (댓글)
 };
 
 export type ReviewListResponse = {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,59 +1,45 @@
-import type { ReviewListResponse, UserProfileDTO } from "./types";
+import client from "./client";
+import type {
+    ApiResponse,
+    PublicUserProfileResponse,
+    ReviewListResponse,
+    UserReviewDTO,
+} from "./types";
 
-// 사용자 프로필 조회 (Mock)
-export async function fetchUserProfile(userId: string): Promise<UserProfileDTO> {
-    await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate delay
-
-    return {
-        userId: Number(userId),
-        nickName: "Jisu",
-        profileImageUrl: "https://i.pravatar.cc/300?img=5",
-        about:
-            "안녕하세요! 여행과 새로운 만남을 좋아하는 Jisu입니다. 서울에서 그래픽 디자이너로 일하고 있어요. 제가 머무는 공간이 여러분에게 편안한 휴식처가 되길 바랍니다.",
-        joinedDate: "2023-01-15",
-        isVerified: true,
-        isSuperhost: true,
-        listingsCount: 3,
-        reviewCount: 48,
-        averageRating: 4.88,
-        location: "서울, 대한민국",
-        work: "그래픽 디자이너",
-        languages: ["한국어", "English"],
-    };
+// 사용자 공개 프로필 조회
+export async function fetchUserProfile(
+    userId: string
+): Promise<PublicUserProfileResponse> {
+    const { data } = await client.get<any, ApiResponse<PublicUserProfileResponse>>(
+        `/api/users/${userId}/public-profile`
+    );
+    return data;
 }
 
-// 사용자 리뷰 조회 (Mock)
-export async function fetchUserReviews(userId: string): Promise<ReviewListResponse> {
-    await new Promise((resolve) => setTimeout(resolve, 600));
+// 사용자 리뷰 조회 (호스트가 게스트에게 남긴 리뷰)
+export async function fetchUserReviews(
+    userId: string
+): Promise<ReviewListResponse> {
+    const reviews = await client.get<any, UserReviewDTO[]>(
+        `/api/review/users/${userId}`
+    );
+
+    const count = reviews.length;
+    const average =
+        count > 0 ? reviews.reduce((acc, r) => acc + r.rating, 0) / count : 0;
 
     return {
-        summary: {
-            average: 4.88,
-            count: 48,
-        },
-        breakdown: {
-            cleanliness: 4.9,
-            accuracy: 4.8,
-            communication: 5.0,
-            location: 4.7,
-            checkIn: 5.0,
-            value: 4.8,
-        },
-        reviews: Array.from({ length: 8 }).map((_, i) => ({
-            reviewId: i + 1,
+        summary: { average, count },
+        reviews: reviews.map((r) => ({
+            reviewId: r.bookingId, // 백엔드 리뷰 DTO에 별도 ID가 없어 우선 bookingId 사용
             author: {
-                userId: 1000 + i,
-                nickName: `Guest ${i + 1}`,
-                profileImageUrl: `https://i.pravatar.cc/150?img=${10 + i}`,
+                userId: 0,
+                nickName: "시스템",
+                profileImageUrl: null,
             },
-            rating: 5,
-            content:
-                i % 2 === 0
-                    ? "정말 멋진 숙소였습니다! 호스트분도 너무 친절하시고, 위치도 완벽했어요. 다음에도 또 방문하고 싶습니다."
-                    : "사진보다 훨씬 넓고 깨끗했습니다. 인테리어 감각이 뛰어나서 머무는 내내 기분이 좋았어요.",
-            createdAt: `2024-03-${10 + i}`,
-            accommodationId: 200 + i,
-            accommodationName: i % 2 === 0 ? "강남 스튜디오" : "홍대 루프탑 하우스",
+            rating: r.rating,
+            content: r.reviewComment,
+            createdAt: "2024-01-01",
         })),
     };
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -40,6 +40,7 @@ export async function fetchUserReviews(
             rating: r.rating,
             content: r.reviewComment,
             createdAt: "2024-01-01",
+            reply: r.comment,
         })),
     };
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -20,27 +20,35 @@ export async function fetchUserProfile(
 export async function fetchUserReviews(
     userId: string
 ): Promise<ReviewListResponse> {
-    const reviews = await client.get<any, UserReviewDTO[]>(
-        `/api/review/users/${userId}`
-    );
+    try {
+        const reviews = await client.get<any, UserReviewDTO[]>(
+            `/api/review/users/${userId}`
+        );
 
-    const count = reviews.length;
-    const average =
-        count > 0 ? reviews.reduce((acc, r) => acc + r.rating, 0) / count : 0;
+        const count = reviews.length;
+        const average =
+            count > 0 ? reviews.reduce((acc, r) => acc + r.rating, 0) / count : 0;
 
-    return {
-        summary: { average, count },
-        reviews: reviews.map((r) => ({
-            reviewId: r.bookingId, // 백엔드 리뷰 DTO에 별도 ID가 없어 우선 bookingId 사용
-            author: {
-                userId: 0,
-                nickName: "시스템",
-                profileImageUrl: null,
-            },
-            rating: r.rating,
-            content: r.reviewComment,
-            createdAt: "2024-01-01",
-            reply: r.comment,
-        })),
-    };
+        return {
+            summary: { average, count },
+            reviews: reviews.map((r) => ({
+                reviewId: r.bookingId, // 백엔드 리뷰 DTO에 별도 ID가 없어 우선 bookingId 사용
+                author: {
+                    userId: 0,
+                    nickName: "시스템",
+                    profileImageUrl: null,
+                },
+                rating: r.rating,
+                content: r.reviewComment,
+                createdAt: "2024-01-01",
+                reply: r.comment,
+            })),
+        };
+    } catch (error) {
+        console.error("Failed to fetch user reviews:", error);
+        return {
+            summary: { average: 0, count: 0 },
+            reviews: [],
+        };
+    }
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,59 @@
+import type { ReviewListResponse, UserProfileDTO } from "./types";
+
+// 사용자 프로필 조회 (Mock)
+export async function fetchUserProfile(userId: string): Promise<UserProfileDTO> {
+    await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate delay
+
+    return {
+        userId: Number(userId),
+        nickName: "Jisu",
+        profileImageUrl: "https://i.pravatar.cc/300?img=5",
+        about:
+            "안녕하세요! 여행과 새로운 만남을 좋아하는 Jisu입니다. 서울에서 그래픽 디자이너로 일하고 있어요. 제가 머무는 공간이 여러분에게 편안한 휴식처가 되길 바랍니다.",
+        joinedDate: "2023-01-15",
+        isVerified: true,
+        isSuperhost: true,
+        listingsCount: 3,
+        reviewCount: 48,
+        averageRating: 4.88,
+        location: "서울, 대한민국",
+        work: "그래픽 디자이너",
+        languages: ["한국어", "English"],
+    };
+}
+
+// 사용자 리뷰 조회 (Mock)
+export async function fetchUserReviews(userId: string): Promise<ReviewListResponse> {
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    return {
+        summary: {
+            average: 4.88,
+            count: 48,
+        },
+        breakdown: {
+            cleanliness: 4.9,
+            accuracy: 4.8,
+            communication: 5.0,
+            location: 4.7,
+            checkIn: 5.0,
+            value: 4.8,
+        },
+        reviews: Array.from({ length: 8 }).map((_, i) => ({
+            reviewId: i + 1,
+            author: {
+                userId: 1000 + i,
+                nickName: `Guest ${i + 1}`,
+                profileImageUrl: `https://i.pravatar.cc/150?img=${10 + i}`,
+            },
+            rating: 5,
+            content:
+                i % 2 === 0
+                    ? "정말 멋진 숙소였습니다! 호스트분도 너무 친절하시고, 위치도 완벽했어요. 다음에도 또 방문하고 싶습니다."
+                    : "사진보다 훨씬 넓고 깨끗했습니다. 인테리어 감각이 뛰어나서 머무는 내내 기분이 좋았어요.",
+            createdAt: `2024-03-${10 + i}`,
+            accommodationId: 200 + i,
+            accommodationName: i % 2 === 0 ? "강남 스튜디오" : "홍대 루프탑 하우스",
+        })),
+    };
+}

--- a/src/components/reviews/ReviewItem.tsx
+++ b/src/components/reviews/ReviewItem.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import type { ReviewDTO } from "../../api/types";
 import { Star } from "lucide-react";
+import ReviewReply from "./ReviewReply";
 
 interface ReviewItemProps {
   review: ReviewDTO;
@@ -42,6 +43,8 @@ export default function ReviewItem({
       </Rating>
 
       <Content>{review.content}</Content>
+
+      {review.reply && <ReviewReply reply={review.reply} />}
     </Container>
   );
 }

--- a/src/components/reviews/ReviewItem.tsx
+++ b/src/components/reviews/ReviewItem.tsx
@@ -3,46 +3,47 @@ import type { ReviewDTO } from "../../api/types";
 import { Star } from "lucide-react";
 
 interface ReviewItemProps {
-    review: ReviewDTO;
-    showAccommodationName?: boolean; // For user profile page, show which accommodation was reviewed
+  review: ReviewDTO;
+  showAccommodationName?: boolean; // For user profile page, show which accommodation was reviewed
 }
 
 export default function ReviewItem({
-    review,
-    showAccommodationName = false,
+  review,
+  showAccommodationName = false,
 }: ReviewItemProps) {
-    return (
-        <Container>
-            <Header>
-                <Avatar
-                    src={review.author.profileImageUrl || "https://via.placeholder.com/48"}
-                    alt={review.author.nickName}
-                />
-                <Meta>
-                    <Author>{review.author.nickName}</Author>
-                    <SubInfo>
-                        {review.createdAt}
-                        {showAccommodationName && review.accommodationName && (
-                            <> · {review.accommodationName}</>
-                        )}
-                    </SubInfo>
-                </Meta>
-            </Header>
+  const authorName = review.author?.nickName || "익명";
+  const profileImage =
+    review.author?.profileImageUrl || "https://via.placeholder.com/48";
 
-            <Rating>
-                {Array.from({ length: 5 }).map((_, i) => (
-                    <Star
-                        key={i}
-                        size={14}
-                        fill={i < review.rating ? "currentColor" : "none"}
-                        className={i < review.rating ? "active" : "inactive"}
-                    />
-                ))}
-            </Rating>
+  return (
+    <Container>
+      <Header>
+        <Avatar src={profileImage} alt={authorName} />
+        <Meta>
+          <Author>{authorName}</Author>
+          <SubInfo>
+            {review.createdAt}
+            {showAccommodationName && review.accommodationName && (
+              <> · {review.accommodationName}</>
+            )}
+          </SubInfo>
+        </Meta>
+      </Header>
 
-            <Content>{review.content}</Content>
-        </Container>
-    );
+      <Rating>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Star
+            key={i}
+            size={14}
+            fill={i < review.rating ? "currentColor" : "none"}
+            className={i < review.rating ? "active" : "inactive"}
+          />
+        ))}
+      </Rating>
+
+      <Content>{review.content}</Content>
+    </Container>
+  );
 }
 
 const Container = styled.div`

--- a/src/components/reviews/ReviewItem.tsx
+++ b/src/components/reviews/ReviewItem.tsx
@@ -1,0 +1,109 @@
+import styled from "styled-components";
+import type { ReviewDTO } from "../../api/types";
+import { Star } from "lucide-react";
+
+interface ReviewItemProps {
+    review: ReviewDTO;
+    showAccommodationName?: boolean; // For user profile page, show which accommodation was reviewed
+}
+
+export default function ReviewItem({
+    review,
+    showAccommodationName = false,
+}: ReviewItemProps) {
+    return (
+        <Container>
+            <Header>
+                <Avatar
+                    src={review.author.profileImageUrl || "https://via.placeholder.com/48"}
+                    alt={review.author.nickName}
+                />
+                <Meta>
+                    <Author>{review.author.nickName}</Author>
+                    <SubInfo>
+                        {review.createdAt}
+                        {showAccommodationName && review.accommodationName && (
+                            <> · {review.accommodationName}</>
+                        )}
+                    </SubInfo>
+                </Meta>
+            </Header>
+
+            <Rating>
+                {Array.from({ length: 5 }).map((_, i) => (
+                    <Star
+                        key={i}
+                        size={14}
+                        fill={i < review.rating ? "currentColor" : "none"}
+                        className={i < review.rating ? "active" : "inactive"}
+                    />
+                ))}
+            </Rating>
+
+            <Content>{review.content}</Content>
+        </Container>
+    );
+}
+
+const Container = styled.div`
+  padding: ${({ theme }) => theme.spacing.lg} 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+
+  &:last-child {
+    border-bottom: none;
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
+`;
+
+const Avatar = styled.img`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  background-color: ${({ theme }) => theme.colors.background.active};
+`;
+
+const Meta = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Author = styled.div`
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: 2px;
+`;
+
+const SubInfo = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+const Rating = styled.div`
+  display: flex;
+  gap: 2px;
+  margin-bottom: ${({ theme }) => theme.spacing.xxs};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  .active {
+    color: ${({ theme }) => theme.colors.text.primary};
+  }
+
+  .inactive {
+    color: ${({ theme }) => theme.colors.border.primary};
+  }
+`;
+
+const Content = styled.p`
+  margin: 0;
+  line-height: ${({ theme }) => theme.font.lineHeight.relaxed};
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  white-space: pre-wrap;
+`;

--- a/src/components/reviews/ReviewRatingBreakdown.tsx
+++ b/src/components/reviews/ReviewRatingBreakdown.tsx
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+import type { ReviewRatingBreakdown as IReviewRatingBreakdown } from "../../api/types";
+
+interface Props {
+    data: IReviewRatingBreakdown;
+}
+
+export default function ReviewRatingBreakdown({ data }: Props) {
+    const items = [
+        { label: "청결도", value: data.cleanliness },
+        { label: "정확도", value: data.accuracy },
+        { label: "의사소통", value: data.communication },
+        { label: "위치", value: data.location },
+        { label: "체크인", value: data.checkIn },
+        { label: "가격 대비 만족도", value: data.value },
+    ];
+
+    return (
+        <Container>
+            {items.map((item) => (
+                <Item key={item.label}>
+                    <Label>{item.label}</Label>
+                    <BarContainer>
+                        <Bar>
+                            <Fill style={{ width: `${(item.value / 5) * 100}%` }} />
+                        </Bar>
+                        <Value>{item.value.toFixed(1)}</Value>
+                    </BarContainer>
+                </Item>
+            ))}
+        </Container>
+    );
+}
+
+const Container = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 80px;
+  row-gap: ${({ theme }) => theme.spacing.md};
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+    column-gap: 0;
+  }
+`;
+
+const Item = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Label = styled.div`
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+`;
+
+const BarContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  width: 140px;
+`;
+
+const Bar = styled.div`
+  flex: 1;
+  height: 4px;
+  background-color: ${({ theme }) => theme.colors.border.light};
+  border-radius: 2px;
+  overflow: hidden;
+`;
+
+const Fill = styled.div`
+  height: 100%;
+  background-color: ${({ theme }) => theme.colors.text.primary};
+  border-radius: 2px;
+`;
+
+const Value = styled.div`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  width: 24px;
+  text-align: right;
+`;

--- a/src/components/reviews/ReviewReply.tsx
+++ b/src/components/reviews/ReviewReply.tsx
@@ -1,0 +1,88 @@
+import styled from "styled-components";
+import type { CommentDTO } from "../../api/types";
+import { CornerDownRight } from "lucide-react";
+
+interface Props {
+    reply: CommentDTO;
+}
+
+export default function ReviewReply({ reply }: Props) {
+    return (
+        <Container>
+            <IconWrapper>
+                <CornerDownRight size={20} />
+            </IconWrapper>
+            <ContentBox>
+                <Header>
+                    <AuthorInfo>
+                        <Avatar
+                            src={reply.authorProfileImage || "https://via.placeholder.com/40"}
+                            alt={reply.authorNickname}
+                        />
+                        <AuthorName>{reply.authorNickname} 님의 답글</AuthorName>
+                    </AuthorInfo>
+                    <Date>{reply.createdAt.split("T")[0]}</Date>
+                </Header>
+                <Body>{reply.content}</Body>
+            </ContentBox>
+        </Container>
+    );
+}
+
+const Container = styled.div`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.md};
+  margin-top: ${({ theme }) => theme.spacing.md};
+  margin-left: ${({ theme }) => theme.spacing.lg};
+  padding: ${({ theme }) => theme.spacing.md};
+  background-color: #f7f7f7; // Fallback or use correct theme token
+  border-radius: ${({ theme }) => theme.radius.md};
+`;
+
+const IconWrapper = styled.div`
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-top: 4px;
+`;
+
+const ContentBox = styled.div`
+  flex: 1;
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: ${({ theme }) => theme.spacing.xs};
+`;
+
+const AuthorInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const Avatar = styled.img`
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const AuthorName = styled.span`
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const Date = styled.span`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+const Body = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  line-height: ${({ theme }) => theme.font.lineHeight.relaxed};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  white-space: pre-wrap;
+`;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -43,7 +43,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 // API에서 사용자 정보 가져오기
 const fetchUserProfile = async (token: string): Promise<User | null> => {
   const backendBaseUrl =
-    import.meta.env.VITE_BACKEND_BASE_URL || 'http://localhost:8080';
+    import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
   const url = `${backendBaseUrl}/api/users/me`;
 
   try {

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useAccommodationStore } from "../../store/accommodationStore";
 import * as S from "./accommodationDetail.styles";
@@ -7,14 +7,17 @@ import GallerySection from "./components/GallerySection";
 import InfoSection from "./components/InfoSection";
 import BookingCard from "./components/BookingCard";
 import LightboxModal from "./components/LightboxModal";
+import ReviewSection from "./components/ReviewSection";
 import { useLightbox } from "./hooks/useLightbox";
 
-import type { AccommodationImageDTO } from "../../api/types";
+import type { AccommodationImageDTO, ReviewListResponse } from "../../api/types";
+import { fetchAccommodationReviews } from "../../api/accommodation";
 
 type ThumbImage = AccommodationImageDTO & { idx: number };
 
 export default function AccommodationDetailPage() {
   const { id = "1" } = useParams();
+  const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
 
   const {
     detail,
@@ -30,6 +33,7 @@ export default function AccommodationDetailPage() {
 
   useEffect(() => {
     load(id);
+    fetchAccommodationReviews(id).then(setReviews);
   }, [id, load]);
 
   const images: AccommodationImageDTO[] = detail?.images ?? [];
@@ -100,16 +104,21 @@ export default function AccommodationDetailPage() {
       )}
 
       <S.Main>
-        <InfoSection detail={detail} />
+        <S.Left>
+          <InfoSection detail={detail} />
+          {reviews && <ReviewSection reviews={reviews} />}
+        </S.Left>
 
-        <BookingCard
-          detail={detail}
-          checkIn={checkIn}
-          checkOut={checkOut}
-          guests={guests}
-          setDates={(ci, co) => setDates(ci ?? null, co ?? null)}
-          setGuests={setGuests}
-        />
+        <S.Right>
+          <BookingCard
+            detail={detail}
+            checkIn={checkIn}
+            checkOut={checkOut}
+            guests={guests}
+            setDates={(ci, co) => setDates(ci ?? null, co ?? null)}
+            setGuests={setGuests}
+          />
+        </S.Right>
       </S.Main>
 
       <LightboxModal

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -7,6 +7,7 @@ import GallerySection from "./components/GallerySection";
 import InfoSection from "./components/InfoSection";
 import BookingCard from "./components/BookingCard";
 import LightboxModal from "./components/LightboxModal";
+import AllPhotosModal from "./components/AllPhotosModal"; // 모달 추가
 import ReviewSection from "./components/ReviewSection";
 import { useLightbox } from "./hooks/useLightbox";
 
@@ -18,6 +19,9 @@ type ThumbImage = AccommodationImageDTO & { idx: number };
 export default function AccommodationDetailPage() {
   const { id = "1" } = useParams();
   const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
+
+  // 전체 사진 모달 상태
+  const [isAllPhotosOpen, setIsAllPhotosOpen] = useState(false);
 
   const {
     detail,
@@ -31,12 +35,32 @@ export default function AccommodationDetailPage() {
     setGuests,
   } = useAccommodationStore();
 
+  const openAllPhotos = () => setIsAllPhotosOpen(true);
+  const closeAllPhotos = () => setIsAllPhotosOpen(false);
+
   useEffect(() => {
     load(id);
     fetchAccommodationReviews(id).then(setReviews);
   }, [id, load]);
 
-  const images: AccommodationImageDTO[] = detail?.images ?? [];
+  /* 
+    임시: 백엔드 데이터가 없을 경우를 대비한 더미 이미지 데이터
+    실제 데이터가 들어오면 이 부분은 사용되지 않습니다.
+  */
+  const MOCK_IMAGES: AccommodationImageDTO[] = Array.from({ length: 5 }).map(
+    (_, i) => ({
+      imageId: 1000 + i,
+      imageUrl: `https://picsum.photos/seed/cozy${1000 + i}/800/600`,
+      isPrimary: i === 0,
+      displayOrder: i,
+    })
+  );
+
+  const images: AccommodationImageDTO[] =
+    detail?.images && detail.images.length > 0
+      ? detail.images
+      : MOCK_IMAGES;
+
   const totalImages = images.length;
 
   const { primary, primaryIndex, thumbs } = useMemo<{
@@ -78,8 +102,8 @@ export default function AccommodationDetailPage() {
   if (error) return <S.Container>에러 : {error}</S.Container>;
   if (!detail) return <S.Container>데이터 없음</S.Container>;
 
-  const averageRating = detail.reviewSummary?.average ?? 0;
-  const reviewCount = detail.reviewSummary?.count ?? 0;
+  const averageRating = reviews?.summary?.average ?? 0;
+  const reviewCount = reviews?.summary?.count ?? 0;
 
   return (
     <S.Container>
@@ -103,6 +127,7 @@ export default function AccommodationDetailPage() {
           primaryIndex={primaryIndex}
           thumbs={thumbs}
           onOpen={openLightbox}
+          onShowAll={openAllPhotos} // 추가: 핸들러 전달
         />
       )}
 
@@ -132,6 +157,13 @@ export default function AccommodationDetailPage() {
         onClose={closeLightbox}
         onPrev={showPrevImage}
         onNext={showNextImage}
+      />
+
+      {/* 새 기능: 전체 사진 보기 모달 */}
+      <AllPhotosModal
+        isOpen={isAllPhotosOpen}
+        onClose={closeAllPhotos}
+        images={images}
       />
     </S.Container>
   );

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -78,14 +78,17 @@ export default function AccommodationDetailPage() {
   if (error) return <S.Container>에러 : {error}</S.Container>;
   if (!detail) return <S.Container>데이터 없음</S.Container>;
 
+  const averageRating = detail.reviewSummary?.average ?? 0;
+  const reviewCount = detail.reviewSummary?.count ?? 0;
+
   return (
     <S.Container>
       <S.Header>
         <S.Title>{detail.title}</S.Title>
         <S.SubMeta>
-          <span>★ {detail.reviewSummary.average.toFixed(2)}</span>
+          <span>★ {averageRating.toFixed(2)}</span>
           <S.Dot>.</S.Dot>
-          <a href="#reviews">후기 {detail.reviewSummary.count}개</a>
+          <a href="#reviews">후기 {reviewCount}개</a>
           <S.Dot>.</S.Dot>
           <span>
             {detail.city}, {detail.country}

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -40,7 +40,11 @@ export default function AccommodationDetailPage() {
 
   useEffect(() => {
     load(id);
-    fetchAccommodationReviews(id).then(setReviews);
+    fetchAccommodationReviews(id)
+      .then(setReviews)
+      .catch((err) => {
+        console.error("리뷰 로딩 실패:", err);
+      });
   }, [id, load]);
 
   /* 

--- a/src/pages/accommodation/accommodationDetail.styles.ts
+++ b/src/pages/accommodation/accommodationDetail.styles.ts
@@ -4,7 +4,7 @@ import { media } from "@/styles/media";
 export const Container = styled.div`
   max-width: ${({ theme }) => theme.layout.maxWidth};
   margin: 0 auto;
-  padding: ${({ theme }) => theme.spacing.xl} ${({ theme }) => theme.spacing.lg};
+  padding: 100px ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.xl};
   color: ${({ theme }) => theme.colors.text.primary};
 
   ${media.mobile} {
@@ -44,6 +44,7 @@ export const Dot = styled.span`
 `;
 
 export const Gallery = styled.section`
+  position: relative;
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
   grid-template-rows: 220px 220px;
@@ -345,4 +346,115 @@ export const LightboxPrev = styled.button`
 export const LightboxNext = styled.button`
   ${arrowBase}
   right: ${({ theme }) => theme.spacing.md};
+`;
+
+// --- 사진 모두 보기 관련 스타일 ---
+
+export const ShowAllButton = styled.button`
+  position: absolute;
+  bottom: ${({ theme }) => theme.spacing.xl};
+  right: ${({ theme }) => theme.spacing.xl};
+  background: ${({ theme }) => theme.colors.common.white};
+  border: 1px solid ${({ theme }) => theme.colors.text.primary};
+  border-radius: ${({ theme }) => theme.radius.sm};
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.xl};
+  font-size: 16px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.xs};
+  box-shadow: ${({ theme }) => theme.shadow.sm};
+  transition: transform 0.1s ease;
+  z-index: 10;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.active};
+    transform: scale(1.02);
+  }
+
+  ${media.mobile} {
+    bottom: ${({ theme }) => theme.spacing.sm};
+    right: ${({ theme }) => theme.spacing.sm};
+    padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.sm};
+  }
+`;
+
+export const PhotoModalOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.common.white};
+  z-index: ${({ theme }) => theme.zIndex.modalOverlay};
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const PhotoModalHeader = styled.header`
+  position: sticky;
+  top: 0;
+  background: ${({ theme }) => theme.colors.common.white};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+  z-index: ${({ theme }) => theme.zIndex.sticky};
+`;
+
+export const CloseButton = styled.button`
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: ${({ theme }) => theme.spacing.xs};
+  border-radius: ${({ theme }) => theme.radius.full};
+  transition: background 0.2s;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+export const PhotoModalBody = styled.div`
+  max-width: 800px;
+  margin: 0 auto;
+  padding: ${({ theme }) => theme.spacing.xl};
+  width: 100%;
+`;
+
+export const PhotoGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: ${({ theme }) => theme.spacing.md};
+
+  /* 3의 배수(3번째, 6번째...) 이미지는 크게 보여주기 (옵션) */
+  & > div:nth-child(3n) {
+    grid-column: span 2;
+  }
+
+  ${media.mobile} {
+    grid-template-columns: 1fr;
+    
+    & > div:nth-child(3n) {
+      grid-column: span 1;
+    }
+  }
+`;
+
+export const PhotoItem = styled.div`
+  width: 100%;
+  height: auto;
+  
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+    cursor: pointer;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
 `;

--- a/src/pages/accommodation/components/AllPhotosModal.tsx
+++ b/src/pages/accommodation/components/AllPhotosModal.tsx
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import * as S from "../accommodationDetail.styles";
+import type { AccommodationImageDTO } from "../../../api/types";
+import { ChevronLeft } from "lucide-react";
+
+type Props = {
+    isOpen: boolean;
+    onClose: () => void;
+    images: AccommodationImageDTO[];
+};
+
+export default function AllPhotosModal({ isOpen, onClose, images }: Props) {
+    // 모달이 열리면 바디 스크롤 막기
+    useEffect(() => {
+        if (isOpen) {
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = "unset";
+        }
+        return () => {
+            document.body.style.overflow = "unset";
+        };
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    return (
+        <S.PhotoModalOverlay>
+            <S.PhotoModalHeader>
+                <S.CloseButton onClick={onClose}>
+                    <ChevronLeft size={24} />
+                </S.CloseButton>
+            </S.PhotoModalHeader>
+
+            <S.PhotoModalBody>
+                <S.PhotoGrid>
+                    {images.map((img) => (
+                        <S.PhotoItem key={img.imageId}>
+                            <img src={img.imageUrl} alt={`숙소 이미지 ${img.imageId}`} />
+                        </S.PhotoItem>
+                    ))}
+                </S.PhotoGrid>
+            </S.PhotoModalBody>
+        </S.PhotoModalOverlay>
+    );
+}

--- a/src/pages/accommodation/components/GallerySection.tsx
+++ b/src/pages/accommodation/components/GallerySection.tsx
@@ -1,5 +1,6 @@
 import * as S from "../accommodationDetail.styles";
 import type { AccommodationImageDTO } from "../../../api/types";
+import { Grip } from "lucide-react";
 
 type ThumbImage = AccommodationImageDTO & { idx: number };
 
@@ -8,6 +9,7 @@ type Props = {
   primaryIndex: number;
   thumbs: ThumbImage[];
   onOpen: (index: number) => void;
+  onShowAll: () => void;
 };
 
 export default function GallerySection({
@@ -15,6 +17,7 @@ export default function GallerySection({
   primaryIndex,
   thumbs,
   onOpen,
+  onShowAll,
 }: Props) {
   return (
     <S.Gallery>
@@ -35,6 +38,11 @@ export default function GallerySection({
           />
         </S.Thumb>
       ))}
+
+      <S.ShowAllButton onClick={onShowAll}>
+        <Grip size={16} />
+        사진 모두 보기
+      </S.ShowAllButton>
     </S.Gallery>
   );
 }

--- a/src/pages/accommodation/components/InfoSection.tsx
+++ b/src/pages/accommodation/components/InfoSection.tsx
@@ -10,7 +10,7 @@ export default function InfoSection({ detail }: Props) {
     <S.Left>
       {/* 숙소 정보 */}
       <S.Section>
-        <S.H2>호스트 : {detail.host.nickName}</S.H2>
+        <S.H2>호스트 : {detail.host?.nickName || "알 수 없음"}</S.H2>
         <S.Meta>
           최대 {detail.maxGuests}명 · 침실 {detail.bedrooms}개 · 침대{" "}
           {detail.beds}개 · 욕실 {detail.bathrooms}개

--- a/src/pages/accommodation/components/InfoSection.tsx
+++ b/src/pages/accommodation/components/InfoSection.tsx
@@ -10,10 +10,11 @@ export default function InfoSection({ detail }: Props) {
     <S.Left>
       {/* 숙소 정보 */}
       <S.Section>
-        <S.H2>호스트 : {detail.host?.nickName || "알 수 없음"}</S.H2>
+        {/* HostDTO가 제거되어 닉네임을 알 수 없음 */}
+        <S.H2>호스트 : 알 수 없음</S.H2>
         <S.Meta>
-          최대 {detail.maxGuests}명 · 침실 {detail.bedrooms}개 · 침대{" "}
-          {detail.beds}개 · 욕실 {detail.bathrooms}개
+          최대 {detail.maxGuests}명 · 침실 {detail.detail?.bedrooms ?? 0}개 ·
+          침대 {detail.detail?.beds ?? 0}개 · 욕실 {detail.detail?.bathrooms ?? 0}개
         </S.Meta>
         <S.P>{detail.description}</S.P>
       </S.Section>

--- a/src/pages/accommodation/components/ReviewSection.tsx
+++ b/src/pages/accommodation/components/ReviewSection.tsx
@@ -1,0 +1,66 @@
+import styled from "styled-components";
+import type { ReviewListResponse } from "../../../api/types";
+import ReviewRatingBreakdown from "../../../components/reviews/ReviewRatingBreakdown";
+import ReviewItem from "../../../components/reviews/ReviewItem";
+import { media } from "../../../styles/media";
+
+interface Props {
+    reviews: ReviewListResponse;
+}
+
+export default function ReviewSection({ reviews }: Props) {
+    return (
+        <Container id="reviews">
+            <Header>
+                <Title>
+                    ★ {reviews.summary.average.toFixed(2)} · 후기 {reviews.summary.count}개
+                </Title>
+            </Header>
+
+            {reviews.breakdown && (
+                <BreakdownWrapper>
+                    <ReviewRatingBreakdown data={reviews.breakdown} />
+                </BreakdownWrapper>
+            )}
+
+            <ReviewGrid>
+                {reviews.reviews.map((review) => (
+                    <ReviewItem key={review.reviewId} review={review} />
+                ))}
+            </ReviewGrid>
+        </Container>
+    );
+}
+
+const Container = styled.section`
+  padding: ${({ theme }) => theme.spacing.xl} 0;
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+  margin-top: ${({ theme }) => theme.spacing.xl};
+`;
+
+const Header = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+const Title = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0;
+`;
+
+const BreakdownWrapper = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+const ReviewGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 80px;
+  row-gap: ${({ theme }) => theme.spacing.lg};
+
+  ${media.tablet} {
+    grid-template-columns: 1fr;
+    column-gap: 0;
+  }
+`;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -48,7 +48,7 @@ const LoginModal = ({ open, onClose }: LoginModalProps) => {
   );
   const [phone, setPhone] = useState('');
 
-  const backendBaseUrl = import.meta.env.VITE_BACKEND_BASE_URL || 'http://localhost:8080';
+  const backendBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
   const kakaoLoginUrl = `${backendBaseUrl}/oauth2/authorization/kakao`;
 
   const handlePhoneSubmit = (event: React.FormEvent<HTMLFormElement>) => {

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -2,97 +2,91 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import { fetchUserProfile, fetchUserReviews } from "../../api/user";
-import type { ReviewListResponse, UserProfileDTO } from "../../api/types";
+import type { ReviewListResponse, PublicUserProfileResponse } from "../../api/types";
 import UserProfileCard from "./components/UserProfileCard";
 import ReviewRatingBreakdown from "../../components/reviews/ReviewRatingBreakdown";
 import ReviewItem from "../../components/reviews/ReviewItem";
 import { media } from "../../styles/media";
 
 export default function UserPage() {
-    const { id } = useParams<{ id: string }>();
-    const [user, setUser] = useState<UserProfileDTO | null>(null);
-    const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
-    const [loading, setLoading] = useState(true);
+  const { id } = useParams<{ id: string }>();
+  const [user, setUser] = useState<PublicUserProfileResponse | null>(null);
+  const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
+  const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        async function loadData() {
-            if (!id) return;
-            try {
-                setLoading(true);
-                const [userData, reviewData] = await Promise.all([
-                    fetchUserProfile(id),
-                    fetchUserReviews(id),
-                ]);
-                setUser(userData);
-                setReviews(reviewData);
-            } catch (error) {
-                console.error("Failed to fetch user data", error);
-            } finally {
-                setLoading(false);
-            }
-        }
-        loadData();
-    }, [id]);
+  useEffect(() => {
+    async function loadData() {
+      if (!id) return;
+      try {
+        setLoading(true);
+        const [userData, reviewData] = await Promise.all([
+          fetchUserProfile(id),
+          fetchUserReviews(id),
+        ]);
+        setUser(userData);
+        setReviews(reviewData);
+      } catch (error) {
+        console.error("Failed to fetch user data", error);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, [id]);
 
-    if (loading) return <Container>Loading...</Container>;
-    if (!user) return <Container>User not found</Container>;
+  if (loading) return <Container>Loading...</Container>;
+  if (!user) return <Container>User not found</Container>;
 
-    return (
-        <Container>
-            <Layout>
-                <Sidebar>
-                    <UserProfileCard user={user} />
-                </Sidebar>
+  return (
+    <Container>
+      <Layout>
+        <Sidebar>
+          <UserProfileCard user={user} />
+        </Sidebar>
 
-                <Main>
-                    <Section>
-                        <H1>안녕하세요, 저는 {user.nickName}입니다.</H1>
-                        <JoinDate>회원 가입: {user.joinedDate.split("-")[0]}년</JoinDate>
+        <Main>
+          <Section>
+            <H1>안녕하세요, 저는 {user.nickName}입니다.</H1>
+            <JoinDate>CozyStay 회원</JoinDate>
 
-                        {user.about && (
-                            <About>
-                                <SectionTitle>소개</SectionTitle>
-                                <p>{user.about}</p>
-                                <MetaList>
-                                    {user.location && <li>거주지: {user.location}</li>}
-                                    {user.work && <li>직업: {user.work}</li>}
-                                    {user.languages && (
-                                        <li>구사 언어: {user.languages.join(", ")}</li>
-                                    )}
-                                </MetaList>
-                            </About>
-                        )}
-                    </Section>
+            <About>
+              <SectionTitle>소개</SectionTitle>
+              <p>
+                {user.nickName}님의 프로필입니다. 현재 {user.grade} 등급으로
+                활동 중이며, 지금까지 {user.reviewCount}개의 후기를 받았습니다.
+              </p>
+            </About>
+          </Section>
 
-                    {reviews && (
-                        <Section>
-                            <ReviewHeader>
-                                <SectionTitle>
-                                    ★ {reviews.summary.average.toFixed(2)} 후기 {reviews.summary.count}개
-                                </SectionTitle>
-                            </ReviewHeader>
+          {reviews && (
+            <Section>
+              <ReviewHeader>
+                <SectionTitle>
+                  ★ {reviews.summary.average.toFixed(2)} 후기 {reviews.summary.count}개
+                </SectionTitle>
+              </ReviewHeader>
 
-                            {reviews.breakdown && (
-                                <BreakdownWrapper>
-                                    <ReviewRatingBreakdown data={reviews.breakdown} />
-                                </BreakdownWrapper>
-                            )}
+              {reviews.breakdown && (
+                <BreakdownWrapper>
+                  <ReviewRatingBreakdown data={reviews.breakdown} />
+                </BreakdownWrapper>
+              )}
 
-                            <ReviewList>
-                                {reviews.reviews.map((review) => (
-                                    <ReviewItem
-                                        key={review.reviewId}
-                                        review={review}
-                                        showAccommodationName
-                                    />
-                                ))}
-                            </ReviewList>
-                        </Section>
-                    )}
-                </Main>
-            </Layout>
-        </Container>
-    );
+              <ReviewList>
+                {reviews.reviews.map((review) => (
+                  <ReviewItem
+                    key={review.reviewId}
+                    review={review}
+                    showAccommodationName
+                  />
+                ))}
+              </ReviewList>
+            </Section>
+          )}
+        </Main>
+      </Layout>
+    </Container>
+  );
 }
 
 const Container = styled.div`
@@ -161,19 +155,6 @@ const About = styled.div`
   }
 `;
 
-const MetaList = styled.ul`
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.sm};
-  color: ${({ theme }) => theme.colors.text.primary};
-  
-  li {
-    font-size: ${({ theme }) => theme.font.size.md};
-  }
-`;
 
 const ReviewHeader = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.xl};

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import { fetchUserProfile, fetchUserReviews } from "../../api/user";
+import type { ReviewListResponse, UserProfileDTO } from "../../api/types";
+import UserProfileCard from "./components/UserProfileCard";
+import ReviewRatingBreakdown from "../../components/reviews/ReviewRatingBreakdown";
+import ReviewItem from "../../components/reviews/ReviewItem";
+import { media } from "../../styles/media";
+
+export default function UserPage() {
+    const { id } = useParams<{ id: string }>();
+    const [user, setUser] = useState<UserProfileDTO | null>(null);
+    const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        async function loadData() {
+            if (!id) return;
+            try {
+                setLoading(true);
+                const [userData, reviewData] = await Promise.all([
+                    fetchUserProfile(id),
+                    fetchUserReviews(id),
+                ]);
+                setUser(userData);
+                setReviews(reviewData);
+            } catch (error) {
+                console.error("Failed to fetch user data", error);
+            } finally {
+                setLoading(false);
+            }
+        }
+        loadData();
+    }, [id]);
+
+    if (loading) return <Container>Loading...</Container>;
+    if (!user) return <Container>User not found</Container>;
+
+    return (
+        <Container>
+            <Layout>
+                <Sidebar>
+                    <UserProfileCard user={user} />
+                </Sidebar>
+
+                <Main>
+                    <Section>
+                        <H1>안녕하세요, 저는 {user.nickName}입니다.</H1>
+                        <JoinDate>회원 가입: {user.joinedDate.split("-")[0]}년</JoinDate>
+
+                        {user.about && (
+                            <About>
+                                <SectionTitle>소개</SectionTitle>
+                                <p>{user.about}</p>
+                                <MetaList>
+                                    {user.location && <li>거주지: {user.location}</li>}
+                                    {user.work && <li>직업: {user.work}</li>}
+                                    {user.languages && (
+                                        <li>구사 언어: {user.languages.join(", ")}</li>
+                                    )}
+                                </MetaList>
+                            </About>
+                        )}
+                    </Section>
+
+                    {reviews && (
+                        <Section>
+                            <ReviewHeader>
+                                <SectionTitle>
+                                    ★ {reviews.summary.average.toFixed(2)} 후기 {reviews.summary.count}개
+                                </SectionTitle>
+                            </ReviewHeader>
+
+                            {reviews.breakdown && (
+                                <BreakdownWrapper>
+                                    <ReviewRatingBreakdown data={reviews.breakdown} />
+                                </BreakdownWrapper>
+                            )}
+
+                            <ReviewList>
+                                {reviews.reviews.map((review) => (
+                                    <ReviewItem
+                                        key={review.reviewId}
+                                        review={review}
+                                        showAccommodationName
+                                    />
+                                ))}
+                            </ReviewList>
+                        </Section>
+                    )}
+                </Main>
+            </Layout>
+        </Container>
+    );
+}
+
+const Container = styled.div`
+  max-width: ${({ theme }) => theme.layout.maxWidth};
+  margin: 0 auto;
+  padding: ${({ theme }) => theme.spacing.xl} ${({ theme }) => theme.spacing.lg};
+
+  ${media.mobile} {
+    padding: ${({ theme }) => theme.spacing.lg} ${({ theme }) => theme.spacing.md};
+  }
+`;
+
+const Layout = styled.div`
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 80px;
+
+  ${media.tablet} {
+    grid-template-columns: 1fr;
+    gap: ${({ theme }) => theme.spacing.xl};
+  }
+`;
+
+const Sidebar = styled.aside``;
+
+const Main = styled.main``;
+
+const Section = styled.div`
+  margin-bottom: 48px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+  padding-bottom: 48px;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+`;
+
+const H1 = styled.h1`
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const JoinDate = styled.div`
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+const SectionTitle = styled.h2`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin: 0 0 ${({ theme }) => theme.spacing.lg};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const About = styled.div`
+  p {
+    font-size: ${({ theme }) => theme.font.size.md};
+    line-height: ${({ theme }) => theme.font.lineHeight.relaxed};
+    color: ${({ theme }) => theme.colors.text.primary};
+    margin-bottom: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+const MetaList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+  
+  li {
+    font-size: ${({ theme }) => theme.font.size.md};
+  }
+`;
+
+const ReviewHeader = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+`;
+
+const BreakdownWrapper = styled.div`
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+  padding: ${({ theme }) => theme.spacing.lg};
+  background-color: ${({ theme }) => theme.colors.background.default};
+  border-radius: ${({ theme }) => theme.radius.md};
+`;
+
+const ReviewList = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/pages/user/components/UserProfileCard.tsx
+++ b/src/pages/user/components/UserProfileCard.tsx
@@ -1,0 +1,166 @@
+import styled from "styled-components";
+import type { UserProfileDTO } from "../../../api/types";
+import { Award, CheckCircle } from "lucide-react";
+
+interface Props {
+    user: UserProfileDTO;
+}
+
+export default function UserProfileCard({ user }: Props) {
+    return (
+        <Card>
+            <ProfileImageWrapper>
+                <ProfileImage
+                    src={user.profileImageUrl || "https://via.placeholder.com/150"}
+                    alt={user.nickName}
+                />
+                {user.isSuperhost && (
+                    <SuperhostBadge>
+                        <Award size={16} />
+                    </SuperhostBadge>
+                )}
+            </ProfileImageWrapper>
+
+            <Stats>
+                <StatItem>
+                    <h3>{user.reviewCount}</h3>
+                    <span>후기</span>
+                </StatItem>
+                <Divider />
+                <StatItem>
+                    <h3>{user.averageRating.toFixed(2)}</h3>
+                    <span>평점</span>
+                </StatItem>
+                <Divider />
+                <StatItem>
+                    <h3>{user.listingsCount}</h3>
+                    <span>숙소 운영</span>
+                </StatItem>
+            </Stats>
+
+            <Section>
+                <SectionTitle>인증 완료</SectionTitle>
+                <VerificationList>
+                    {user.isVerified && (
+                        <VerificationItem>
+                            <CheckCircle size={18} />
+                            <span>자신 인증 완료</span>
+                        </VerificationItem>
+                    )}
+                    <VerificationItem>
+                        <CheckCircle size={18} />
+                        <span>이메일 주소</span>
+                    </VerificationItem>
+                    <VerificationItem>
+                        <CheckCircle size={18} />
+                        <span>전화번호</span>
+                    </VerificationItem>
+                </VerificationList>
+            </Section>
+        </Card>
+    );
+}
+
+const Card = styled.div`
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  padding: ${({ theme }) => theme.spacing.xl};
+  background: ${({ theme }) => theme.colors.common.white};
+  box-shadow: ${({ theme }) => theme.shadow.sm};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg};
+
+  @media (max-width: 768px) {
+    padding: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+const ProfileImageWrapper = styled.div`
+  position: relative;
+  width: 120px;
+  height: 120px;
+`;
+
+const ProfileImage = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const SuperhostBadge = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  background: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid ${({ theme }) => theme.colors.common.white};
+`;
+
+const Stats = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  width: 100%;
+  justify-content: center;
+`;
+
+const StatItem = styled.div`
+  text-align: center;
+
+  h3 {
+    margin: 0;
+    font-size: ${({ theme }) => theme.font.size.xl};
+    font-weight: ${({ theme }) => theme.font.weight.bold};
+    color: ${({ theme }) => theme.colors.text.primary};
+  }
+
+  span {
+    font-size: ${({ theme }) => theme.font.size.xs};
+    color: ${({ theme }) => theme.colors.text.secondary};
+  }
+`;
+
+const Divider = styled.div`
+  width: 1px;
+  height: 40px;
+  background: ${({ theme }) => theme.colors.border.light};
+`;
+
+const Section = styled.div`
+  width: 100%;
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+  padding-top: ${({ theme }) => theme.spacing.lg};
+`;
+
+const SectionTitle = styled.h4`
+  margin: 0 0 ${({ theme }) => theme.spacing.md};
+  font-size: ${({ theme }) => theme.font.size.lg};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const VerificationList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+const VerificationItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+
+  svg {
+    color: ${({ theme }) => theme.colors.status.success};
+  }
+`;

--- a/src/pages/user/components/UserProfileCard.tsx
+++ b/src/pages/user/components/UserProfileCard.tsx
@@ -1,64 +1,48 @@
 import styled from "styled-components";
-import type { UserProfileDTO } from "../../../api/types";
-import { Award, CheckCircle } from "lucide-react";
+import type { PublicUserProfileResponse } from "../../../api/types";
+import { CheckCircle } from "lucide-react";
 
 interface Props {
-    user: UserProfileDTO;
+  user: PublicUserProfileResponse;
 }
 
 export default function UserProfileCard({ user }: Props) {
-    return (
-        <Card>
-            <ProfileImageWrapper>
-                <ProfileImage
-                    src={user.profileImageUrl || "https://via.placeholder.com/150"}
-                    alt={user.nickName}
-                />
-                {user.isSuperhost && (
-                    <SuperhostBadge>
-                        <Award size={16} />
-                    </SuperhostBadge>
-                )}
-            </ProfileImageWrapper>
+  return (
+    <Card>
+      <ProfileImageWrapper>
+        <ProfileImage
+          src={user.profileImageUrl || "https://via.placeholder.com/150"}
+          alt={user.nickName}
+        />
+      </ProfileImageWrapper>
 
-            <Stats>
-                <StatItem>
-                    <h3>{user.reviewCount}</h3>
-                    <span>후기</span>
-                </StatItem>
-                <Divider />
-                <StatItem>
-                    <h3>{user.averageRating.toFixed(2)}</h3>
-                    <span>평점</span>
-                </StatItem>
-                <Divider />
-                <StatItem>
-                    <h3>{user.listingsCount}</h3>
-                    <span>숙소 운영</span>
-                </StatItem>
-            </Stats>
+      <Stats>
+        <StatItem>
+          <h3>{user.reviewCount}</h3>
+          <span>후기</span>
+        </StatItem>
+        <Divider />
+        <StatItem>
+          <h3>{user.grade}</h3>
+          <span>등급</span>
+        </StatItem>
+      </Stats>
 
-            <Section>
-                <SectionTitle>인증 완료</SectionTitle>
-                <VerificationList>
-                    {user.isVerified && (
-                        <VerificationItem>
-                            <CheckCircle size={18} />
-                            <span>자신 인증 완료</span>
-                        </VerificationItem>
-                    )}
-                    <VerificationItem>
-                        <CheckCircle size={18} />
-                        <span>이메일 주소</span>
-                    </VerificationItem>
-                    <VerificationItem>
-                        <CheckCircle size={18} />
-                        <span>전화번호</span>
-                    </VerificationItem>
-                </VerificationList>
-            </Section>
-        </Card>
-    );
+      <Section>
+        <SectionTitle>인증 완료</SectionTitle>
+        <VerificationList>
+          <VerificationItem>
+            <CheckCircle size={18} />
+            <span>본인 인증 완료</span>
+          </VerificationItem>
+          <VerificationItem>
+            <CheckCircle size={18} />
+            <span>이메일 주소</span>
+          </VerificationItem>
+        </VerificationList>
+      </Section>
+    </Card>
+  );
 }
 
 const Card = styled.div`
@@ -90,20 +74,6 @@ const ProfileImage = styled.img`
   object-fit: cover;
 `;
 
-const SuperhostBadge = styled.div`
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  background: ${({ theme }) => theme.colors.primary.main};
-  color: ${({ theme }) => theme.colors.common.white};
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px solid ${({ theme }) => theme.colors.common.white};
-`;
 
 const Stats = styled.div`
   display: flex;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,6 +7,7 @@ import SearchPage from "../pages/search/SearchPage";
 import HostingPage from "../pages/hosting/HostingPage";
 import BecomeHostPage from "../pages/hosting/BecomeHostPage";
 import MyPage from "../pages/mypage/MyPage";
+import UserPage from "../pages/user/UserPage";
 
 export const router = createBrowserRouter([
   {
@@ -30,6 +31,10 @@ export const router = createBrowserRouter([
   {
     path: "/mypage",
     element: <MyPage />,
+  },
+  {
+    path: "/users/:id",
+    element: <UserPage />,
   },
 ]);
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#20 ) feat/review -> dev


## 📝 작업 내용

숙소 리뷰, 사용자 리뷰를 위한 페이지를 만들었습니다.

**1. 숙소 리뷰**
기존 숙소 상세보기 페이지 하단에 리뷰 항목을 만들었습니다.
<img width="730" height="691" alt="image" src="https://github.com/user-attachments/assets/8a603496-69d8-4a1b-8a3d-7e81b4373912" />


---

**2. 사용자 리뷰**
사용자 리뷰를 위해 '공개 프로필' 페이지를 구현하였습니다.

(공개 프로필_리뷰가 없는 경우)
<img width="1916" height="914" alt="image" src="https://github.com/user-attachments/assets/5ef731d8-f5e5-4677-b4a4-fe3520972393" />

<br>

(공개 프로필_리뷰가 있는 경우)
<img width="1915" height="912" alt="image" src="https://github.com/user-attachments/assets/f734cf7b-39dd-4b23-87b9-fad9b891e8b6" />


## 💬 리뷰 요구사항
- 현재 리뷰 응답으로 사용자의 프로필 이미지와 프로필 이름이 오지 않고 있습니다. 해당 문제는 서비스가 1차적으로 모두 완성된 후 리팩터링 단계에서 수정하도록 하겠습니다.

