### PR TITLE
Feat: 위시리스트 페이지 컴포넌트 구현 및 연동

### DIFF
--- a/src/api/favorite.ts
+++ b/src/api/favorite.ts
@@ -1,0 +1,81 @@
+import client from './client';
+import type {
+  FavoriteResponseDTO,
+  FavoriteCreateRequestDTO,
+  FavoriteCreateResponseDTO,
+  FavoriteDetailResponseDTO,
+  FavoriteUpdateRequestDTO,
+} from './types';
+
+const BASE = '/api/favorites';
+
+function validateId(value: unknown, name: string): asserts value is string {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    throw new Error(`Invalid ${name}: ${value}`);
+  }
+}
+
+/** 즐겨찾기 목록 조회 */
+export async function fetchFavorites(): Promise<FavoriteResponseDTO[]> {
+  const data = (await client.get(BASE)) as unknown as FavoriteResponseDTO[];
+  return Array.isArray(data) ? data : [];
+}
+
+/** 즐겨찾기 상세 조회 */
+export async function fetchFavoriteDetail(
+  favoriteId: string,
+): Promise<FavoriteDetailResponseDTO> {
+  validateId(favoriteId, 'favoriteId');
+  return (await client.get(
+    `${BASE}/${encodeURIComponent(favoriteId)}`,
+  )) as unknown as FavoriteDetailResponseDTO;
+}
+
+/** 즐겨찾기 생성 */
+export async function createFavorite(
+  request: FavoriteCreateRequestDTO,
+): Promise<FavoriteCreateResponseDTO> {
+  return (await client.post(
+    BASE,
+    request,
+  )) as unknown as FavoriteCreateResponseDTO;
+}
+
+/** 즐겨찾기 수정 */
+export async function updateFavorite(
+  favoriteId: string,
+  request: FavoriteUpdateRequestDTO,
+): Promise<void> {
+  validateId(favoriteId, 'favoriteId');
+  await client.patch(`${BASE}/${encodeURIComponent(favoriteId)}`, request);
+}
+
+/** 즐겨찾기 삭제 */
+export async function deleteFavorite(favoriteId: string): Promise<void> {
+  validateId(favoriteId, 'favoriteId');
+  await client.delete(`${BASE}/${encodeURIComponent(favoriteId)}`);
+}
+
+/** 즐겨찾기에 숙소 추가 */
+export async function addAccommodationToFavorite(
+  favoriteId: string,
+  accommodationId: string,
+): Promise<void> {
+  validateId(favoriteId, 'favoriteId');
+  validateId(accommodationId, 'accommodationId');
+  await client.post(
+    `${BASE}/${encodeURIComponent(favoriteId)}/accommodations/${encodeURIComponent(accommodationId)}`,
+  );
+}
+
+/** 즐겨찾기에서 숙소 제거 */
+export async function removeAccommodationFromFavorite(
+  favoriteId: string,
+  accommodationId: string,
+): Promise<void> {
+  validateId(favoriteId, 'favoriteId');
+  validateId(accommodationId, 'accommodationId');
+  await client.delete(
+    `${BASE}/${encodeURIComponent(favoriteId)}/accommodations/${encodeURIComponent(accommodationId)}`,
+  );
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -144,3 +144,48 @@ export type ReviewListResponse = {
   };
   breakdown?: ReviewRatingBreakdown;
 };
+
+// --- Favorite (즐겨찾기) API ---
+export type FavoriteResponseDTO = {
+  favoriteId: number;
+  name: string;
+  description: string;
+  isPrivate?: boolean;
+  private?: boolean;
+  accommodationCount: number;
+  coverImageUrl?: string | null;
+};
+
+export type FavoriteCreateRequestDTO = {
+  name: string;
+  description: string;
+  isPrivate: boolean;
+};
+
+export type FavoriteCreateResponseDTO = {
+  favoriteId: number;
+};
+
+export type FavoriteAccommodationDTO = {
+  accommodationId: number;
+  title: string;
+  city: string;
+  country: string;
+  pricePerNight: number;
+  imageUrl: string | null;
+};
+
+export type FavoriteDetailResponseDTO = {
+  favoriteId: number;
+  name: string;
+  description: string;
+  isPrivate?: boolean;
+  private?: boolean;
+  accommodations: FavoriteAccommodationDTO[];
+};
+
+export type FavoriteUpdateRequestDTO = {
+  name?: string;
+  description?: string;
+  isPrivate?: boolean;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -151,7 +151,6 @@ export type FavoriteResponseDTO = {
   name: string;
   description: string;
   isPrivate?: boolean;
-  private?: boolean;
   accommodationCount: number;
   coverImageUrl?: string | null;
 };
@@ -180,7 +179,6 @@ export type FavoriteDetailResponseDTO = {
   name: string;
   description: string;
   isPrivate?: boolean;
-  private?: boolean;
   accommodations: FavoriteAccommodationDTO[];
 };
 

--- a/src/components/AccommodationCard/AccommodationCard.tsx
+++ b/src/components/AccommodationCard/AccommodationCard.tsx
@@ -83,6 +83,7 @@ const AccommodationCard = ({
       const list = await fetchFavorites();
       setFavoritesList(list);
     } catch {
+      alert('위시리스트 목록을 불러오는 데 실패했습니다.');
       setFavoritesList([]);
     } finally {
       setIsListLoading(false);

--- a/src/components/AccommodationCard/AccommodationCard.tsx
+++ b/src/components/AccommodationCard/AccommodationCard.tsx
@@ -12,8 +12,15 @@ import {
 } from './AccommodationCard.styles';
 import { Heart, Star } from 'lucide-react';
 import WishlistModal from '@/components/WishlistModal/WishlistModal';
+import {
+  fetchFavorites,
+  createFavorite,
+  addAccommodationToFavorite,
+} from '@/api/favorite';
+import type { FavoriteResponseDTO } from '@/api/types';
 
 export interface AccommodationCardProps {
+  accommodationId?: number;
   image: string;
   badge?: string;
   title: string;
@@ -28,30 +35,27 @@ export interface AccommodationCardProps {
   onFavoriteClick?: () => void;
 }
 
-// 날짜 포맷팅 함수
 const formatDateRange = (start: Date, end: Date): string => {
   const startMonth = start.getMonth() + 1;
   const startDay = start.getDate();
   const endMonth = end.getMonth() + 1;
   const endDay = end.getDate();
-
   if (startMonth === endMonth) {
     return `${startMonth}월 ${startDay}일~${endDay}일`;
   }
   return `${startMonth}월 ${startDay}일~${endMonth}월 ${endDay}일`;
 };
 
-// 가격 포맷팅 함수
 const formatPrice = (price: number): string => {
   return `₩${price.toLocaleString('ko-KR')}`;
 };
 
-// 박수 포맷팅 함수
 const formatNights = (nights: number): string => {
   return `${nights}박`;
 };
 
 const AccommodationCard = ({
+  accommodationId,
   image,
   badge,
   title,
@@ -63,21 +67,60 @@ const AccommodationCard = ({
   onFavoriteClick,
 }: AccommodationCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [favoritesList, setFavoritesList] = useState<FavoriteResponseDTO[]>([]);
+  const [isListLoading, setIsListLoading] = useState(false);
+  const [isCreateLoading, setIsCreateLoading] = useState(false);
 
-  const handleHeartClick = (e: React.MouseEvent) => {
+  const handleHeartClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
     if (isFavorite && onFavoriteClick) {
       onFavoriteClick();
-    } else {
-      setIsModalOpen(true);
+      return;
+    }
+    setIsModalOpen(true);
+    setIsListLoading(true);
+    try {
+      const list = await fetchFavorites();
+      setFavoritesList(list);
+    } catch {
+      setFavoritesList([]);
+    } finally {
+      setIsListLoading(false);
     }
   };
 
-  const handleCreateWishlist = (name: string) => {
-    // 위시리스트 생성 로직 (나중에 API로 대체)
-    console.log(`위시리스트 생성: ${name}`);
-    if (onFavoriteClick) {
-      onFavoriteClick();
+  const handleAddToFavorite = async (favoriteId: number) => {
+    if (accommodationId == null) return;
+    try {
+      await addAccommodationToFavorite(
+        String(favoriteId),
+        String(accommodationId),
+      );
+      onFavoriteClick?.();
+    } catch {
+      alert('위시리스트에 추가하지 못했습니다.');
+    }
+  };
+
+  const handleCreateWishlist = async (name: string) => {
+    setIsCreateLoading(true);
+    try {
+      const res = await createFavorite({
+        name,
+        description: '',
+        isPrivate: false,
+      });
+      if (accommodationId != null) {
+        await addAccommodationToFavorite(
+          String(res.favoriteId),
+          String(accommodationId),
+        );
+      }
+      onFavoriteClick?.();
+    } catch {
+      alert('위시리스트 생성에 실패했습니다.');
+    } finally {
+      setIsCreateLoading(false);
     }
   };
 
@@ -104,7 +147,11 @@ const AccommodationCard = ({
       <WishlistModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+        favorites={favoritesList}
+        isLoadingList={isListLoading}
+        onAddToFavorite={handleAddToFavorite}
         onCreate={handleCreateWishlist}
+        isLoading={isCreateLoading}
       />
     </>
   );

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -1,5 +1,5 @@
-import { useRef, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   DropdownMenu,
   DropdownItem,
@@ -9,7 +9,7 @@ import {
   DropdownHeaderTitle,
   DropdownHeaderDesc,
   DropdownHeaderImage,
-} from "./ProfileDropdown.styles";
+} from './ProfileDropdown.styles';
 import {
   Heart,
   Home,
@@ -21,8 +21,8 @@ import {
   LogOut,
   UserPlus,
   Users,
-} from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
+} from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 
 type ProfileDropdownProps = {
   onClose: () => void;
@@ -31,18 +31,18 @@ type ProfileDropdownProps = {
 
 // 메뉴 텍스트 상수 (향후 i18n 적용 시 쉽게 교체 가능)
 const MENU_LABELS = {
-  wishlist: "위시리스트",
-  trips: "여행",
-  messages: "메시지",
-  profile: "프로필",
-  accountSettings: "계정 관리",
-  languageAndCurrency: "언어 및 통화",
-  helpCenter: "도움말 센터",
-  hosting: "호스팅 하기",
-  hostingDescription: "간단하게 호스팅을 시작하고 부수입을 올릴 수 있습니다.",
-  recommendHost: "호스트 추천하기",
-  findCoHost: "공동 호스트 찾기",
-  logout: "로그아웃",
+  wishlist: '위시리스트',
+  trips: '여행',
+  messages: '메시지',
+  profile: '프로필',
+  accountSettings: '계정 관리',
+  languageAndCurrency: '언어 및 통화',
+  helpCenter: '도움말 센터',
+  hosting: '호스팅 하기',
+  hostingDescription: '간단하게 호스팅을 시작하고 부수입을 올릴 수 있습니다.',
+  recommendHost: '호스트 추천하기',
+  findCoHost: '공동 호스트 찾기',
+  logout: '로그아웃',
 } as const;
 
 const ProfileDropdown = ({ onClose, buttonRef }: ProfileDropdownProps) => {
@@ -61,8 +61,8 @@ const ProfileDropdown = ({ onClose, buttonRef }: ProfileDropdownProps) => {
       }
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [onClose, buttonRef]);
 
   const handleLogout = () => {
@@ -78,7 +78,7 @@ const ProfileDropdown = ({ onClose, buttonRef }: ProfileDropdownProps) => {
   return (
     <DropdownMenu ref={dropdownRef}>
       <DropdownSection>
-        <DropdownItem>
+        <DropdownItem onClick={() => handleNavigate('/wishlist')}>
           <Heart />
           {MENU_LABELS.wishlist}
         </DropdownItem>
@@ -104,7 +104,7 @@ const ProfileDropdown = ({ onClose, buttonRef }: ProfileDropdownProps) => {
       <DropdownDivider />
 
       <DropdownSection>
-        <DropdownItem onClick={() => handleNavigate("/account")}>
+        <DropdownItem onClick={() => handleNavigate('/account')}>
           <Settings />
           {MENU_LABELS.accountSettings}
         </DropdownItem>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import {
   SidebarOverlay,
@@ -36,14 +37,16 @@ interface SidebarProps {
 }
 
 const Sidebar = ({ isOpen, onClose, isScrolled = false }: SidebarProps) => {
+  const navigate = useNavigate();
+
   const menuItems = [
-    { icon: Heart, text: '위시리스트' },
-    { icon: Plane, text: '여행' },
-    { icon: MessageSquare, text: '메시지' },
-    { icon: User, text: '프로필' },
-    { icon: Settings, text: '계정 관리' },
-    { icon: Globe, text: '언어 및 통화' },
-    { icon: HelpCircle, text: '도움말 센터' },
+    { icon: Heart, text: '위시리스트', path: '/wishlist' },
+    { icon: Plane, text: '여행', path: undefined },
+    { icon: MessageSquare, text: '메시지', path: '/messages' },
+    { icon: User, text: '프로필', path: '/profile' },
+    { icon: Settings, text: '계정 관리', path: '/account' },
+    { icon: Globe, text: '언어 및 통화', path: undefined },
+    { icon: HelpCircle, text: '도움말 센터', path: undefined },
   ];
 
   const hostItems = [
@@ -66,7 +69,16 @@ const Sidebar = ({ isOpen, onClose, isScrolled = false }: SidebarProps) => {
           {menuItems.map((item, index) => {
             const Icon = item.icon;
             return (
-              <SidebarMenuItem key={index}>
+              <SidebarMenuItem
+                key={index}
+                type="button"
+                onClick={() => {
+                  if (item.path) {
+                    navigate(item.path);
+                    onClose();
+                  }
+                }}
+              >
                 <SidebarMenuIcon>
                   <Icon size={20} />
                 </SidebarMenuIcon>

--- a/src/components/WishlistModal/WishlistModal.styles.ts
+++ b/src/components/WishlistModal/WishlistModal.styles.ts
@@ -3,103 +3,168 @@ import { media } from '@/styles/media';
 
 export const ModalOverlay = styled.div`
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
   background: ${({ theme }) => theme.colors.overlay.default};
   z-index: ${({ theme }) => theme.zIndex.modalOverlay};
   display: flex;
   align-items: center;
   justify-content: center;
   padding: ${({ theme }) => theme.spacing.lg};
-  box-sizing: border-box;
 
   ${media.mobile} {
     padding: ${({ theme }) => theme.spacing.md};
     align-items: flex-end;
-    justify-content: center;
   }
 `;
 
 export const ModalContainer = styled.div`
   background: ${({ theme }) => theme.colors.common.white};
   border-radius: ${({ theme }) => theme.radius.xl};
+  width: 100%;
   max-width: 568px;
-  width: calc(100% - ${({ theme }) => theme.spacing.xl} * 2);
+  height: 720px;
   max-height: 90vh;
   display: flex;
   flex-direction: column;
   box-shadow: ${({ theme }) => theme.shadow.lg};
   overflow: hidden;
-  z-index: ${({ theme }) => theme.zIndex.modalContainer};
-  box-sizing: border-box;
 
   ${media.mobile} {
-    max-width: 100%;
-    width: 100%;
+    height: 80vh;
+    max-height: 80vh;
     border-radius: ${({ theme }) => theme.radius.xl}
       ${({ theme }) => theme.radius.xl} 0 0;
-    max-height: 80vh;
   }
 `;
 
 export const ModalHeader = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
   align-items: center;
-  justify-content: space-between;
   padding: ${({ theme }) => theme.spacing.xl};
   border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
-
-  ${media.mobile} {
-    padding: ${({ theme }) => theme.spacing.lg};
-  }
 `;
 
 export const ModalTitle = styled.h2`
+  grid-column: 2;
+  justify-self: center;
+  margin: 0;
   font-size: ${({ theme }) => theme.font.size.xl};
   font-weight: ${({ theme }) => theme.font.weight.bold};
   color: ${({ theme }) => theme.colors.text.primary};
-  margin: 0;
-
-  ${media.mobile} {
-    font-size: ${({ theme }) => theme.font.size.lg};
-  }
+  text-align: center;
 `;
 
 export const ModalCloseButton = styled.button`
+  grid-column: 3;
+  justify-self: end;
   width: 32px;
   height: 32px;
-  border-radius: ${({ theme }) => theme.radius.full};
+  padding: 0;
   border: none;
-  background: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.full};
+  background: transparent;
+  color: ${({ theme }) => theme.colors.text.primary};
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: ${({ theme }) => theme.transition.normal};
-  color: ${({ theme }) => theme.colors.text.primary};
 
   &:hover {
     background: ${({ theme }) => theme.colors.border.light};
   }
-
-  ${media.mobile} {
-    width: 28px;
-    height: 28px;
-  }
 `;
 
 export const ModalContent = styled.div`
-  padding: ${({ theme }) => theme.spacing.xl};
   flex: 1;
-  overflow-y: auto;
+  padding: ${({ theme }) => theme.spacing.xl};
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 
   ${media.mobile} {
     padding: ${({ theme }) => theme.spacing.lg};
   }
 `;
 
+/* 목록 뷰: 스크롤 영역 + 하단 버튼 */
+export const ListScroll = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: ${({ theme }) => theme.spacing.lg};
+  padding-right: ${({ theme }) => theme.spacing.md};
+`;
+
+export const WishlistList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: ${({ theme }) => theme.spacing.md};
+
+  ${media.mobile} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const WishlistItem = styled.button`
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.lg};
+  background: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  box-shadow: 0 0 0 1px ${({ theme }) => theme.colors.border.light};
+  transition: ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    box-shadow: ${({ theme }) => theme.shadow.md};
+  }
+`;
+
+export const WishlistItemThumb = styled.div<{ $imageUrl?: string | null }>`
+  width: 100%;
+  aspect-ratio: 1;
+  background: ${({ $imageUrl, theme }) =>
+    $imageUrl
+      ? `url(${$imageUrl}) center/cover`
+      : `linear-gradient(135deg, ${theme.colors.border.light} 0%, ${theme.colors.border.primary} 100%)`};
+`;
+
+export const WishlistItemBody = styled.div`
+  padding: ${({ theme }) => theme.spacing.md};
+`;
+
+export const WishlistItemTitle = styled.div`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const WishlistItemCount = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const ModalNewWishlistButton = styled.button`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  background: ${({ theme }) => theme.colors.text.primary};
+  color: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+/* 만들기 뷰 */
 export const ModalInputLabel = styled.label`
   display: block;
   font-size: ${({ theme }) => theme.font.size.md};
@@ -116,13 +181,11 @@ export const ModalInput = styled.input`
   font-size: ${({ theme }) => theme.font.size.md};
   color: ${({ theme }) => theme.colors.text.primary};
   background: ${({ theme }) => theme.colors.common.white};
-  transition: ${({ theme }) => theme.transition.colors.normal};
   box-sizing: border-box;
 
   &:focus {
     outline: none;
     border-color: ${({ theme }) => theme.colors.primary.main};
-    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.primary.light};
   }
 
   &::placeholder {
@@ -139,20 +202,44 @@ export const ModalCharCount = styled.div`
 
 export const ModalFooter = styled.div`
   display: flex;
-  align-items: center;
   justify-content: flex-end;
   gap: ${({ theme }) => theme.spacing.md};
   padding: ${({ theme }) => theme.spacing.xl};
   border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
 
-  ${media.mobile} {
-    padding: ${({ theme }) => theme.spacing.lg};
-    flex-direction: column-reverse;
-    gap: ${({ theme }) => theme.spacing.sm};
+export const ModalCancelButton = styled.button`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  background: ${({ theme }) => theme.colors.common.white};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
 
-    button {
-      width: 100%;
-    }
+  &:hover {
+    background: ${({ theme }) => theme.colors.border.light};
+  }
+`;
+
+export const ModalCreateButton = styled.button`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  border: none;
+  background: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.primary.hover};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 
@@ -161,31 +248,13 @@ export const ModalButton = styled.button`
   border-radius: ${({ theme }) => theme.radius.md};
   font-size: ${({ theme }) => theme.font.size.md};
   font-weight: ${({ theme }) => theme.font.weight.medium};
-  cursor: pointer;
-  transition: ${({ theme }) => theme.transition.colors.normal};
   border: none;
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-`;
-
-export const ModalCancelButton = styled(ModalButton)`
-  background: ${({ theme }) => theme.colors.common.white};
+  background: transparent;
   color: ${({ theme }) => theme.colors.text.primary};
-  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  cursor: pointer;
+  margin-bottom: ${({ theme }) => theme.spacing.sm};
 
-  &:hover:not(:disabled) {
+  &:hover {
     background: ${({ theme }) => theme.colors.border.light};
-  }
-`;
-
-export const ModalCreateButton = styled(ModalButton)`
-  background: ${({ theme }) => theme.colors.primary.main};
-  color: ${({ theme }) => theme.colors.common.white};
-
-  &:hover:not(:disabled) {
-    background: ${({ theme }) => theme.colors.primary.hover};
   }
 `;

--- a/src/components/WishlistModal/WishlistModal.tsx
+++ b/src/components/WishlistModal/WishlistModal.tsx
@@ -11,60 +11,93 @@ import {
   ModalInputLabel,
   ModalCharCount,
   ModalFooter,
+  ModalButton,
   ModalCancelButton,
   ModalCreateButton,
+  ListScroll,
+  WishlistList,
+  WishlistItem,
+  WishlistItemThumb,
+  WishlistItemBody,
+  WishlistItemTitle,
+  WishlistItemCount,
+  ModalNewWishlistButton,
 } from './WishlistModal.styles';
 import { X } from 'lucide-react';
+import type { FavoriteResponseDTO } from '@/api/types';
 
 interface WishlistModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreate?: (name: string) => void;
+  /** 조회한 즐겨찾기 목록. 빈 배열이면 생성 폼만 표시 */
+  favorites?: FavoriteResponseDTO[];
+  isLoadingList?: boolean;
+  /** 목록에서 항목 클릭 시 해당 즐겨찾기에 숙소 추가 */
+  onAddToFavorite?: (favoriteId: number) => void | Promise<void>;
+  /** 새 위시리스트 이름으로 생성 (Promise 반환 시 완료 후 모달 닫힘) */
+  onCreate?: (name: string) => void | Promise<void>;
+  isLoading?: boolean;
 }
 
-const WishlistModal = ({ isOpen, onClose, onCreate }: WishlistModalProps) => {
-  const [wishlistName, setWishlistName] = useState('');
+const WishlistModal = ({
+  isOpen,
+  onClose,
+  favorites = [],
+  isLoadingList = false,
+  onAddToFavorite,
+  onCreate,
+  isLoading = false,
+}: WishlistModalProps) => {
+  const [name, setName] = useState('');
+  const [view, setView] = useState<'list' | 'create'>('list');
   const inputRef = useRef<HTMLInputElement>(null);
   const MAX_LENGTH = 50;
+
+  const hasFavorites = favorites.length > 0;
+  const showList = hasFavorites && view === 'list';
 
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
-      // 모달이 열릴 때 입력 필드에 포커스
-      setTimeout(() => {
-        inputRef.current?.focus();
-      }, 100);
+      setView(hasFavorites ? 'list' : 'create');
+      if (!hasFavorites) setTimeout(() => inputRef.current?.focus(), 100);
     } else {
       document.body.style.overflow = '';
-      setWishlistName('');
+      setName('');
+      setView('list');
     }
     return () => {
       document.body.style.overflow = '';
     };
-  }, [isOpen]);
+  }, [isOpen, hasFavorites]);
 
   useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onClose();
-      }
+    if (isOpen && !showList) setTimeout(() => inputRef.current?.focus(), 100);
+  }, [isOpen, showList]);
+
+  useEffect(() => {
+    const onEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) onClose();
     };
-    window.addEventListener('keydown', handleEscape);
-    return () => window.removeEventListener('keydown', handleEscape);
+    window.addEventListener('keydown', onEscape);
+    return () => window.removeEventListener('keydown', onEscape);
   }, [isOpen, onClose]);
 
-  const handleCreate = () => {
-    if (wishlistName.trim() && onCreate) {
-      onCreate(wishlistName.trim());
-      setWishlistName('');
-      onClose();
-    }
+  const handleCreate = async () => {
+    if (!name.trim() || !onCreate) return;
+    await onCreate(name.trim());
+    setName('');
+    onClose();
+  };
+
+  const handleAdd = async (favoriteId: number) => {
+    if (!onAddToFavorite) return;
+    await onAddToFavorite(favoriteId);
+    onClose();
   };
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
-      onClose();
-    }
+    if (e.target === e.currentTarget) onClose();
   };
 
   if (!isOpen) return null;
@@ -73,34 +106,87 @@ const WishlistModal = ({ isOpen, onClose, onCreate }: WishlistModalProps) => {
     <ModalOverlay onClick={handleOverlayClick}>
       <ModalContainer onClick={(e) => e.stopPropagation()}>
         <ModalHeader>
-          <ModalTitle>위시리스트 만들기</ModalTitle>
+          <ModalTitle>
+            {showList ? '위시리스트에 저장하기' : '위시리스트 만들기'}
+          </ModalTitle>
           <ModalCloseButton onClick={onClose}>
             <X size={20} />
           </ModalCloseButton>
         </ModalHeader>
         <ModalContent>
-          <ModalInputLabel>이름</ModalInputLabel>
-          <ModalInput
-            ref={inputRef}
-            type="text"
-            value={wishlistName}
-            onChange={(e) => setWishlistName(e.target.value)}
-            placeholder="위시리스트 이름을 입력하세요"
-            maxLength={MAX_LENGTH}
-          />
-          <ModalCharCount>
-            {wishlistName.length}/{MAX_LENGTH}자
-          </ModalCharCount>
+          {isLoadingList ? (
+            <div>목록 불러오는 중...</div>
+          ) : showList ? (
+            <>
+              <ListScroll>
+                <WishlistList>
+                  {favorites.map((fav) => (
+                    <WishlistItem
+                      key={fav.favoriteId}
+                      type="button"
+                      onClick={() => handleAdd(fav.favoriteId)}
+                    >
+                      <WishlistItemThumb
+                        $imageUrl={fav.coverImageUrl ?? null}
+                      />
+                      <WishlistItemBody>
+                        <WishlistItemTitle>{fav.name}</WishlistItemTitle>
+                        <WishlistItemCount>
+                          저장된 항목 {fav.accommodationCount}개
+                        </WishlistItemCount>
+                      </WishlistItemBody>
+                    </WishlistItem>
+                  ))}
+                </WishlistList>
+              </ListScroll>
+              <ModalNewWishlistButton
+                type="button"
+                onClick={() => setView('create')}
+              >
+                새로운 위시리스트 만들기
+              </ModalNewWishlistButton>
+            </>
+          ) : (
+            <>
+              {hasFavorites && (
+                <ModalButton
+                  type="button"
+                  onClick={() => setView('list')}
+                  style={{
+                    marginBottom: 12,
+                    background: 'transparent',
+                    color: 'inherit',
+                  }}
+                >
+                  ← 목록으로
+                </ModalButton>
+              )}
+              <ModalInputLabel>이름</ModalInputLabel>
+              <ModalInput
+                ref={inputRef}
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="위시리스트 이름을 입력하세요"
+                maxLength={MAX_LENGTH}
+              />
+              <ModalCharCount>
+                {name.length}/{MAX_LENGTH}자
+              </ModalCharCount>
+            </>
+          )}
         </ModalContent>
-        <ModalFooter>
-          <ModalCancelButton onClick={onClose}>취소</ModalCancelButton>
-          <ModalCreateButton
-            onClick={handleCreate}
-            disabled={!wishlistName.trim()}
-          >
-            새로 만들기
-          </ModalCreateButton>
-        </ModalFooter>
+        {!showList && !isLoadingList && (
+          <ModalFooter>
+            <ModalCancelButton onClick={onClose}>취소</ModalCancelButton>
+            <ModalCreateButton
+              onClick={handleCreate}
+              disabled={!name.trim() || isLoading}
+            >
+              {isLoading ? '만드는 중...' : '새로 만들기'}
+            </ModalCreateButton>
+          </ModalFooter>
+        )}
       </ModalContainer>
     </ModalOverlay>
   );

--- a/src/components/WishlistModal/WishlistModal.tsx
+++ b/src/components/WishlistModal/WishlistModal.tsx
@@ -60,7 +60,6 @@ const WishlistModal = ({
     if (isOpen) {
       document.body.style.overflow = 'hidden';
       setView(hasFavorites ? 'list' : 'create');
-      if (!hasFavorites) setTimeout(() => inputRef.current?.focus(), 100);
     } else {
       document.body.style.overflow = '';
       setName('');

--- a/src/pages/main/AccommodationSection.tsx
+++ b/src/pages/main/AccommodationSection.tsx
@@ -92,6 +92,7 @@ const AccommodationSection = ({
           {accommodations.map((accommodation) => (
             <AccommodationCard
               key={accommodation.id}
+              accommodationId={accommodation.id}
               image={accommodation.image}
               badge={accommodation.badge}
               title={accommodation.title}

--- a/src/pages/wishlist/RenameWishlistModal.styles.ts
+++ b/src/pages/wishlist/RenameWishlistModal.styles.ts
@@ -1,0 +1,77 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.overlay.default};
+  z-index: ${({ theme }) => theme.zIndex.modalOverlay};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const Container = styled.div`
+  background: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.xl};
+  width: 100%;
+  max-width: 400px;
+  padding: ${({ theme }) => theme.spacing.xl};
+  box-shadow: ${({ theme }) => theme.shadow.lg};
+`;
+
+export const Title = styled.h3`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  margin: 0 0 ${({ theme }) => theme.spacing.lg};
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  box-sizing: border-box;
+  margin-bottom: ${({ theme }) => theme.spacing.lg};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.colors.primary.main};
+  }
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const Button = styled.button`
+  padding: ${({ theme }) => theme.spacing.sm} ${({ theme }) => theme.spacing.lg};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  cursor: pointer;
+  border: none;
+  background: ${({ theme }) => theme.colors.border.light};
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.border.primary};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+export const PrimaryButton = styled(Button)`
+  background: ${({ theme }) => theme.colors.primary.main};
+  color: ${({ theme }) => theme.colors.common.white};
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.primary.hover};
+  }
+`;

--- a/src/pages/wishlist/RenameWishlistModal.tsx
+++ b/src/pages/wishlist/RenameWishlistModal.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Overlay,
+  Container,
+  Title,
+  Input,
+  Actions,
+  Button,
+  PrimaryButton,
+} from './RenameWishlistModal.styles';
+
+interface RenameWishlistModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentName: string;
+  onConfirm: (newName: string) => void | Promise<void>;
+  isLoading?: boolean;
+}
+
+const RenameWishlistModal = ({
+  isOpen,
+  onClose,
+  currentName,
+  onConfirm,
+  isLoading = false,
+}: RenameWishlistModalProps) => {
+  const [name, setName] = useState(currentName);
+
+  useEffect(() => {
+    if (isOpen) setName(currentName);
+  }, [isOpen, currentName]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    await onConfirm(trimmed);
+    onClose();
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const content = (
+    <Overlay onClick={handleOverlayClick}>
+      <Container onClick={(e) => e.stopPropagation()}>
+        <Title>이름 변경</Title>
+        <Input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="위시리스트 이름"
+          maxLength={50}
+        />
+        <Actions>
+          <Button type="button" onClick={onClose}>
+            취소
+          </Button>
+          <PrimaryButton
+            type="button"
+            onClick={handleSubmit}
+            disabled={!name.trim() || isLoading}
+          >
+            {isLoading ? '저장 중...' : '확인'}
+          </PrimaryButton>
+        </Actions>
+      </Container>
+    </Overlay>
+  );
+
+  return createPortal(content, document.body);
+};
+
+export default RenameWishlistModal;

--- a/src/pages/wishlist/WishlistDetailPage.styles.ts
+++ b/src/pages/wishlist/WishlistDetailPage.styles.ts
@@ -1,0 +1,228 @@
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { media } from '@/styles/media';
+
+export const PageContainer = styled.div`
+  padding-top: ${({ theme }) => theme.spacing['6xl']};
+  padding-bottom: ${({ theme }) => theme.spacing['5xl']};
+  max-width: ${({ theme }) => theme.layout.maxWidth};
+  margin: 0 auto;
+  padding-left: ${({ theme }) => theme.spacing['3xl']};
+  padding-right: ${({ theme }) => theme.spacing['3xl']};
+  background: ${({ theme }) => theme.colors.background.default};
+  min-height: 100vh;
+
+  ${media.mobile} {
+    padding-top: ${({ theme }) => theme.spacing['5xl']};
+    padding-left: ${({ theme }) => theme.spacing.lg};
+    padding-right: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const DetailHeader = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${({ theme }) => theme.spacing.xl};
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const BackButton = styled(Link)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  border: none;
+  background: ${({ theme }) => theme.colors.common.white};
+  color: ${({ theme }) => theme.colors.text.primary};
+  text-decoration: none;
+  flex-shrink: 0;
+  transition: ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.border.light};
+  }
+`;
+
+export const DetailTitle = styled.h1`
+  flex: 1;
+  min-width: 0;
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0;
+  text-align: center;
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.xl};
+    text-align: left;
+  }
+`;
+
+export const MenuButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: ${({ theme }) => theme.radius.full};
+  border: none;
+  background: ${({ theme }) => theme.colors.common.white};
+  color: ${({ theme }) => theme.colors.text.primary};
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 20px;
+  line-height: 1;
+  transition: ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.border.light};
+  }
+`;
+
+export const AccList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: ${({ theme }) => theme.spacing.xl};
+
+  ${media.tablet} {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  ${media.mobile} {
+    grid-template-columns: 1fr;
+    gap: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const AccCard = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  border-radius: ${({ theme }) => theme.radius.xl};
+  overflow: hidden;
+  background: ${({ theme }) => theme.colors.common.white};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  text-decoration: none;
+  color: inherit;
+  transition: ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    box-shadow: ${({ theme }) => theme.shadow.md};
+  }
+`;
+
+export const AccCardImageWrap = styled.div`
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1;
+`;
+
+export const AccCardImage = styled.div<{ $imageUrl?: string | null }>`
+  position: absolute;
+  inset: 0;
+  background: ${({ $imageUrl, theme }) =>
+    $imageUrl
+      ? `url(${$imageUrl}) center/cover`
+      : `linear-gradient(135deg, ${theme.colors.border.light} 0%, ${theme.colors.border.primary} 100%)`};
+`;
+
+export const AccCardBadge = styled.span`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.md};
+  left: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.xs} ${({ theme }) => theme.spacing.sm};
+  background: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const AccCardHeart = styled.button`
+  position: absolute;
+  top: ${({ theme }) => theme.spacing.md};
+  right: ${({ theme }) => theme.spacing.md};
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: ${({ theme }) => theme.colors.common.white};
+  color: ${({ theme }) => theme.colors.status.error};
+  cursor: pointer;
+  border-radius: ${({ theme }) => theme.radius.full};
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: ${({ theme }) => theme.transition.normal};
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+`;
+
+export const AccCardBody = styled.div`
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const AccCardTitleRow = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const AccCardTitle = styled.div`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  min-width: 0;
+  flex: 1;
+`;
+
+export const AccCardMeta = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  line-height: 1.4;
+`;
+
+export const AccCardPrice = styled.div`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+export const AccCardMemo = styled.div`
+  margin: 0 ${({ theme }) => theme.spacing.lg}
+    ${({ theme }) => theme.spacing.lg};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  background: ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  text-align: center;
+  pointer-events: none;
+`;
+
+export const EmptyState = styled.div`
+  padding: ${({ theme }) => theme.spacing['5xl']};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.md};
+`;
+
+export const LoadingState = styled.div`
+  padding: ${({ theme }) => theme.spacing['5xl']};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;

--- a/src/pages/wishlist/WishlistDetailPage.tsx
+++ b/src/pages/wishlist/WishlistDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ChevronLeft, MoreHorizontal, Heart } from 'lucide-react';
 import {
@@ -45,7 +45,7 @@ export default function WishlistDetailPage() {
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameLoading, setRenameLoading] = useState(false);
 
-  const loadDetail = async () => {
+  const loadDetail = useCallback(async () => {
     if (!favoriteId) return;
     setLoading(true);
     try {
@@ -56,11 +56,11 @@ export default function WishlistDetailPage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [favoriteId]);
 
   useEffect(() => {
     loadDetail();
-  }, [favoriteId]);
+  }, [loadDetail]);
 
   const handleRename = () => {
     setRenameOpen(true);

--- a/src/pages/wishlist/WishlistDetailPage.tsx
+++ b/src/pages/wishlist/WishlistDetailPage.tsx
@@ -163,9 +163,7 @@ export default function WishlistDetailPage() {
                 <AccCardMeta>
                   {[acc.city, acc.country].filter(Boolean).join(' · ')}
                 </AccCardMeta>
-                <AccCardPrice>
-                  {formatPrice(Number(acc.pricePerNight))}
-                </AccCardPrice>
+                <AccCardPrice>{formatPrice(acc.pricePerNight)}</AccCardPrice>
               </AccCardBody>
               <AccCardMemo>메모 추가</AccCardMemo>
             </AccCard>

--- a/src/pages/wishlist/WishlistDetailPage.tsx
+++ b/src/pages/wishlist/WishlistDetailPage.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ChevronLeft, MoreHorizontal, Heart } from 'lucide-react';
+import {
+  fetchFavoriteDetail,
+  updateFavorite,
+  deleteFavorite,
+  removeAccommodationFromFavorite,
+} from '@/api/favorite';
+import type { FavoriteDetailResponseDTO } from '@/api/types';
+import {
+  PageContainer,
+  DetailHeader,
+  BackButton,
+  DetailTitle,
+  MenuButton,
+  AccList,
+  AccCard,
+  AccCardImageWrap,
+  AccCardImage,
+  AccCardBadge,
+  AccCardHeart,
+  AccCardBody,
+  AccCardTitleRow,
+  AccCardTitle,
+  AccCardMeta,
+  AccCardPrice,
+  AccCardMemo,
+  EmptyState,
+  LoadingState,
+} from './WishlistDetailPage.styles';
+import WishlistSettingsModal from './WishlistSettingsModal';
+import RenameWishlistModal from './RenameWishlistModal';
+
+const formatPrice = (price: number): string => {
+  return `₩${price.toLocaleString('ko-KR')} / 박`;
+};
+
+export default function WishlistDetailPage() {
+  const { favoriteId } = useParams<{ favoriteId: string }>();
+  const navigate = useNavigate();
+  const [detail, setDetail] = useState<FavoriteDetailResponseDTO | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [renameLoading, setRenameLoading] = useState(false);
+
+  const loadDetail = async () => {
+    if (!favoriteId) return;
+    setLoading(true);
+    try {
+      const data = await fetchFavoriteDetail(favoriteId);
+      setDetail(data);
+    } catch {
+      setDetail(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDetail();
+  }, [favoriteId]);
+
+  const handleRename = () => {
+    setRenameOpen(true);
+  };
+
+  const handleRenameConfirm = async (newName: string) => {
+    if (!favoriteId) return;
+    setRenameLoading(true);
+    try {
+      await updateFavorite(favoriteId, { name: newName });
+      await loadDetail();
+      setRenameOpen(false);
+    } catch {
+      alert('이름 변경에 실패했습니다.');
+    } finally {
+      setRenameLoading(false);
+    }
+  };
+
+  const handleDelete = () => {
+    if (!favoriteId) return;
+    if (!window.confirm('이 위시리스트를 삭제하시겠습니까?')) return;
+    deleteFavorite(favoriteId)
+      .then(() => navigate('/wishlist'))
+      .catch(() => alert('삭제에 실패했습니다.'));
+  };
+
+  const handleRemoveAccommodation = async (
+    e: React.MouseEvent,
+    accommodationId: number,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!favoriteId) return;
+    try {
+      await removeAccommodationFromFavorite(
+        favoriteId,
+        String(accommodationId),
+      );
+      await loadDetail();
+    } catch {
+      alert('즐겨찾기에서 삭제에 실패했습니다.');
+    }
+  };
+
+  if (!favoriteId) {
+    return (
+      <PageContainer>
+        <LoadingState>잘못된 경로입니다.</LoadingState>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <DetailHeader>
+        <BackButton to="/wishlist">
+          <ChevronLeft size={24} />
+        </BackButton>
+        <DetailTitle>{detail?.name ?? '위시리스트'}</DetailTitle>
+        <MenuButton
+          type="button"
+          onClick={() => setSettingsOpen(true)}
+          aria-label="메뉴"
+        >
+          <MoreHorizontal size={24} />
+        </MenuButton>
+      </DetailHeader>
+
+      {loading && <LoadingState>불러오는 중...</LoadingState>}
+
+      {!loading && detail && detail.accommodations.length === 0 && (
+        <EmptyState>저장된 숙소가 없습니다.</EmptyState>
+      )}
+
+      {!loading && detail && detail.accommodations.length > 0 && (
+        <AccList>
+          {detail.accommodations.map((acc) => (
+            <AccCard
+              key={acc.accommodationId}
+              to={`/accommodation/${acc.accommodationId}`}
+            >
+              <AccCardImageWrap>
+                <AccCardImage $imageUrl={acc.imageUrl ?? null} />
+                <AccCardBadge>게스트 선호</AccCardBadge>
+                <AccCardHeart
+                  type="button"
+                  onClick={(e) =>
+                    handleRemoveAccommodation(e, acc.accommodationId)
+                  }
+                  aria-label="이 위시리스트에서 삭제"
+                >
+                  <Heart size={20} fill="currentColor" />
+                </AccCardHeart>
+              </AccCardImageWrap>
+              <AccCardBody>
+                <AccCardTitleRow>
+                  <AccCardTitle>{acc.title}</AccCardTitle>
+                </AccCardTitleRow>
+                <AccCardMeta>
+                  {[acc.city, acc.country].filter(Boolean).join(' · ')}
+                </AccCardMeta>
+                <AccCardPrice>
+                  {formatPrice(Number(acc.pricePerNight))}
+                </AccCardPrice>
+              </AccCardBody>
+              <AccCardMemo>메모 추가</AccCardMemo>
+            </AccCard>
+          ))}
+        </AccList>
+      )}
+
+      <WishlistSettingsModal
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        onRename={handleRename}
+        onDelete={handleDelete}
+      />
+
+      <RenameWishlistModal
+        isOpen={renameOpen}
+        onClose={() => setRenameOpen(false)}
+        currentName={detail?.name ?? ''}
+        onConfirm={handleRenameConfirm}
+        isLoading={renameLoading}
+      />
+    </PageContainer>
+  );
+}

--- a/src/pages/wishlist/WishlistPage.styles.ts
+++ b/src/pages/wishlist/WishlistPage.styles.ts
@@ -1,0 +1,99 @@
+import styled from 'styled-components';
+import { media } from '@/styles/media';
+
+export const PageContainer = styled.div`
+  padding-top: ${({ theme }) => theme.spacing['6xl']};
+  padding-bottom: ${({ theme }) => theme.spacing['5xl']};
+  max-width: ${({ theme }) => theme.layout.maxWidth};
+  margin: 0 auto;
+  padding-left: ${({ theme }) => theme.spacing['3xl']};
+  padding-right: ${({ theme }) => theme.spacing['3xl']};
+  background: ${({ theme }) => theme.colors.background.default};
+
+  ${media.mobile} {
+    padding-top: ${({ theme }) => theme.spacing['5xl']};
+    padding-left: ${({ theme }) => theme.spacing.lg};
+    padding-right: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const PageTitle = styled.h1`
+  font-size: ${({ theme }) => theme.font.size.xxl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0 0 ${({ theme }) => theme.spacing.xl};
+  text-align: center;
+
+  ${media.mobile} {
+    font-size: ${({ theme }) => theme.font.size.xl};
+    margin-bottom: ${({ theme }) => theme.spacing.lg};
+  }
+`;
+
+export const CardGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: ${({ theme }) => theme.spacing.lg};
+
+  ${media.mobile} {
+    grid-template-columns: repeat(2, 1fr);
+    gap: ${({ theme }) => theme.spacing.md};
+  }
+`;
+
+export const WishlistCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: ${({ theme }) => theme.radius.xl};
+  overflow: hidden;
+  background: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+  transition: ${({ theme }) => theme.transition.normal};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    box-shadow: ${({ theme }) => theme.shadow.md};
+  }
+`;
+
+export const WishlistCardImage = styled.div<{ $imageUrl?: string | null }>`
+  width: 100%;
+  aspect-ratio: 1;
+  background: ${({ $imageUrl, theme }) =>
+    $imageUrl
+      ? `url(${$imageUrl}) center/cover`
+      : `linear-gradient(135deg, ${theme.colors.border.light} 0%, ${theme.colors.border.primary} 100%)`};
+`;
+
+export const WishlistCardBody = styled.div`
+  padding: ${({ theme }) => theme.spacing.md};
+`;
+
+export const WishlistCardTitle = styled.div`
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin-bottom: 2px;
+`;
+
+export const WishlistCardSubtitle = styled.div`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const EmptyState = styled.div`
+  padding: ${({ theme }) => theme.spacing['5xl']}
+    ${({ theme }) => theme.spacing.xl};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.md};
+`;
+
+export const LoadingState = styled.div`
+  padding: ${({ theme }) => theme.spacing['5xl']}
+    ${({ theme }) => theme.spacing.xl};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;

--- a/src/pages/wishlist/WishlistPage.tsx
+++ b/src/pages/wishlist/WishlistPage.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchFavorites } from '@/api/favorite';
+import type { FavoriteResponseDTO } from '@/api/types';
+import {
+  PageContainer,
+  PageTitle,
+  CardGrid,
+  WishlistCard,
+  WishlistCardImage,
+  WishlistCardBody,
+  WishlistCardTitle,
+  WishlistCardSubtitle,
+  EmptyState,
+  LoadingState,
+} from './WishlistPage.styles';
+
+const WishlistPage = () => {
+  const [favorites, setFavorites] = useState<FavoriteResponseDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchFavorites()
+      .then((list) => {
+        if (!cancelled) setFavorites(list);
+      })
+      .catch(() => {
+        if (!cancelled) setFavorites([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <PageContainer>
+      <PageTitle>위시리스트</PageTitle>
+
+      {loading && <LoadingState>목록을 불러오는 중...</LoadingState>}
+
+      {!loading && favorites.length === 0 && (
+        <EmptyState>저장한 위시리스트가 없습니다.</EmptyState>
+      )}
+
+      {!loading && favorites.length > 0 && (
+        <CardGrid>
+          {favorites.map((fav) => (
+            <WishlistCard
+              key={fav.favoriteId}
+              as={Link}
+              to={`/wishlist/${fav.favoriteId}`}
+            >
+              <WishlistCardImage $imageUrl={fav.coverImageUrl ?? null} />
+              <WishlistCardBody>
+                <WishlistCardTitle>{fav.name}</WishlistCardTitle>
+                <WishlistCardSubtitle>
+                  저장된 항목 {fav.accommodationCount}개
+                </WishlistCardSubtitle>
+              </WishlistCardBody>
+            </WishlistCard>
+          ))}
+        </CardGrid>
+      )}
+    </PageContainer>
+  );
+};
+
+export default WishlistPage;

--- a/src/pages/wishlist/WishlistSettingsModal.styles.ts
+++ b/src/pages/wishlist/WishlistSettingsModal.styles.ts
@@ -1,0 +1,105 @@
+import styled from 'styled-components';
+
+export const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  background: ${({ theme }) => theme.colors.overlay.default};
+  z-index: ${({ theme }) => theme.zIndex.modalOverlay};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const Container = styled.div`
+  background: ${({ theme }) => theme.colors.common.white};
+  border-radius: ${({ theme }) => theme.radius.xl};
+  width: 100%;
+  max-width: 480px;
+  padding-top: ${({ theme }) => theme.spacing.xl};
+  padding-bottom: ${({ theme }) => theme.spacing.xl};
+  box-shadow: ${({ theme }) => theme.shadow.lg};
+  overflow: hidden;
+`;
+
+export const Header = styled.div`
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
+  align-items: center;
+  padding: 0 ${({ theme }) => theme.spacing.lg}
+    ${({ theme }) => theme.spacing.lg};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const Title = styled.h2`
+  grid-column: 2;
+  justify-self: center;
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  margin: 0;
+  text-align: center;
+`;
+
+export const CloseBtn = styled.button`
+  grid-column: 3;
+  justify-self: end;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.full};
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.text.primary};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.border.light};
+  }
+`;
+
+export const MenuList = styled.div`
+  padding: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const MenuItem = styled.button`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.lg};
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: transparent;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+  text-align: left;
+  transition: ${({ theme }) => theme.transition.normal};
+
+  & > span:nth-child(2) {
+    flex: 1;
+  }
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.border.light};
+  }
+
+  &:last-of-type {
+    color: ${({ theme }) => theme.colors.status.error};
+  }
+`;
+
+export const MenuIcon = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const Chevron = styled.span`
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: 14px;
+`;

--- a/src/pages/wishlist/WishlistSettingsModal.tsx
+++ b/src/pages/wishlist/WishlistSettingsModal.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { Pencil, Trash2, X } from 'lucide-react';
+import {
+  Overlay,
+  Container,
+  Header,
+  Title,
+  CloseBtn,
+  MenuList,
+  MenuItem,
+  MenuIcon,
+  Chevron,
+} from './WishlistSettingsModal.styles';
+
+interface WishlistSettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+const WishlistSettingsModal = ({
+  isOpen,
+  onClose,
+  onRename,
+  onDelete,
+}: WishlistSettingsModalProps) => {
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  const content = (
+    <Overlay onClick={handleOverlayClick}>
+      <Container onClick={(e) => e.stopPropagation()}>
+        <Header>
+          <Title>환경설정</Title>
+          <CloseBtn type="button" onClick={onClose}>
+            <X size={20} />
+          </CloseBtn>
+        </Header>
+        <MenuList>
+          <MenuItem
+            type="button"
+            onClick={() => {
+              onRename();
+              onClose();
+            }}
+          >
+            <MenuIcon>
+              <Pencil size={18} />
+            </MenuIcon>
+            <span>이름 변경</span>
+            <Chevron>&gt;</Chevron>
+          </MenuItem>
+          <MenuItem
+            type="button"
+            onClick={() => {
+              onDelete();
+              onClose();
+            }}
+          >
+            <MenuIcon>
+              <Trash2 size={18} />
+            </MenuIcon>
+            <span>삭제</span>
+            <Chevron>&gt;</Chevron>
+          </MenuItem>
+        </MenuList>
+      </Container>
+    </Overlay>
+  );
+
+  return createPortal(content, document.body);
+};
+
+export default WishlistSettingsModal;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,20 +1,20 @@
-import { createBrowserRouter } from "react-router-dom";
-import PublicLayout from "../layouts/PublicLayout/PublicLayout";
-import LandingPage from "../pages/landing/LandingPage";
-import MainPage from "../pages/main/MainPage";
-import AccommodationDetailPage from "../pages/accommodation/AccommodationDetailPage.tsx";
-import SearchPage from "../pages/search/SearchPage";
-import HostingPage from "../pages/hosting/HostingPage";
-import BecomeHostPage from "../pages/hosting/BecomeHostPage";
-import MyPage from "../pages/mypage/MyPage";
-import UserPage from "../pages/user/UserPage";
-import MessagePage from "../pages/chat/MessagePage";
-import AccountPage from "../pages/account/AccountPage";
-import ProfilePage from "../pages/profile/ProfilePage";
-import ProfileEditPage from "../pages/profile/edit/ProfileEditPage";
-import ReviewsPage from "../pages/profile/reviews/ReviewsPage";
-
-
+import { createBrowserRouter } from 'react-router-dom';
+import PublicLayout from '../layouts/PublicLayout/PublicLayout';
+import LandingPage from '../pages/landing/LandingPage';
+import MainPage from '../pages/main/MainPage';
+import AccommodationDetailPage from '../pages/accommodation/AccommodationDetailPage.tsx';
+import SearchPage from '../pages/search/SearchPage';
+import HostingPage from '../pages/hosting/HostingPage';
+import BecomeHostPage from '../pages/hosting/BecomeHostPage';
+// import MyPage from "../pages/mypage/MyPage";
+import UserPage from '../pages/user/UserPage';
+import MessagePage from '../pages/chat/MessagePage';
+import AccountPage from '../pages/account/AccountPage';
+import ProfilePage from '../pages/profile/ProfilePage';
+import ProfileEditPage from '../pages/profile/edit/ProfileEditPage';
+import ReviewsPage from '../pages/profile/reviews/ReviewsPage';
+import WishlistPage from '../pages/wishlist/WishlistPage';
+import WishlistDetailPage from '../pages/wishlist/WishlistDetailPage';
 
 export const router = createBrowserRouter([
   {
@@ -22,15 +22,17 @@ export const router = createBrowserRouter([
     element: <PublicLayout />,
     children: [
       { index: true, element: <MainPage /> },
-      { path: "landing", element: <LandingPage /> },
-      { path: "accommodation/:id", element: <AccommodationDetailPage /> },
-      { path: "search", element: <SearchPage /> },
-      { path: "messages", element: <MessagePage /> },
-      { path: "account", element: <AccountPage /> },
-      { path: "profile", element: <ProfilePage /> },
-      { path: "profile/edit", element: <ProfileEditPage /> },
-      { path: "profile/reviews", element: <ReviewsPage /> },
-      { path: "users/:id", element: <UserPage /> },
+      { path: 'landing', element: <LandingPage /> },
+      { path: 'accommodation/:id', element: <AccommodationDetailPage /> },
+      { path: 'search', element: <SearchPage /> },
+      { path: 'wishlist', element: <WishlistPage /> },
+      { path: 'wishlist/:favoriteId', element: <WishlistDetailPage /> },
+      { path: 'messages', element: <MessagePage /> },
+      { path: 'account', element: <AccountPage /> },
+      { path: 'profile', element: <ProfilePage /> },
+      { path: 'profile/edit', element: <ProfileEditPage /> },
+      { path: 'profile/reviews', element: <ReviewsPage /> },
+      { path: 'users/:id', element: <UserPage /> },
     ],
   },
   {


### PR DESCRIPTION
## 🔗 반영 브랜치

(#37 ) feature/favorite -> dev

## 📝 작업 내용

- 위시리스트 모달 컴포넌트 구현 (하트 클릭 시)
<img width="1560" height="787" alt="스크린샷 2026-03-12 144607" src="https://github.com/user-attachments/assets/cfed7e7c-851c-4389-8937-b164eb88aa24" />

- 사이드 바 위시리스트 연동

- 위시리스트 페이지 구현
<img width="1866" height="879" alt="image" src="https://github.com/user-attachments/assets/47e03b58-d6fb-40be-959d-420a3ed97a79" />

- 위시리스트 상세 페이지 구현
<img width="1854" height="883" alt="image" src="https://github.com/user-attachments/assets/502718c6-cd87-4b72-85b9-77b425c89be5" />

- 위시리스트 CRUD API 연동

## 💬 리뷰 요구사항(선택 사항)
- index.tsx 파일의 import MyPage from "../pages/mypage/MyPage"; 코드가 존재 하지 않는 경로를 import하는 오류가 발생하여 일단 주석처리 하였습니다. 
