### PR TITLE
Feat: 결제 페이지 UI 및 예약/결제 API 연동

### DIFF
--- a/src/api/booking.ts
+++ b/src/api/booking.ts
@@ -1,0 +1,25 @@
+import axios from "axios";
+
+export type BookingCreateRequest = {
+    accommodationId: number;
+    checkInDate: string;
+    checkOutDate: string;
+    numberOfGuests: number;
+};
+
+export type BookingResponse = {
+    bookingId: number;
+    accommodationId: number;
+    guestId: number;
+    checkInDate: string;
+    checkOutDate: string;
+    numberOfGuests: number;
+    totalPrice: string;
+    bookingStatus: string;
+};
+
+export async function createBooking(req: BookingCreateRequest){
+    const res = await axios.post<BookingResponse>("/api/bookings", req);
+    return res.data;
+}
+

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+
+export type PaymentMethod = "MOCK" | "CARD" | "EASY_PAY";
+
+export type PaymentCreateRequest = {
+    bookingId: number;
+    paymentMethod: PaymentMethod;
+};
+
+export type PaymentCreateResponse = {
+    paymentId: number;
+    paymentStatus: string;
+    paymentMethod: PaymentMethod;
+    amount: string;
+};
+
+export async function createPayment(req: PaymentCreateRequest){
+    const res = await axios.post<PaymentCreateResponse>("/api/payments", req);
+    return res.data;
+}
+
+export type PaymentConfirmRequest = {
+    paymentKey: string;
+}
+
+export type PaymentResponse = {
+    paymentId: number;
+    bookingId: number;
+    amount: string;
+    paymentMethod: PaymentMethod;
+    paymentStatus: string;
+    paymentKey: string | null;
+    paidAt: string | null;
+    cancelledAt: string | null;
+};
+
+export async function confirmPayment(paymentId: number, req: PaymentConfirmRequest){
+    const res = await axios.post<PaymentResponse>(`/api/payments/${paymentId}/confirm`, req);
+    return res.data;
+}

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -38,3 +38,8 @@ export async function confirmPayment(paymentId: number, req: PaymentConfirmReque
     const res = await axios.post<PaymentResponse>(`/api/payments/${paymentId}/confirm`, req);
     return res.data;
 }
+
+export async function failPayment(paymentId: number){
+    const res = await axios.post<PaymentResponse>(`/api/payments/${paymentId}/fail`);
+    return res.data;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -85,6 +85,8 @@ export type AccommodationDetailInfoDTO = {
 export type AccommodationDetailDTO = {
   accommodationId: number;
   hostId: number;
+  hostNickname: string;
+  hostProfileImageUrl?: string | null;
   title: string;
   description: string;
   accommodationType: AccommodationType;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -110,6 +110,8 @@ export type AccommodationDetailDTO = {
   images: AccommodationImageDTO[];
   amenities: AmenityDTO[];
 
+  reviewSummary?: ReviewSummaryDTO;
+
   // Frontend specific or optional fields if needed for compatibility (e.g. from reviews)
   // host: HostDTO; // Removing this as backend only sends hostId
 };
@@ -146,3 +148,8 @@ export type ReviewListResponse = {
   };
   breakdown?: ReviewRatingBreakdown;
 };
+
+export type ReviewSummryDTO = {
+  average: number;
+  count: number;
+}

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -113,10 +113,10 @@ export default function AccommodationDetailPage() {
   const handleGoToPayment = () => {
     const params = new URLSearchParams();
 
-    if(checkIn) params.set("checkin:", checkIn);
+    if(checkIn) params.set("checkin", checkIn);
     if(checkOut) params.set("checkout", checkOut);
 
-    params.set("numberOfGuest", String(guests));
+    params.set("numberOfGuests", String(guests));
     params.set("guestCurrency", "KRW");
 
     navigate(`/payment/${id}?${params.toString()}`);

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useAccommodationStore } from "../../store/accommodationStore";
 import * as S from "./accommodationDetail.styles";
 
@@ -18,6 +18,7 @@ type ThumbImage = AccommodationImageDTO & { idx: number };
 
 export default function AccommodationDetailPage() {
   const { id = "1" } = useParams();
+  const navigate = useNavigate();
   const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
 
   // 전체 사진 모달 상태
@@ -109,6 +110,18 @@ export default function AccommodationDetailPage() {
   const averageRating = reviews?.summary?.average ?? 0;
   const reviewCount = reviews?.summary?.count ?? 0;
 
+  const handleGoToPayment = () => {
+    const params = new URLSearchParams();
+
+    if(checkIn) params.set("checkin:", checkIn);
+    if(checkOut) params.set("checkout", checkOut);
+
+    params.set("numberOfGuest", String(guests));
+    params.set("guestCurrency", "KRW");
+
+    navigate(`/payment/${id}?${params.toString()}`);
+  };
+
   return (
     <S.Container>
       <S.Header>
@@ -149,6 +162,7 @@ export default function AccommodationDetailPage() {
             guests={guests}
             setDates={(ci, co) => setDates(ci ?? null, co ?? null)}
             setGuests={setGuests}
+            onReserve={handleGoToPayment}
           />
         </S.Right>
       </S.Main>

--- a/src/pages/accommodation/components/BookingCard.tsx
+++ b/src/pages/accommodation/components/BookingCard.tsx
@@ -16,6 +16,7 @@ type Props = {
   guests: number;
   setDates: (ci: string | null, co: string | null) => void;
   setGuests: (n: number) => void;
+  onReserve: () => void;
 };
 
 export default function BookingCard({
@@ -25,6 +26,7 @@ export default function BookingCard({
   guests,
   setDates,
   setGuests,
+  onReserve,
 }: Props) {
   const nights = nightsBetween(checkIn ?? undefined, checkOut ?? undefined);
 
@@ -125,14 +127,15 @@ export default function BookingCard({
           disabled={!canReserve}
           onClick={() => {
             if (!canReserve) return;
-            alert(
-              `예약 요청: ${checkIn} ~ ${checkOut}, ${guests}명 (총액: ₩${formatKRW(
-                total
-              )})`
-            );
+            onReserve();
+            // alert(
+            //   `예약 요청: ${checkIn} ~ ${checkOut}, ${guests}명 (총액: ₩${formatKRW(
+            //     total
+            //   )})`
+            // );
           }}
         >
-          {canReserve ? "예약 요청하기" : "날짜와 인원을 선택해주세요"}
+          {canReserve ? "예약하기" : "날짜와 인원을 선택해주세요"}
         </S.ReserveButton>
       </S.StickyCard>
     </S.Right>

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -6,7 +6,6 @@ export default function PaymentFailPage() {
     const [sp] = useSearchParams();
 
     const bookingId = sp.get("bookingId");
-    const paymentId = sp.get("paymentId");
 
     const canRetry = useMemo(() => {
         return !!bookingId;
@@ -30,22 +29,6 @@ export default function PaymentFailPage() {
                 <br />
                 다시 시도하거나, 문제가 계속되면 잠시 후 재시도해주세요.
             </p>
-
-            <div
-                style={{
-                    marginTop: 20,
-                    padding: 16,
-                    border: "1px solid #ddd",
-                    borderRadius: 12,
-                }}
-            >
-                <div style={{ marginBottom: 8 }}>
-                    <strong>bookingId:</strong> {bookingId ?? "-"}
-                </div>
-                <div>
-                    <strong>paymentId:</strong> {paymentId ?? "-"}
-                </div>
-            </div>
 
             <div style={{ display: "flex", gap: 12, marginTop: 20, flexWrap: "wrap" }}>
                 {/* 결제 재시도: 다시 PaymentPage로 */}

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+
+export default function PaymentFailPage() {
+    const navigate = useNavigate();
+    const [sp] = useSearchParams();
+
+    const bookingId = sp.get("bookingId");
+    const paymentId = sp.get("paymentId");
+
+    const canRetry = useMemo(() => {
+        return !!bookingId;
+    }, [bookingId]);
+
+    return (
+        <div
+            style={{
+                padding: 24,
+                paddingTop: 120, // TODO: fixed header 생기면 삭제
+                maxWidth: 720,
+                margin: "0 auto",
+            }}
+        >
+            <h1 style={{ fontSize: 24, fontWeight: 800 }}>
+                결제에 실패했습니다
+            </h1>
+
+            <p style={{ marginTop: 12, color: "#666", lineHeight: 1.6 }}>
+                네트워크 문제 또는 결제 과정에서 오류가 발생했을 수 있어요.
+                <br />
+                다시 시도하거나, 문제가 계속되면 잠시 후 재시도해주세요.
+            </p>
+
+            <div
+                style={{
+                    marginTop: 20,
+                    padding: 16,
+                    border: "1px solid #ddd",
+                    borderRadius: 12,
+                }}
+            >
+                <div style={{ marginBottom: 8 }}>
+                    <strong>bookingId:</strong> {bookingId ?? "-"}
+                </div>
+                <div>
+                    <strong>paymentId:</strong> {paymentId ?? "-"}
+                </div>
+            </div>
+
+            <div style={{ display: "flex", gap: 12, marginTop: 20, flexWrap: "wrap" }}>
+                {/* 결제 재시도: 다시 PaymentPage로 */}
+                <button
+                    type="button"
+                    disabled={!canRetry}
+                    onClick={() => {
+                        if (!bookingId) return;
+
+                        // 간단 재시도: 뒤로 가기(= PaymentPage로 복귀)
+                        navigate(-1);
+                    }}
+                    style={{
+                        padding: "10px 14px",
+                        borderRadius: 10,
+                        border: "1px solid #333",
+                        background: "#fff",
+                        cursor: canRetry ? "pointer" : "not-allowed",
+                        opacity: canRetry ? 1 : 0.5,
+                    }}
+                >
+                    결제 다시 시도
+                </button>
+
+                <Link
+                    to="/"
+                    style={{
+                        padding: "10px 14px",
+                        borderRadius: 10,
+                        border: "1px solid #ddd",
+                        textDecoration: "none",
+                        color: "#333",
+                        background: "#fff",
+                    }}
+                >
+                    홈으로
+                </Link>
+
+                {/* 예약 상세로 이동  */}
+                {bookingId && (
+                    <Link
+                        to={`/bookings/${bookingId}`}
+                        style={{
+                            padding: "10px 14px",
+                            borderRadius: 10,
+                            border: "1px solid #ddd",
+                            textDecoration: "none",
+                            color: "#333",
+                            background: "#fff",
+                        }}
+                    >
+                        예약 상세 보기
+                    </Link>
+                )}
+            </div>
+
+            <div style={{ marginTop: 28, color: "#777", fontSize: 13, lineHeight: 1.6 }}>
+                <div>• 결제가 실패해도 예약이 자동으로 확정되진 않아요.</div>
+                <div>• 문제가 지속되면 결제 수단을 바꾸거나 잠시 후 다시 시도해보세요.</div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -1,5 +1,14 @@
 import { useMemo } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import {
+    PaymentFailButtonGroup,
+    PaymentFailDescription,
+    PaymentFailLinkButton,
+    PaymentFailNotice,
+    PaymentFailPageContainer,
+    PaymentFailRetryButton,
+    PaymentFailTitle,
+} from "./paymentFail.styles";
 
 export default function PaymentFailPage() {
     const navigate = useNavigate();
@@ -12,83 +21,45 @@ export default function PaymentFailPage() {
     }, [bookingId]);
 
     return (
-        <div
-            style={{
-                padding: 24,
-                paddingTop: 120, // TODO: fixed header 생기면 삭제
-                maxWidth: 720,
-                margin: "0 auto",
-            }}
-        >
-            <h1 style={{ fontSize: 24, fontWeight: 800 }}>
-                결제에 실패했습니다
-            </h1>
+        <PaymentFailPageContainer>
+            <PaymentFailTitle>결제에 실패했습니다</PaymentFailTitle>
 
-            <p style={{ marginTop: 12, color: "#666", lineHeight: 1.6 }}>
+            <PaymentFailDescription>
                 네트워크 문제 또는 결제 과정에서 오류가 발생했을 수 있어요.
                 <br />
                 다시 시도하거나, 문제가 계속되면 잠시 후 재시도해주세요.
-            </p>
+            </PaymentFailDescription>
 
-            <div style={{ display: "flex", gap: 12, marginTop: 20, flexWrap: "wrap" }}>
+            <PaymentFailButtonGroup>
                 {/* 결제 재시도: 다시 PaymentPage로 */}
-                <button
+                <PaymentFailRetryButton
                     type="button"
                     disabled={!canRetry}
+                    $disabled={!canRetry}
                     onClick={() => {
                         if (!bookingId) return;
 
                         // 간단 재시도: 뒤로 가기(= PaymentPage로 복귀)
                         navigate(-1);
                     }}
-                    style={{
-                        padding: "10px 14px",
-                        borderRadius: 10,
-                        border: "1px solid #333",
-                        background: "#fff",
-                        cursor: canRetry ? "pointer" : "not-allowed",
-                        opacity: canRetry ? 1 : 0.5,
-                    }}
                 >
                     결제 다시 시도
-                </button>
+                </PaymentFailRetryButton>
 
-                <Link
-                    to="/"
-                    style={{
-                        padding: "10px 14px",
-                        borderRadius: 10,
-                        border: "1px solid #ddd",
-                        textDecoration: "none",
-                        color: "#333",
-                        background: "#fff",
-                    }}
-                >
-                    홈으로
-                </Link>
+                <PaymentFailLinkButton to="/">홈으로</PaymentFailLinkButton>
 
-                {/* 예약 상세로 이동  */}
+                {/* 예약 상세로 이동 */}
                 {bookingId && (
-                    <Link
-                        to={`/bookings/${bookingId}`}
-                        style={{
-                            padding: "10px 14px",
-                            borderRadius: 10,
-                            border: "1px solid #ddd",
-                            textDecoration: "none",
-                            color: "#333",
-                            background: "#fff",
-                        }}
-                    >
+                    <PaymentFailLinkButton to={`/bookings/${bookingId}`}>
                         예약 상세 보기
-                    </Link>
+                    </PaymentFailLinkButton>
                 )}
-            </div>
+            </PaymentFailButtonGroup>
 
-            <div style={{ marginTop: 28, color: "#777", fontSize: 13, lineHeight: 1.6 }}>
+            <PaymentFailNotice>
                 <div>• 결제가 실패해도 예약이 자동으로 확정되진 않아요.</div>
                 <div>• 문제가 지속되면 결제 수단을 바꾸거나 잠시 후 다시 시도해보세요.</div>
-            </div>
-        </div>
+            </PaymentFailNotice>
+        </PaymentFailPageContainer>
     );
 }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -127,26 +127,35 @@ export default function PaymentPage() {
                 );
             }
         } catch (e: unknown) {
+
+            let msg = "예약/결제 요청에 실패했습니다.";
+
             // createBooking / createPayment 단계에서의 에러
             if (axios.isAxiosError<{ message?: string }>(e)) {
                 const status = e.response?.status;
-                const msg =
+                msg =
                     status === 401
                         ? "로그인이 필요합니다."
-                        : e.response?.data?.message ?? "예약/결제 요청에 실패했습니다.";
-                setSubmitError(msg);
+                        : e.response?.data?.message ?? msg;
             } else {
-                setSubmitError("알 수 없는 오류가 발생했습니다.");
+                msg = "알 수 없는 오류가 발생했습니다.";
             }
             console.error(e);
 
-            // 여기서도 paymentId가 있으면 fail 처리하고 fail 페이지로 보낼 수 있음
-            // (지금은 createPayment 전에 실패하면 paymentId가 없을 수 있어서 기본은 에러 표시만)
-            if (bookingIdForNav && paymentIdForNav) {
-                navigate(
-                    `/payment/fail?bookingId=${bookingIdForNav}&paymentId=${paymentIdForNav}`
-                );
+            // 예약이 만들어진 상태면(Booking-PENDING) 실패 페이지로 보내서 재결제 안내
+            if(bookingIdForNav){
+                const params = new URLSearchParams();
+                params.set("bookingId", String(bookingIdForNav));
+
+                if(paymentIdForNav){
+                    params.set("paymentId", String(paymentIdForNav));
+                }
+                navigate(`/payment/fail?${params.toString()}`);
+                return;
             }
+            // 예약도 못 만든 경우만 현재 페이지에 에러 표시
+            setSubmitError(msg);
+
         } finally {
             setSubmitting(false);
         }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -104,10 +104,6 @@ export default function PaymentPage() {
                     paymentKey: mockPaymentKey,
                 });
 
-                console.log("booking: ", booking);
-                console.log("payment(created): ", payment);
-                console.log("payment(confirmed): ", confirmed);
-
                 // 결제 성공 페이지로 이동
                 navigate(
                     `/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import axios from "axios";
 
-import { useAccommodationStore } from "@/store/accommodationStore.ts";
+import { useAccommodationStore } from "@/store/accommodationStore";
 import { nightsBetween, calcTotal } from "../../utils/price";
 
 import BookingSummaryCard from "./components/BookngSummaryCard";

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -176,8 +176,8 @@ export default function PaymentPage() {
             <BookingSummaryCard
                 title={detail.title}
                 thumbnailUrl={detail.images?.[0]?.imageUrl}
-                averageRating={5.0}
-                reviewCount={4}
+                averageRating={detail.reviewSummary?.average ?? 0}
+                reviewCount={detail.reviewSummary?.count ?? 0}
                 checkIn={checkIn}
                 checkOut={checkOut}
                 guests={guests}

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -133,10 +133,24 @@ export default function PaymentPage() {
                     status === 401
                         ? "로그인이 필요합니다."
                         : e.response?.data?.message ?? msg;
+
+                // 민감 정보 노출 방지: DEV에서만 최소 정보 로그
+                if (import.meta.env.DEV) {
+                    console.error("[PaymentPage] AxiosError:", {
+                        status,
+                        message: e.message,
+                        url: e.config?.url,
+                        method: e.config?.method,
+                    });
+                }
             } else {
                 msg = "알 수 없는 오류가 발생했습니다.";
+
+                // DEV에서만 로그 (객체 전체 말고 메시지 위주)
+                if (import.meta.env.DEV) {
+                    console.error("[PaymentPage] Unknown error:", String(e));
+                }
             }
-            console.error(e);
 
             // 예약이 만들어진 상태면(Booking-PENDING) 실패 페이지로 보내서 재결제 안내
             if(bookingIdForNav){

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -50,8 +50,6 @@ export default function PaymentPage() {
     if (error) return <div>에러: {error}</div>;
     if (!detail) return <div>데이터 없음</div>;
 
-    const HEADER_OFFSET = 80;
-
     const canSubmit =
         !!price &&
         !!checkIn &&
@@ -178,7 +176,7 @@ export default function PaymentPage() {
                 gridTemplateColumns: "360px minmax(0,700px)",
                 gap: 24,
                 padding: 24,
-                paddingTop: 24 + HEADER_OFFSET,
+                paddingTop: 24,
                 justifyContent: "center",
             }}
         >

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -6,13 +6,13 @@ import { useAccommodationStore } from "@/store/accommodationStore.ts";
 import { nightsBetween, calcTotal } from "../../utils/price";
 
 import BookingSummaryCard from "./components/BookngSummaryCard";
-import PaymentMethodSection, { type UiPaymentMethod,} from "./components/PaymentMethodSection";
+import PaymentMethodSection, { type UiPaymentMethod, } from "./components/PaymentMethodSection";
 
 import HostMessageSection from "./components/HostMessageSection";
 import RequestConfirmSection from "./components/RequestConfirmSection";
 
 import { createBooking } from "@/api/booking";
-import { createPayment, confirmPayment, type PaymentMethod as ApiPaymentMethod,} from "@/api/payment";
+import { createPayment, confirmPayment, failPayment, type PaymentMethod as ApiPaymentMethod, } from "@/api/payment";
 
 export default function PaymentPage() {
     const { id } = useParams<{ id: string }>();
@@ -21,8 +21,7 @@ export default function PaymentPage() {
     const { detail, loading, error, load } = useAccommodationStore();
 
     /** 결제수단 */
-    const [paymentMethod, setPaymentMethod] =
-        useState<UiPaymentMethod>("CARD");
+    const [paymentMethod, setPaymentMethod] = useState<UiPaymentMethod>("CARD");
 
     const [hostMessage, setHostMessage] = useState("");
     const [submitting, setSubmitting] = useState(false);
@@ -32,9 +31,7 @@ export default function PaymentPage() {
     const checkOut = searchParams.get("checkout");
     const guests = Number(searchParams.get("numberOfGuests") ?? 1);
 
-    useEffect(() => {
-        if (id) load(id);
-    }, [id, load]);
+    useEffect(() => { if (id) load(id); }, [id, load]);
 
     const nights = nightsBetween(checkIn ?? undefined, checkOut ?? undefined);
 
@@ -64,9 +61,7 @@ export default function PaymentPage() {
         !submitting;
 
     /** UI → 서버 PaymentMethod 매핑 */
-    const toApiPaymentMethod = (
-        m: UiPaymentMethod
-    ): ApiPaymentMethod => {
+    const toApiPaymentMethod = (m: UiPaymentMethod): ApiPaymentMethod => {
         if (m === "CARD") return "CARD";
         // NAVERPAY / KAKAOPAY는 서버에서는 EASY_PAY
         return "EASY_PAY";
@@ -76,11 +71,14 @@ export default function PaymentPage() {
     const handleSubmit = async () => {
         if (!canSubmit) return;
 
+        let bookingIdForNav: number | null = null;
+        let paymentIdForNav: number | null = null;
+
         try {
             setSubmitting(true);
             setSubmitError(null);
 
-            // 예약 생성
+            // 1) 예약 생성
             const booking = await createBooking({
                 accommodationId: Number(id),
                 checkInDate: checkIn!,
@@ -88,25 +86,48 @@ export default function PaymentPage() {
                 numberOfGuests: guests,
             });
 
-            // 결제 생성
+            bookingIdForNav = booking.bookingId;
+
+            // 2) 결제 생성
             const payment = await createPayment({
                 bookingId: booking.bookingId,
                 paymentMethod: toApiPaymentMethod(paymentMethod),
             });
 
-            // 결제 confirm (PG 연동 전이라 임시 키 생성)
+            paymentIdForNav = payment.paymentId;
+
+            // 3) 결제 confirm (PG 연동 전이라 임시 키 생성)
             const mockPaymentKey = `MOCK_${payment.paymentId}_${Date.now()}`;
 
-            const confirmed = await confirmPayment(payment.paymentId, {paymentKey: mockPaymentKey,});
+            try {
+                const confirmed = await confirmPayment(payment.paymentId, {
+                    paymentKey: mockPaymentKey,
+                });
 
-            console.log("booking: ", booking);
-            console.log("payment(created): ", payment);
-            console.log("payment(confirmed): ", confirmed);
+                console.log("booking: ", booking);
+                console.log("payment(created): ", payment);
+                console.log("payment(confirmed): ", confirmed);
 
-            // 결제 성공 페이지로 이동
-            navigate(`/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`);
+                // 결제 성공 페이지로 이동
+                navigate(
+                    `/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`
+                );
+            } catch {
+                // confirm 실패 → failPayment 호출(백엔드 상태 FAIL로)
+                try {
+                    await failPayment(payment.paymentId);
+                } catch (failErr) {
+                    // failPayment도 실패할 수 있으니 로그 남김
+                    console.error("failPayment 호출 실패:", failErr);
+                }
 
+                // 실패 페이지로 이동
+                navigate(
+                    `/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`
+                );
+            }
         } catch (e: unknown) {
+            // createBooking / createPayment 단계에서의 에러
             if (axios.isAxiosError<{ message?: string }>(e)) {
                 const status = e.response?.status;
                 const msg =
@@ -118,6 +139,14 @@ export default function PaymentPage() {
                 setSubmitError("알 수 없는 오류가 발생했습니다.");
             }
             console.error(e);
+
+            // 여기서도 paymentId가 있으면 fail 처리하고 fail 페이지로 보낼 수 있음
+            // (지금은 createPayment 전에 실패하면 paymentId가 없을 수 있어서 기본은 에러 표시만)
+            if (bookingIdForNav && paymentIdForNav) {
+                navigate(
+                    `/payment/fail?bookingId=${bookingIdForNav}&paymentId=${paymentIdForNav}`
+                );
+            }
         } finally {
             setSubmitting(false);
         }
@@ -150,16 +179,9 @@ export default function PaymentPage() {
 
             {/* 오른쪽: 결제 영역 */}
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                <PaymentMethodSection
-                    value={paymentMethod}
-                    onChange={setPaymentMethod}
-                />
+                <PaymentMethodSection value={paymentMethod} onChange={setPaymentMethod} />
 
-                <HostMessageSection
-                    value={hostMessage}
-                    onChange={setHostMessage}
-                    hostName="현진"
-                />
+                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName="현진" />
 
                 {submitError && (
                     <div
@@ -176,10 +198,7 @@ export default function PaymentPage() {
                     </div>
                 )}
 
-                <RequestConfirmSection
-                    disabled={!canSubmit}
-                    onSubmit={handleSubmit}
-                />
+                <RequestConfirmSection disabled={!canSubmit} onSubmit={handleSubmit} />
             </div>
         </div>
     );

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -14,6 +14,12 @@ import RequestConfirmSection from "./components/RequestConfirmSection";
 import { createBooking } from "@/api/booking";
 import { createPayment, confirmPayment, failPayment, type PaymentMethod as ApiPaymentMethod, } from "@/api/payment";
 
+import {
+    PaymentPageLayout,
+    PaymentContent,
+    SubmitErrorBox,
+} from "./payment.styles";
+
 export default function PaymentPage() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -170,16 +176,7 @@ export default function PaymentPage() {
     };
 
     return (
-        <div
-            style={{
-                display: "grid",
-                gridTemplateColumns: "360px minmax(0,700px)",
-                gap: 24,
-                padding: 24,
-                paddingTop: 24,
-                justifyContent: "center",
-            }}
-        >
+        <PaymentPageLayout>
             {/* 왼쪽: 숙소 요약 */}
             <BookingSummaryCard
                 title={detail.title}
@@ -195,28 +192,25 @@ export default function PaymentPage() {
             />
 
             {/* 오른쪽: 결제 영역 */}
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                <PaymentMethodSection value={paymentMethod} onChange={setPaymentMethod} />
+            <PaymentContent>
+                <PaymentMethodSection
+                    value={paymentMethod}
+                    onChange={setPaymentMethod}
+                />
 
-                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName={detail.hostNickname ?? "호스트"} />
+                <HostMessageSection
+                    value={hostMessage}
+                    onChange={setHostMessage}
+                    hostName={detail.hostNickname ?? "호스트"}
+                />
 
-                {submitError && (
-                    <div
-                        style={{
-                            padding: 12,
-                            borderRadius: 12,
-                            border: "1px solid #fca5a5",
-                            background: "#fef2f2",
-                            color: "#991b1b",
-                            fontSize: 14,
-                        }}
-                    >
-                        {submitError}
-                    </div>
-                )}
+                {submitError && <SubmitErrorBox>{submitError}</SubmitErrorBox>}
 
-                <RequestConfirmSection disabled={!canSubmit} onSubmit={handleSubmit} />
-            </div>
-        </div>
+                <RequestConfirmSection
+                    disabled={!canSubmit}
+                    onSubmit={handleSubmit}
+                />
+            </PaymentContent>
+        </PaymentPageLayout>
     );
 }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,49 +1,143 @@
 import { useEffect, useMemo, useState } from "react";
-import { useParams, useSearchParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import axios from "axios";
+
 import { useAccommodationStore } from "@/store/accommodationStore.ts";
 import { nightsBetween, calcTotal } from "../../utils/price";
 
 import BookingSummaryCard from "./components/BookngSummaryCard";
-import PaymentMethodSection from "./components/PaymentMethodSection";
-import type { PaymentMethod } from "./components/PaymentMethodSection";
+import PaymentMethodSection, { type UiPaymentMethod,} from "./components/PaymentMethodSection";
+
 import HostMessageSection from "./components/HostMessageSection";
 import RequestConfirmSection from "./components/RequestConfirmSection";
 
-export default function PaymentPage(){
-    const{ id } = useParams<{ id: string } >();
+import { createBooking } from "@/api/booking";
+import { createPayment, confirmPayment, type PaymentMethod as ApiPaymentMethod,} from "@/api/payment";
+
+type ErrorResponse = {
+    message?: string;
+};
+
+export default function PaymentPage() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const { detail, loading, error, load } = useAccommodationStore();
 
-    const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("CARD");
+    /** 결제수단 */
+    const [paymentMethod, setPaymentMethod] =
+        useState<UiPaymentMethod>("CARD");
+
     const [hostMessage, setHostMessage] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
 
     const checkIn = searchParams.get("checkin");
     const checkOut = searchParams.get("checkout");
     const guests = Number(searchParams.get("numberOfGuests") ?? 1);
 
     useEffect(() => {
-        if(id) load(id);
+        if (id) load(id);
     }, [id, load]);
 
     const nights = nightsBetween(checkIn ?? undefined, checkOut ?? undefined);
 
     const price = useMemo(() => {
-        if(!detail || !checkIn || !checkOut || nights <= 0) return null;
-        return calcTotal(nights, detail.pricePerNight, detail.cleaningFee, detail.serviceFeePercentage);
+        if (!detail || !checkIn || !checkOut || nights <= 0) return null;
+        return calcTotal(
+            nights,
+            detail.pricePerNight,
+            detail.cleaningFee,
+            detail.serviceFeePercentage
+        );
     }, [detail, checkIn, checkOut, nights]);
 
-    if(!id) return <div>잘못된 접근</div>;
+    if (!id) return <div>잘못된 접근</div>;
     if (loading) return <div>불러오는 중...</div>;
     if (error) return <div>에러: {error}</div>;
     if (!detail) return <div>데이터 없음</div>;
 
     const HEADER_OFFSET = 80;
 
-    return(
-        <div style = {{ display : "grid", gridTemplateColumns : "360px minmax(0,700px)",
-            gap: 24, padding: 24, paddingTop : 24+HEADER_OFFSET,
-            justifyContent : "center"}}>
-        {/*  예약 숙소 요약 카드  */}
+    const canSubmit =
+        !!price &&
+        !!checkIn &&
+        !!checkOut &&
+        guests >= 1 &&
+        guests <= detail.maxGuests &&
+        !submitting;
+
+    /** UI → 서버 PaymentMethod 매핑 */
+    const toApiPaymentMethod = (
+        m: UiPaymentMethod
+    ): ApiPaymentMethod => {
+        if (m === "CARD") return "CARD";
+        // NAVERPAY / KAKAOPAY는 서버에서는 EASY_PAY
+        return "EASY_PAY";
+    };
+
+    /** 예약 + 결제 생성 */
+    const handleSubmit = async () => {
+        if (!canSubmit) return;
+
+        try {
+            setSubmitting(true);
+            setSubmitError(null);
+
+            // 예약 생성
+            const booking = await createBooking({
+                accommodationId: Number(id),
+                checkInDate: checkIn!,
+                checkOutDate: checkOut!,
+                numberOfGuests: guests,
+            });
+
+            // 결제 생성
+            const payment = await createPayment({
+                bookingId: booking.bookingId,
+                paymentMethod: toApiPaymentMethod(paymentMethod),
+            });
+
+            // 결제 confirm (PG 연동 전이라 임시 키 생성)
+            const mockPaymentKey = `MOCK_${payment.paymentId}_${Date.now()}`;
+
+            await confirmPayment(payment.paymentId, {paymentKey: mockPaymentKey,});
+
+            // 결제 성공 페이지로 이동
+            navigate(`/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`);
+        } catch (e: unknown) {
+            if (axios.isAxiosError<ErrorResponse>(e)) {
+                const status = e.response?.status;
+
+                const msg =
+                    status === 401
+                        ? "로그인이 필요합니다."
+                        : e.response?.data?.message ??
+                        "예약/결제 요청에 실패했습니다.";
+
+                setSubmitError(msg);
+            } else {
+                setSubmitError("알 수 없는 오류가 발생했습니다.");
+            }
+
+            console.error(e);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div
+            style={{
+                display: "grid",
+                gridTemplateColumns: "360px minmax(0,700px)",
+                gap: 24,
+                padding: 24,
+                paddingTop: 24 + HEADER_OFFSET,
+                justifyContent: "center",
+            }}
+        >
+            {/* 왼쪽: 숙소 요약 */}
             <BookingSummaryCard
                 title={detail.title}
                 thumbnailUrl={detail.images?.[0]?.imageUrl}
@@ -56,23 +150,40 @@ export default function PaymentPage(){
                 pricePerNight={detail.pricePerNight}
                 total={price?.total}
             />
-            {/* 오른쪽: 3개 섹션 */}
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                <PaymentMethodSection value={paymentMethod} onChange={setPaymentMethod} />
 
-                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName="현진" />
+            {/* 오른쪽: 결제 영역 */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <PaymentMethodSection
+                    value={paymentMethod}
+                    onChange={setPaymentMethod}
+                />
+
+                <HostMessageSection
+                    value={hostMessage}
+                    onChange={setHostMessage}
+                    hostName="현진"
+                />
+
+                {submitError && (
+                    <div
+                        style={{
+                            padding: 12,
+                            borderRadius: 12,
+                            border: "1px solid #fca5a5",
+                            background: "#fef2f2",
+                            color: "#991b1b",
+                            fontSize: 14,
+                        }}
+                    >
+                        {submitError}
+                    </div>
+                )}
 
                 <RequestConfirmSection
-                    disabled={!price || !checkIn || !checkOut || guests < 1 || guests > detail.maxGuests}
-                    onSubmit={() => {
-                        // 4단계에서 예약 생성 API 붙이는 자리
-                        alert(`예약 요청! 결제수단:${paymentMethod}, 메시지:${hostMessage}`);
-                    }}
+                    disabled={!canSubmit}
+                    onSubmit={handleSubmit}
                 />
             </div>
         </div>
-    )
-
-
-
+    );
 }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -181,7 +181,7 @@ export default function PaymentPage() {
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
                 <PaymentMethodSection value={paymentMethod} onChange={setPaymentMethod} />
 
-                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName="현진" />
+                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName={detail.hostNickname ?? "호스트"} />
 
                 {submitError && (
                     <div

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -14,10 +14,6 @@ import RequestConfirmSection from "./components/RequestConfirmSection";
 import { createBooking } from "@/api/booking";
 import { createPayment, confirmPayment, type PaymentMethod as ApiPaymentMethod,} from "@/api/payment";
 
-type ErrorResponse = {
-    message?: string;
-};
-
 export default function PaymentPage() {
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
@@ -101,25 +97,26 @@ export default function PaymentPage() {
             // 결제 confirm (PG 연동 전이라 임시 키 생성)
             const mockPaymentKey = `MOCK_${payment.paymentId}_${Date.now()}`;
 
-            await confirmPayment(payment.paymentId, {paymentKey: mockPaymentKey,});
+            const confirmed = await confirmPayment(payment.paymentId, {paymentKey: mockPaymentKey,});
+
+            console.log("booking: ", booking);
+            console.log("payment(created): ", payment);
+            console.log("payment(confirmed): ", confirmed);
 
             // 결제 성공 페이지로 이동
             navigate(`/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`);
-        } catch (e: unknown) {
-            if (axios.isAxiosError<ErrorResponse>(e)) {
-                const status = e.response?.status;
 
+        } catch (e: unknown) {
+            if (axios.isAxiosError<{ message?: string }>(e)) {
+                const status = e.response?.status;
                 const msg =
                     status === 401
                         ? "로그인이 필요합니다."
-                        : e.response?.data?.message ??
-                        "예약/결제 요청에 실패했습니다.";
-
+                        : e.response?.data?.message ?? "예약/결제 요청에 실패했습니다.";
                 setSubmitError(msg);
             } else {
                 setSubmitError("알 수 없는 오류가 발생했습니다.");
             }
-
             console.error(e);
         } finally {
             setSubmitting(false);

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,0 +1,3 @@
+export default function PaymentPage(){
+    return <div>PaymentPage</div>;
+}

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,3 +1,78 @@
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useAccommodationStore } from "@/store/accommodationStore.ts";
+import { nightsBetween, calcTotal } from "../../utils/price";
+
+import BookingSummaryCard from "./components/BookngSummaryCard";
+import PaymentMethodSection from "./components/PaymentMethodSection";
+import type { PaymentMethod } from "./components/PaymentMethodSection";
+import HostMessageSection from "./components/HostMessageSection";
+import RequestConfirmSection from "./components/RequestConfirmSection";
+
 export default function PaymentPage(){
-    return <div>PaymentPage</div>;
+    const{ id } = useParams<{ id: string } >();
+    const [searchParams] = useSearchParams();
+    const { detail, loading, error, load } = useAccommodationStore();
+
+    const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("CARD");
+    const [hostMessage, setHostMessage] = useState("");
+
+    const checkIn = searchParams.get("checkin");
+    const checkOut = searchParams.get("checkout");
+    const guests = Number(searchParams.get("numberOfGuests") ?? 1);
+
+    useEffect(() => {
+        if(id) load(id);
+    }, [id, load]);
+
+    const nights = nightsBetween(checkIn ?? undefined, checkOut ?? undefined);
+
+    const price = useMemo(() => {
+        if(!detail || !checkIn || !checkOut || nights <= 0) return null;
+        return calcTotal(nights, detail.pricePerNight, detail.cleaningFee, detail.serviceFeePercentage);
+    }, [detail, checkIn, checkOut, nights]);
+
+    if(!id) return <div>잘못된 접근</div>;
+    if (loading) return <div>불러오는 중...</div>;
+    if (error) return <div>에러: {error}</div>;
+    if (!detail) return <div>데이터 없음</div>;
+
+    const HEADER_OFFSET = 80;
+
+    return(
+        <div style = {{ display : "grid", gridTemplateColumns : "360px minmax(0,700px)",
+            gap: 24, padding: 24, paddingTop : 24+HEADER_OFFSET,
+            justifyContent : "center"}}>
+        {/*  예약 숙소 요약 카드  */}
+            <BookingSummaryCard
+                title={detail.title}
+                thumbnailUrl={detail.images?.[0]?.imageUrl}
+                averageRating={5.0}
+                reviewCount={4}
+                checkIn={checkIn}
+                checkOut={checkOut}
+                guests={guests}
+                nights={nights}
+                pricePerNight={detail.pricePerNight}
+                total={price?.total}
+            />
+            {/* 오른쪽: 3개 섹션 */}
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <PaymentMethodSection value={paymentMethod} onChange={setPaymentMethod} />
+
+                <HostMessageSection value={hostMessage} onChange={setHostMessage} hostName="현진" />
+
+                <RequestConfirmSection
+                    disabled={!price || !checkIn || !checkOut || guests < 1 || guests > detail.maxGuests}
+                    onSubmit={() => {
+                        // 4단계에서 예약 생성 API 붙이는 자리
+                        alert(`예약 요청! 결제수단:${paymentMethod}, 메시지:${hostMessage}`);
+                    }}
+                />
+            </div>
+        </div>
+    )
+
+
+
 }

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -100,7 +100,7 @@ export default function PaymentPage() {
             const mockPaymentKey = `MOCK_${payment.paymentId}_${Date.now()}`;
 
             try {
-                const confirmed = await confirmPayment(payment.paymentId, {
+                await confirmPayment(payment.paymentId, {
                     paymentKey: mockPaymentKey,
                 });
 

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -3,7 +3,6 @@ import { useSearchParams, Link } from "react-router-dom";
 export default function PaymentSuccessPage(){
     const [sp] = useSearchParams();
     const bookingId = sp.get("bookingId");
-    const paymentId = sp.get("paymentId");
 
     return (
         <div style={{ padding: 24, paddingTop: 120, maxWidth: 720, margin: "0 auto" }}>
@@ -11,11 +10,6 @@ export default function PaymentSuccessPage(){
             <p style={{ marginTop: 12, color: "#666" }}>
                 예약이 정상적으로 접수되었어요.
             </p>
-
-            <div style={{ marginTop: 20, padding: 16, border: "1px solid #ddd", borderRadius: 12 }}>
-                <div>bookingId: {bookingId ?? "-"}</div>
-                <div>paymentId: {paymentId ?? "-"}</div>
-            </div>
 
             <div style={{ display: "flex", gap: 12, marginTop: 20 }}>
                 {bookingId && (

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -1,26 +1,33 @@
-import { useSearchParams, Link } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
+import {
+    PaymentSuccessContainer,
+    PaymentSuccessTitle,
+    PaymentSuccessDescription,
+    PaymentSuccessButtonGroup,
+    PaymentSuccessLink,
+} from "./paymentSuccess.styles";
 
-export default function PaymentSuccessPage(){
+export default function PaymentSuccessPage() {
     const [sp] = useSearchParams();
     const bookingId = sp.get("bookingId");
 
     return (
-        <div style={{ padding: 24, paddingTop: 120, maxWidth: 720, margin: "0 auto" }}>
-            <h1 style={{ fontSize: 24, fontWeight: 800 }}>결제가 완료되었습니다</h1>
-            <p style={{ marginTop: 12, color: "#666" }}>
-                예약이 정상적으로 접수되었어요.
-            </p>
+        <PaymentSuccessContainer>
+            <PaymentSuccessTitle>결제가 완료되었습니다</PaymentSuccessTitle>
 
-            <div style={{ display: "flex", gap: 12, marginTop: 20 }}>
+            <PaymentSuccessDescription>
+                예약이 정상적으로 접수되었어요.
+            </PaymentSuccessDescription>
+
+            <PaymentSuccessButtonGroup>
                 {bookingId && (
-                    <Link to={`/bookings/${bookingId}`} style={{ textDecoration: "underline" }}>
+                    <PaymentSuccessLink to={`/bookings/${bookingId}`}>
                         예약 상세로 이동
-                    </Link>
+                    </PaymentSuccessLink>
                 )}
-                <Link to="/" style={{ textDecoration: "underline" }}>
-                    홈으로
-                </Link>
-            </div>
-        </div>
+
+                <PaymentSuccessLink to="/">홈으로</PaymentSuccessLink>
+            </PaymentSuccessButtonGroup>
+        </PaymentSuccessContainer>
     );
 }

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -1,0 +1,32 @@
+import { useSearchParams, Link } from "react-router-dom";
+
+export default function PaymentSuccessPage(){
+    const [sp] = useSearchParams();
+    const bookingId = sp.get("bookingId");
+    const paymentId = sp.get("paymentId");
+
+    return (
+        <div style={{ padding: 24, paddingTop: 120, maxWidth: 720, margin: "0 auto" }}>
+            <h1 style={{ fontSize: 24, fontWeight: 800 }}>결제가 완료되었습니다</h1>
+            <p style={{ marginTop: 12, color: "#666" }}>
+                예약이 정상적으로 접수되었어요.
+            </p>
+
+            <div style={{ marginTop: 20, padding: 16, border: "1px solid #ddd", borderRadius: 12 }}>
+                <div>bookingId: {bookingId ?? "-"}</div>
+                <div>paymentId: {paymentId ?? "-"}</div>
+            </div>
+
+            <div style={{ display: "flex", gap: 12, marginTop: 20 }}>
+                {bookingId && (
+                    <Link to={`/bookings/${bookingId}`} style={{ textDecoration: "underline" }}>
+                        예약 상세로 이동
+                    </Link>
+                )}
+                <Link to="/" style={{ textDecoration: "underline" }}>
+                    홈으로
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/payment/components/BookngSummaryCard.tsx
+++ b/src/pages/payment/components/BookngSummaryCard.tsx
@@ -1,0 +1,69 @@
+import * as S from "../payment.styles";
+
+type Props = {
+    title : string;
+    thumbnailUrl?: string;
+    averageRating: number;
+    reviewCount : number;
+    checkIn: string | null;
+    checkOut: string | null;
+    guests: number;
+    nights: number;
+    pricePerNight: number;
+    total?: number;
+};
+
+export default function BookingSummaryCard({
+    title,
+    thumbnailUrl,
+    averageRating,
+    reviewCount,
+    checkIn,
+    checkOut,
+    guests,
+    nights,
+    pricePerNight,
+    total,}: Props){
+    return (
+        <S.SummaryCard>
+            <S.SummaryTop>
+                {thumbnailUrl && <S.Thumbnail src={thumbnailUrl}/>}
+                <div>
+                    <S.SummaryTitle>{title}</S.SummaryTitle>
+                    <S.SummaryMeta>
+                        ★ {averageRating.toFixed(1)} (후기 {reviewCount}개)
+                    </S.SummaryMeta>
+                </div>
+            </S.SummaryTop>
+
+            <S.Divider/>
+
+            <S.SummaryRow>
+                <span>날짜</span>
+                <span>
+                    {checkIn} ~ {checkOut}
+                </span>
+            </S.SummaryRow>
+
+            <S.SummaryRow>
+                <span>게스트</span>
+                <span>{guests}명</span>
+            </S.SummaryRow>
+
+            <S.Divider/>
+
+            <S.SummaryRow>
+                <span>
+                     ₩{pricePerNight.toLocaleString()} × {nights}박
+                </span>
+            </S.SummaryRow>
+
+            {total && (
+                <S.TotalRow>
+                    <span>총액 KRW</span>
+                    <span>₩{total.toLocaleString()}</span>
+                </S.TotalRow>
+            )}
+        </S.SummaryCard>
+    );
+}

--- a/src/pages/payment/components/HostMessageSection.tsx
+++ b/src/pages/payment/components/HostMessageSection.tsx
@@ -1,0 +1,33 @@
+import * as S from "../payment.styles";
+
+type Props = {
+    value: string;
+    onChange: (v: string) => void;
+    hostName: string;
+};
+
+export default function HostMessageSection({
+                                               value,
+                                               onChange,
+                                               hostName,
+                                           }: Props) {
+    return (
+        <S.SectionCard>
+            <S.SectionTitle>2. 호스트에게 보낼 메시지 작성</S.SectionTitle>
+
+            <S.HostInfo>
+                <S.HostAvatar />
+                <div>
+                    <div>{hostName}</div>
+                    <S.SmallText>호스트</S.SmallText>
+                </div>
+            </S.HostInfo>
+
+            <S.TextArea
+                placeholder="여행 목적과 예약 이유를 간단히 작성해주세요."
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+            />
+        </S.SectionCard>
+    );
+}

--- a/src/pages/payment/components/PaymentMethodSection.tsx
+++ b/src/pages/payment/components/PaymentMethodSection.tsx
@@ -1,0 +1,53 @@
+import * as S from "../payment.styles";
+
+export type PaymentMethod = "CARD" | "NAVERPAY" | "KAKAOPAY";
+
+type Props = {
+    value: PaymentMethod;
+    onChange: (method: PaymentMethod) => void;
+};
+
+export default function PaymentMethodSection({ value, onChange }: Props) {
+    return (
+        <S.SectionCard>
+            <S.SectionTitle>1. 결제 수단 추가</S.SectionTitle>
+
+            <S.RadioItem>
+                <input
+                    type="radio"
+                    checked={value === "CARD"}
+                    onChange={() => onChange("CARD")}
+                />
+                <span>신용카드 또는 체크카드</span>
+            </S.RadioItem>
+
+            {value === "CARD" && (
+                <S.CardForm>
+                    <S.Input placeholder="카드 번호" />
+                    <S.Row>
+                        <S.Input placeholder="만료일" />
+                        <S.Input placeholder="CVV" />
+                    </S.Row>
+                </S.CardForm>
+            )}
+
+            <S.RadioItem>
+                <input
+                    type="radio"
+                    checked={value === "NAVERPAY"}
+                    onChange={() => onChange("NAVERPAY")}
+                />
+                <span>네이버페이</span>
+            </S.RadioItem>
+
+            <S.RadioItem>
+                <input
+                    type="radio"
+                    checked={value === "KAKAOPAY"}
+                    onChange={() => onChange("KAKAOPAY")}
+                />
+                <span>카카오페이</span>
+            </S.RadioItem>
+        </S.SectionCard>
+    );
+}

--- a/src/pages/payment/components/PaymentMethodSection.tsx
+++ b/src/pages/payment/components/PaymentMethodSection.tsx
@@ -26,7 +26,7 @@ export default function PaymentMethodSection({ value, onChange }: Props) {
                     <S.Input placeholder="카드 번호" />
                     <S.Row>
                         <S.Input placeholder="만료일" />
-                        <S.Input placeholder="CVV" />
+                        <S.Input type="password" placeholder="CVV" />
                     </S.Row>
                 </S.CardForm>
             )}

--- a/src/pages/payment/components/PaymentMethodSection.tsx
+++ b/src/pages/payment/components/PaymentMethodSection.tsx
@@ -1,10 +1,10 @@
 import * as S from "../payment.styles";
 
-export type PaymentMethod = "CARD" | "NAVERPAY" | "KAKAOPAY";
+export type UiPaymentMethod = "CARD" | "NAVERPAY" | "KAKAOPAY";
 
 type Props = {
-    value: PaymentMethod;
-    onChange: (method: PaymentMethod) => void;
+    value: UiPaymentMethod;
+    onChange: (method: UiPaymentMethod) => void;
 };
 
 export default function PaymentMethodSection({ value, onChange }: Props) {

--- a/src/pages/payment/components/RequestConfirmSection.tsx
+++ b/src/pages/payment/components/RequestConfirmSection.tsx
@@ -1,0 +1,25 @@
+import * as S from "../payment.styles";
+
+type Props = {
+    disabled: boolean;
+    onSubmit: () => void;
+};
+
+export default function RequestConfirmSection({
+                                                  disabled,
+                                                  onSubmit,
+                                              }: Props) {
+    return (
+        <S.SectionCard>
+            <S.SectionTitle>3. 요청 내용 확인</S.SectionTitle>
+
+            <S.SmallText>
+                버튼을 선택하면 예약 약관에 동의하게 됩니다.
+            </S.SmallText>
+
+            <S.PrimaryButton disabled={disabled} onClick={onSubmit}>
+                예약 요청
+            </S.PrimaryButton>
+        </S.SectionCard>
+    );
+}

--- a/src/pages/payment/payment.styles.ts
+++ b/src/pages/payment/payment.styles.ts
@@ -1,0 +1,123 @@
+import styled from "styled-components";
+
+export const SummaryCard = styled.div`
+  border: 1px solid #ddd;
+  border-radius: 16px;
+  padding: 20px;
+`;
+
+export const SectionCard = styled.div`
+  border: 1px solid #ddd;
+  border-radius: 16px;
+  padding: 20px;
+`;
+
+export const SectionTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 16px;
+`;
+
+export const Divider = styled.hr`
+  margin: 16px 0;
+  border: none;
+  border-top: 1px solid #eee;
+`;
+
+export const SummaryRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin: 6px 0;
+`;
+
+export const TotalRow = styled(SummaryRow)`
+  font-weight: 800;
+  margin-top: 12px;
+`;
+
+export const RadioItem = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+`;
+
+export const CardForm = styled.div`
+  margin: 12px 0;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+`;
+
+export const TextArea = styled.textarea`
+  width: 100%;
+  min-height: 120px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #ccc;
+`;
+
+export const PrimaryButton = styled.button`
+  width: 100%;
+  margin-top: 16px;
+  padding: 14px;
+  border-radius: 12px;
+  border: none;
+  font-weight: 700;
+  background: #ff385c;
+  color: white;
+  cursor: pointer;
+
+  &:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+  }
+`;
+
+export const SmallText = styled.p`
+  font-size: 14px;
+  color: #666;
+`;
+
+export const SummaryTop = styled.div`
+  display: flex;
+  gap: 12px;
+`;
+
+export const Thumbnail = styled.img`
+  width: 80px;
+  height: 80px;
+  border-radius: 12px;
+  object-fit: cover;
+`;
+
+export const SummaryTitle = styled.h3`
+  font-weight: 700;
+`;
+
+export const SummaryMeta = styled.div`
+  font-size: 14px;
+  color: #666;
+`;
+
+export const HostInfo = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+`;
+
+export const HostAvatar = styled.div`
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: #ddd;
+`;

--- a/src/pages/payment/payment.styles.ts
+++ b/src/pages/payment/payment.styles.ts
@@ -121,3 +121,27 @@ export const HostAvatar = styled.div`
   border-radius: 50%;
   background: #ddd;
 `;
+
+export const PaymentPageLayout = styled.div`
+  display: grid;
+  grid-template-columns: 360px minmax(0, 700px);
+  gap: 24px;
+  padding: 24px;
+  padding-top: 24px;
+  justify-content: center;
+`;
+
+export const PaymentContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+export const SubmitErrorBox = styled.div`
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+  font-size: 14px;
+`;

--- a/src/pages/payment/paymentFail.styles.ts
+++ b/src/pages/payment/paymentFail.styles.ts
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+export const PaymentFailPageContainer = styled.div`
+  padding: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+`;
+
+export const PaymentFailTitle = styled.h1`
+  font-size: 24px;
+  font-weight: 800;
+`;
+
+export const PaymentFailDescription = styled.p`
+  margin-top: 12px;
+  color: #666;
+  line-height: 1.6;
+`;
+
+export const PaymentFailButtonGroup = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+`;
+
+export const PaymentFailRetryButton = styled.button<{ $disabled: boolean }>`
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #333;
+  background: #fff;
+  cursor: ${({ $disabled }) => ($disabled ? "not-allowed" : "pointer")};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
+`;
+
+export const PaymentFailLinkButton = styled(Link)`
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #ddd;
+  text-decoration: none;
+  color: #333;
+  background: #fff;
+`;
+
+export const PaymentFailNotice = styled.div`
+  margin-top: 28px;
+  color: #777;
+  font-size: 13px;
+  line-height: 1.6;
+`;

--- a/src/pages/payment/paymentSuccess.styles.ts
+++ b/src/pages/payment/paymentSuccess.styles.ts
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import { Link } from "react-router-dom";
+
+export const PaymentSuccessContainer = styled.div`
+  padding: 24px;
+  max-width: 720px;
+  margin: 0 auto;
+`;
+
+export const PaymentSuccessTitle = styled.h1`
+  font-size: 24px;
+  font-weight: 800;
+`;
+
+export const PaymentSuccessDescription = styled.p`
+  margin-top: 12px;
+  color: #666;
+`;
+
+export const PaymentSuccessButtonGroup = styled.div`
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+`;
+
+export const PaymentSuccessLink = styled(Link)`
+  text-decoration: underline;
+`;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -13,6 +13,7 @@ import ReviewsPage from "../pages/profile/reviews/ReviewsPage";
 import UserPage from "../pages/user/UserPage";
 import PaymentPage from "../pages/payment/PaymentPage";
 import PaymentSuccessPage from "../pages/payment/PaymentSuccessPage.tsx";
+import PaymentFailPage from "../pages/payment/PaymentFailPage.tsx";
 
 export const router = createBrowserRouter([
   {
@@ -24,6 +25,7 @@ export const router = createBrowserRouter([
       { path: "accommodation/:id", element: <AccommodationDetailPage /> },
       { path: "payment/:id", element: <PaymentPage/>},
       { path: "payment/success", element: <PaymentSuccessPage/>},
+      { path: "payment/fail", element: <PaymentFailPage/>},
       { path: "search", element: <SearchPage /> },
     ],
   },

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -2,7 +2,7 @@ import { createBrowserRouter } from "react-router-dom";
 import PublicLayout from "../layouts/PublicLayout/PublicLayout";
 import LandingPage from "../pages/landing/LandingPage";
 import MainPage from "../pages/main/MainPage";
-import AccommodationDetailPage from "../pages/accommodation/AccommodationDetailPage.tsx";
+import AccommodationDetailPage from "../pages/accommodation/AccommodationDetailPage";
 import SearchPage from "../pages/search/SearchPage";
 import HostingPage from "../pages/hosting/HostingPage";
 import BecomeHostPage from "../pages/hosting/BecomeHostPage";
@@ -11,6 +11,7 @@ import ProfilePage from "../pages/profile/ProfilePage";
 import ProfileEditPage from "../pages/profile/edit/ProfileEditPage";
 import ReviewsPage from "../pages/profile/reviews/ReviewsPage";
 import UserPage from "../pages/user/UserPage";
+import PaymentPage from "../pages/payment/PaymentPage";
 
 export const router = createBrowserRouter([
   {
@@ -20,6 +21,7 @@ export const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: "landing", element: <LandingPage /> },
       { path: "accommodation/:id", element: <AccommodationDetailPage /> },
+      { path: "payment/:id", element: <PaymentPage/>},
       { path: "search", element: <SearchPage /> },
     ],
   },

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,8 +12,8 @@ import ProfileEditPage from "../pages/profile/edit/ProfileEditPage";
 import ReviewsPage from "../pages/profile/reviews/ReviewsPage";
 import UserPage from "../pages/user/UserPage";
 import PaymentPage from "../pages/payment/PaymentPage";
-import PaymentSuccessPage from "../pages/payment/PaymentSuccessPage.tsx";
-import PaymentFailPage from "../pages/payment/PaymentFailPage.tsx";
+import PaymentSuccessPage from "../pages/payment/PaymentSuccessPage";
+import PaymentFailPage from "../pages/payment/PaymentFailPage";
 
 export const router = createBrowserRouter([
   {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,6 +12,7 @@ import ProfileEditPage from "../pages/profile/edit/ProfileEditPage";
 import ReviewsPage from "../pages/profile/reviews/ReviewsPage";
 import UserPage from "../pages/user/UserPage";
 import PaymentPage from "../pages/payment/PaymentPage";
+import PaymentSuccessPage from "../pages/payment/PaymentSuccessPage.tsx";
 
 export const router = createBrowserRouter([
   {
@@ -22,6 +23,7 @@ export const router = createBrowserRouter([
       { path: "landing", element: <LandingPage /> },
       { path: "accommodation/:id", element: <AccommodationDetailPage /> },
       { path: "payment/:id", element: <PaymentPage/>},
+      { path: "payment/success", element: <PaymentSuccessPage/>},
       { path: "search", element: <SearchPage /> },
     ],
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,4 +9,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "src"),
     },
   },
+
+  server: {
+    proxy: {
+      "/api" : {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 🔗 반영 브랜치

(#33 ) feature/payment -> dev

## 📝 작업 내용

결제 페이지(PaymentPage) UI 구성 및 예약/결제 백엔드 API 연동을 추가했습니다. <br>

- PaymentPage 레이아웃 구현(좌측 예약 요약 / 우측 결제 섹션)
- 숙소 상세 → 결제 페이지 이동 시 쿼리 파라미터 전달 및 파싱
- checkin, checkout, numberOfGuests 키 정리
- 가격 계산 유틸 연결(nightsBetween / calcTotal)
- 예약 생성/결제 생성/결제 확정(confirm)/결제 실패(fail) API 호출 플로우 추가
- 버튼 활성 조건(canSubmit) 및 제출 중 상태(submitting) 처리
- Vite proxy 설정 추가(`/api` → 백엔드)


<img width="2843" height="1458" alt="결제페이지" src="https://github.com/user-attachments/assets/d2d418aa-a06a-4cfe-8f42-fe5a48e52ac4" />
<img width="2875" height="1439" alt="결제 성공페이지" src="https://github.com/user-attachments/assets/8c9d8b69-371d-4085-9cae-04f9d3cb3042" />

<img width="2848" height="1464" alt="결제 실패 페이지" src="https://github.com/user-attachments/assets/7fafad57-87c7-4b80-b9dd-b9cd3d521cf4" />



## 💬 리뷰 요구사항(선택 사항)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
