### PR TITLE
Feat: 결제 페이지 토스 결제창 및 성공/실패 페이지 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@stomp/stompjs": "^7.3.0",
+        "@tosspayments/tosspayments-sdk": "^2.6.0",
         "axios": "^1.13.2",
         "date-fns": "^4.1.0",
         "lucide-react": "^0.546.0",
@@ -1421,6 +1422,12 @@
       "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.6.0.tgz",
+      "integrity": "sha512-d/9tCj5d+Jbj312bWYXo9dtGNzQaWRxTKWmw6rTwuDgw5g4mrJWV9dP9qiN6/x9PYaphbYDjxGenguHoVQXTGA==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2628,6 +2635,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eventsource": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
@@ -2636,13 +2650,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4024,34 +4031,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sockjs-client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
-      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "eventsource": "^2.0.2",
-        "faye-websocket": "^0.11.4",
-        "inherits": "^2.0.4",
-        "url-parse": "^1.5.10"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
-      }
-    },
-    "node_modules/sockjs-client/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4093,6 +4072,34 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^7.3.0",
+    "@tosspayments/tosspayments-sdk": "^2.6.0",
     "axios": "^1.13.2",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.546.0",

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -9,6 +9,7 @@ export type PaymentCreateRequest = {
 
 export type PaymentCreateResponse = {
   paymentId: number;
+  orderId: string;
   paymentStatus: string;
   paymentMethod: PaymentMethod;
   amount: string;
@@ -21,6 +22,8 @@ export async function createPayment(req: PaymentCreateRequest) {
 
 export type PaymentConfirmRequest = {
   paymentKey: string;
+  orderId: string;
+  amount: number;
 };
 
 export type PaymentResponse = {
@@ -34,14 +37,8 @@ export type PaymentResponse = {
   cancelledAt: string | null;
 };
 
-export async function confirmPayment(
-  paymentId: number,
-  req: PaymentConfirmRequest,
-) {
-  const res = await axios.post<PaymentResponse>(
-    `/api/payments/${paymentId}/confirm`,
-    req,
-  );
+export async function confirmPayment(req: PaymentConfirmRequest) {
+  const res = await axios.post<PaymentResponse>('/api/payments/confirm', req);
   return res.data;
 }
 

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -20,7 +20,7 @@ export async function createPayment(req: PaymentCreateRequest) {
     '/api/payments',
     req,
   );
-  return response;
+  return response.data;
 }
 
 export type PaymentConfirmRequest = {
@@ -52,5 +52,5 @@ export async function failPayment(paymentId: number) {
   const response = await client.post<PaymentResponse>(
     `/api/payments/${paymentId}/fail`,
   );
-  return response;
+  return response.data;
 }

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -15,12 +15,13 @@ export type PaymentCreateResponse = {
   amount: string;
 };
 
-export async function createPayment(req: PaymentCreateRequest) {
-  const response = await client.post<PaymentCreateResponse>(
+export async function createPayment(
+  req: PaymentCreateRequest,
+): Promise<PaymentCreateResponse> {
+  return client.post<PaymentCreateResponse, PaymentCreateResponse>(
     '/api/payments',
     req,
   );
-  return response.data;
 }
 
 export type PaymentConfirmRequest = {
@@ -40,17 +41,17 @@ export type PaymentResponse = {
   cancelledAt: string | null;
 };
 
-export async function confirmPayment(req: PaymentConfirmRequest) {
-  const response = await client.post<PaymentResponse>(
+export async function confirmPayment(
+  req: PaymentConfirmRequest,
+): Promise<PaymentResponse> {
+  return client.post<PaymentResponse, PaymentResponse>(
     '/api/payments/confirm',
     req,
   );
-  return response;
 }
 
-export async function failPayment(paymentId: number) {
-  const response = await client.post<PaymentResponse>(
+export async function failPayment(paymentId: number): Promise<PaymentResponse> {
+  return client.post<PaymentResponse, PaymentResponse>(
     `/api/payments/${paymentId}/fail`,
   );
-  return response.data;
 }

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -16,10 +16,10 @@ export type PaymentCreateResponse = {
 };
 
 export async function createPayment(req: PaymentCreateRequest) {
-  const response = (await client.post(
+  const response = await client.post<PaymentCreateResponse>(
     '/api/payments',
     req,
-  )) as PaymentCreateResponse;
+  );
   return response;
 }
 

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -41,10 +41,10 @@ export type PaymentResponse = {
 };
 
 export async function confirmPayment(req: PaymentConfirmRequest) {
-  const response = (await client.post(
+  const response = await client.post<PaymentResponse>(
     '/api/payments/confirm',
     req,
-  )) as PaymentResponse;
+  );
   return response;
 }
 

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -49,8 +49,8 @@ export async function confirmPayment(req: PaymentConfirmRequest) {
 }
 
 export async function failPayment(paymentId: number) {
-  const response = (await client.post(
+  const response = await client.post<PaymentResponse>(
     `/api/payments/${paymentId}/fail`,
-  )) as PaymentResponse;
+  );
   return response;
 }

--- a/src/api/payment.ts
+++ b/src/api/payment.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import client from './client';
 
 export type PaymentMethod = 'MOCK' | 'CARD' | 'EASY_PAY';
 
@@ -16,8 +16,11 @@ export type PaymentCreateResponse = {
 };
 
 export async function createPayment(req: PaymentCreateRequest) {
-  const res = await axios.post<PaymentCreateResponse>('/api/payments', req);
-  return res.data;
+  const response = (await client.post(
+    '/api/payments',
+    req,
+  )) as PaymentCreateResponse;
+  return response;
 }
 
 export type PaymentConfirmRequest = {
@@ -38,13 +41,16 @@ export type PaymentResponse = {
 };
 
 export async function confirmPayment(req: PaymentConfirmRequest) {
-  const res = await axios.post<PaymentResponse>('/api/payments/confirm', req);
-  return res.data;
+  const response = (await client.post(
+    '/api/payments/confirm',
+    req,
+  )) as PaymentResponse;
+  return response;
 }
 
 export async function failPayment(paymentId: number) {
-  const res = await axios.post<PaymentResponse>(
+  const response = (await client.post(
     `/api/payments/${paymentId}/fail`,
-  );
-  return res.data;
+  )) as PaymentResponse;
+  return response;
 }

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -86,10 +86,10 @@ export default function PaymentFailPage() {
         </PaymentFailSummaryCard>
       )}
 
-      {code && (
+      {(code || message) && (
         <PaymentFailNotice>
-          <div>• 오류 코드: {code}</div>
-          {message && <div>• 상세 메시지: {message}</div>}
+          {code && <div>• 오류 코드: {code}</div>}
+          {message && <div>• 안내 메시지: {message}</div>}
         </PaymentFailNotice>
       )}
 
@@ -100,6 +100,8 @@ export default function PaymentFailPage() {
           $disabled={!canRetry}
           onClick={() => {
             if (!bookingId) return;
+
+            // TODO: navigate(-!) 대신 bookingId 기반 재결제 진입 경로로 교체
             navigate(-1);
           }}
         >

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -34,6 +34,13 @@ export default function PaymentFailPage() {
     return !!bookingId && !!accommodationId;
   }, [bookingId, accommodationId]);
 
+  const parsedAmount = useMemo(() => {
+    if (!amount) return null;
+
+    const value = Number(amount);
+    return Number.isFinite(value) ? value : null;
+  }, [amount]);
+
   return (
     <PaymentFailPageContainer>
       <PaymentFailTitle>결제에 실패했습니다</PaymentFailTitle>
@@ -44,7 +51,7 @@ export default function PaymentFailPage() {
         진행해주세요.
       </PaymentFailDescription>
 
-      {(title || checkIn || checkOut || guests || amount) && (
+      {(title || checkIn || checkOut || guests || parsedAmount !== null) && (
         <PaymentFailSummaryCard>
           <PaymentFailSummaryTitle>예약 정보</PaymentFailSummaryTitle>
 
@@ -76,11 +83,11 @@ export default function PaymentFailPage() {
             </PaymentFailSummaryRow>
           )}
 
-          {amount && (
+          {parsedAmount !== null && (
             <PaymentFailSummaryRow>
               <PaymentFailSummaryLabel>결제 예정 금액</PaymentFailSummaryLabel>
               <PaymentFailSummaryValue>
-                ₩{Number(amount).toLocaleString()}
+                ₩{parsedAmount.toLocaleString()}
               </PaymentFailSummaryValue>
             </PaymentFailSummaryRow>
           )}

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -15,6 +15,8 @@ export default function PaymentFailPage() {
   const [sp] = useSearchParams();
 
   const bookingId = sp.get('bookingId');
+  const code = sp.get('code');
+  const message = sp.get('message');
 
   const canRetry = useMemo(() => {
     return !!bookingId;
@@ -25,21 +27,25 @@ export default function PaymentFailPage() {
       <PaymentFailTitle>결제에 실패했습니다</PaymentFailTitle>
 
       <PaymentFailDescription>
-        네트워크 문제 또는 결제 과정에서 오류가 발생했을 수 있어요.
+        {message ??
+          '네트워크 문제 또는 결제 과정에서 오류가 발생했을 수 있어요.'}
         <br />
         다시 시도하거나, 문제가 계속되면 잠시 후 재시도해주세요.
       </PaymentFailDescription>
 
+      {code && (
+        <PaymentFailNotice>
+          <div>• 오류 코드: {code}</div>
+        </PaymentFailNotice>
+      )}
+
       <PaymentFailButtonGroup>
-        {/* 결제 재시도: 다시 PaymentPage로 */}
         <PaymentFailRetryButton
           type="button"
           disabled={!canRetry}
           $disabled={!canRetry}
           onClick={() => {
             if (!bookingId) return;
-
-            // 간단 재시도: 뒤로 가기(= PaymentPage로 복귀)
             navigate(-1);
           }}
         >
@@ -48,7 +54,6 @@ export default function PaymentFailPage() {
 
         <PaymentFailLinkButton to="/">홈으로</PaymentFailLinkButton>
 
-        {/* 예약 상세로 이동 */}
         {bookingId && (
           <PaymentFailLinkButton to={`/bookings/${bookingId}`}>
             예약 상세 보기

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -16,7 +16,6 @@ export default function PaymentFailPage() {
 
   const bookingId = sp.get('bookingId');
   const code = sp.get('code');
-  const message = sp.get('message');
 
   const canRetry = useMemo(() => {
     return !!bookingId;
@@ -27,10 +26,10 @@ export default function PaymentFailPage() {
       <PaymentFailTitle>결제에 실패했습니다</PaymentFailTitle>
 
       <PaymentFailDescription>
-        {message ??
-          '네트워크 문제 또는 결제 과정에서 오류가 발생했을 수 있어요.'}
+        결제에 실패했지만 예약은 아직 유지되고 있어요.
         <br />
-        다시 시도하거나, 문제가 계속되면 잠시 후 재시도해주세요.
+        약 10분 동안 예약이 대기 상태로 유지됩니다.
+        <br />그 전에 다시 결제를 진행해주세요.
       </PaymentFailDescription>
 
       {code && (
@@ -49,7 +48,7 @@ export default function PaymentFailPage() {
             navigate(-1);
           }}
         >
-          결제 다시 시도
+          다시 결제하기
         </PaymentFailRetryButton>
 
         <PaymentFailLinkButton to="/">홈으로</PaymentFailLinkButton>
@@ -62,9 +61,9 @@ export default function PaymentFailPage() {
       </PaymentFailButtonGroup>
 
       <PaymentFailNotice>
-        <div>• 결제가 실패해도 예약이 자동으로 확정되진 않아요.</div>
+        <div>• 결제가 완료되지 않으면 예약은 자동으로 취소됩니다.</div>
         <div>
-          • 문제가 지속되면 결제 수단을 바꾸거나 잠시 후 다시 시도해보세요.
+          • 문제가 지속되면 결제 수단을 변경하거나 잠시 후 다시 시도해주세요.
         </div>
       </PaymentFailNotice>
     </PaymentFailPageContainer>

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -20,6 +20,7 @@ export default function PaymentFailPage() {
   const [sp] = useSearchParams();
 
   const bookingId = sp.get('bookingId');
+  const accommodationId = sp.get('accommodationId');
   const code = sp.get('code');
   const message = sp.get('message');
 
@@ -30,8 +31,8 @@ export default function PaymentFailPage() {
   const amount = sp.get('amount');
 
   const canRetry = useMemo(() => {
-    return !!bookingId;
-  }, [bookingId]);
+    return !!bookingId && !!accommodationId;
+  }, [bookingId, accommodationId]);
 
   return (
     <PaymentFailPageContainer>
@@ -99,10 +100,16 @@ export default function PaymentFailPage() {
           disabled={!canRetry}
           $disabled={!canRetry}
           onClick={() => {
-            if (!bookingId) return;
+            if (!bookingId || !accommodationId) return;
 
-            // TODO: navigate(-!) 대신 bookingId 기반 재결제 진입 경로로 교체
-            navigate(-1);
+            const params = new URLSearchParams();
+            params.set('bookingId', bookingId);
+
+            if (checkIn) params.set('checkin', checkIn);
+            if (checkOut) params.set('checkout', checkOut);
+            if (guests) params.set('numberOfGuests', guests);
+
+            navigate(`/payment/retry/${accommodationId}?${params.toString()}`);
           }}
         >
           다시 결제하기

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -8,6 +8,11 @@ import {
   PaymentFailPageContainer,
   PaymentFailRetryButton,
   PaymentFailTitle,
+  PaymentFailSummaryCard,
+  PaymentFailSummaryTitle,
+  PaymentFailSummaryRow,
+  PaymentFailSummaryLabel,
+  PaymentFailSummaryValue,
 } from './paymentFail.styles';
 
 export default function PaymentFailPage() {
@@ -16,6 +21,13 @@ export default function PaymentFailPage() {
 
   const bookingId = sp.get('bookingId');
   const code = sp.get('code');
+  const message = sp.get('message');
+
+  const title = sp.get('title');
+  const checkIn = sp.get('checkin');
+  const checkOut = sp.get('checkout');
+  const guests = sp.get('guests');
+  const amount = sp.get('amount');
 
   const canRetry = useMemo(() => {
     return !!bookingId;
@@ -27,14 +39,57 @@ export default function PaymentFailPage() {
 
       <PaymentFailDescription>
         결제에 실패했지만 예약은 아직 유지되고 있어요.
-        <br />
-        약 10분 동안 예약이 대기 상태로 유지됩니다.
-        <br />그 전에 다시 결제를 진행해주세요.
+        <br />약 10분 동안 예약이 대기 상태로 유지됩니다. 그 전에 다시 결제를
+        진행해주세요.
       </PaymentFailDescription>
+
+      {(title || checkIn || checkOut || guests || amount) && (
+        <PaymentFailSummaryCard>
+          <PaymentFailSummaryTitle>예약 정보</PaymentFailSummaryTitle>
+
+          {title && (
+            <PaymentFailSummaryRow>
+              <PaymentFailSummaryLabel>숙소</PaymentFailSummaryLabel>
+              <PaymentFailSummaryValue>{title}</PaymentFailSummaryValue>
+            </PaymentFailSummaryRow>
+          )}
+
+          {checkIn && (
+            <PaymentFailSummaryRow>
+              <PaymentFailSummaryLabel>체크인</PaymentFailSummaryLabel>
+              <PaymentFailSummaryValue>{checkIn}</PaymentFailSummaryValue>
+            </PaymentFailSummaryRow>
+          )}
+
+          {checkOut && (
+            <PaymentFailSummaryRow>
+              <PaymentFailSummaryLabel>체크아웃</PaymentFailSummaryLabel>
+              <PaymentFailSummaryValue>{checkOut}</PaymentFailSummaryValue>
+            </PaymentFailSummaryRow>
+          )}
+
+          {guests && (
+            <PaymentFailSummaryRow>
+              <PaymentFailSummaryLabel>게스트</PaymentFailSummaryLabel>
+              <PaymentFailSummaryValue>{guests}명</PaymentFailSummaryValue>
+            </PaymentFailSummaryRow>
+          )}
+
+          {amount && (
+            <PaymentFailSummaryRow>
+              <PaymentFailSummaryLabel>결제 예정 금액</PaymentFailSummaryLabel>
+              <PaymentFailSummaryValue>
+                ₩{Number(amount).toLocaleString()}
+              </PaymentFailSummaryValue>
+            </PaymentFailSummaryRow>
+          )}
+        </PaymentFailSummaryCard>
+      )}
 
       {code && (
         <PaymentFailNotice>
           <div>• 오류 코드: {code}</div>
+          {message && <div>• 상세 메시지: {message}</div>}
         </PaymentFailNotice>
       )}
 

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
+import { useAuth } from '@/contexts/AuthContext';
 
 import { useAccommodationStore } from '@/store/accommodationStore';
 import { nightsBetween, calcTotal } from '../../utils/price';
@@ -35,6 +36,7 @@ export default function PaymentPage() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const { detail, loading, error, load } = useAccommodationStore();
+  const { user } = useAuth();
 
   const [paymentMethod, setPaymentMethod] = useState<UiPaymentMethod>('CARD');
   const [hostMessage, setHostMessage] = useState('');
@@ -175,7 +177,7 @@ export default function PaymentPage() {
         orderName: `${detail.title} 예약`,
         successUrl: `${frontBaseUrl}/payment/success?${commonParams.toString()}`,
         failUrl: `${frontBaseUrl}/payment/fail?${commonParams.toString()}`,
-        customerName: '고객',
+        customerName: user?.nickname ?? '고객',
       });
     } catch (e: unknown) {
       let msg = '예약/결제 요청에 실패했습니다.';

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -148,8 +148,8 @@ export default function PaymentPage() {
         },
         orderId: payment.orderId,
         orderName: `${detail.title} 예약`,
-        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}`,
-        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}`,
+        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}&title=${encodeURIComponent(detail.title)}&amount=${payment.amount}`,
+        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}&title=${encodeURIComponent(detail.title)}&amount=${payment.amount}`,
         customerName: '고객',
       });
     } catch (e: unknown) {

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
 
@@ -31,6 +31,7 @@ const frontBaseUrl =
   import.meta.env.VITE_FRONT_BASE_URL ?? window.location.origin;
 
 export default function PaymentPage() {
+  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const { detail, loading, error, load } = useAccommodationStore();
@@ -114,6 +115,9 @@ export default function PaymentPage() {
   const handleSubmit = async () => {
     if (!canSubmit) return;
 
+    let bookingIdForNav: number | null = null;
+    let paymentIdForNav: number | null = null;
+
     try {
       setSubmitting(true);
       setSubmitError(null);
@@ -129,15 +133,29 @@ export default function PaymentPage() {
         numberOfGuests: guests,
       });
 
+      bookingIdForNav = booking.bookingId;
+
       const payment = await createPayment({
         bookingId: booking.bookingId,
         paymentMethod: toApiPaymentMethod(paymentMethod),
       });
 
+      paymentIdForNav = payment.paymentId;
+
       const tossPayments = await loadTossPayments(tossClientKey);
 
       const paymentSdk = tossPayments.payment({
         customerKey: `booking_${booking.bookingId}`,
+      });
+
+      const commonParams = new URLSearchParams({
+        bookingId: String(booking.bookingId),
+        paymentId: String(payment.paymentId),
+        checkin: String(checkIn),
+        checkout: String(checkOut),
+        guests: String(guests),
+        title: detail.title,
+        amount: String(payment.amount),
       });
 
       await paymentSdk.requestPayment({
@@ -148,8 +166,8 @@ export default function PaymentPage() {
         },
         orderId: payment.orderId,
         orderName: `${detail.title} 예약`,
-        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}&title=${encodeURIComponent(detail.title)}&amount=${payment.amount}`,
-        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}&title=${encodeURIComponent(detail.title)}&amount=${payment.amount}`,
+        successUrl: `${frontBaseUrl}/payment/success?${commonParams.toString()}`,
+        failUrl: `${frontBaseUrl}/payment/fail?${commonParams.toString()}`,
         customerName: '고객',
       });
     } catch (e: unknown) {
@@ -182,6 +200,25 @@ export default function PaymentPage() {
         if (import.meta.env.DEV) {
           console.error('[PaymentPage] Unknown error:', String(e));
         }
+      }
+
+      if (bookingIdForNav) {
+        const params = new URLSearchParams();
+        params.set('bookingId', String(bookingIdForNav));
+
+        if (paymentIdForNav) {
+          params.set('paymentId', String(paymentIdForNav));
+        }
+
+        params.set('checkin', String(checkIn));
+        params.set('checkout', String(checkOut));
+        params.set('guests', String(guests));
+        params.set('title', detail.title);
+        params.set('amount', String(price?.total ?? ''));
+        params.set('message', msg);
+
+        navigate(`/payment/fail?${params.toString()}`);
+        return;
       }
 
       setSubmitError(msg);

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -78,6 +78,39 @@ export default function PaymentPage() {
     return 'EASY_PAY';
   };
 
+  const getUserFriendlyErrorMessage = (
+    status?: number,
+    serverMessage?: string,
+  ) => {
+    const message = serverMessage ?? '';
+
+    if (status === 401) {
+      return '로그인이 필요합니다.';
+    }
+
+    if (status === 409) {
+      if (message.includes('겹치는 예약')) {
+        return '선택한 날짜에 이미 예약이 있어요. 다른 날짜를 선택해주세요.';
+      }
+
+      if (message.includes('이미 결제 진행 중')) {
+        return '이미 결제가 진행 중인 예약입니다. 잠시 후 다시 확인해주세요.';
+      }
+
+      if (message.includes('이미 결제 완료된 예약')) {
+        return '이미 결제가 완료된 예약입니다.';
+      }
+
+      return '요청을 처리할 수 없어요. 입력한 정보를 다시 확인해주세요.';
+    }
+
+    if (status === 400) {
+      return '입력한 정보가 올바르지 않습니다. 다시 확인해주세요.';
+    }
+
+    return message || '예약/결제 요청에 실패했습니다.';
+  };
+
   const handleSubmit = async () => {
     if (!canSubmit) return;
 
@@ -124,14 +157,14 @@ export default function PaymentPage() {
 
       if (axios.isAxiosError<{ message?: string }>(e)) {
         const status = e.response?.status;
-        msg =
-          status === 401
-            ? '로그인이 필요합니다.'
-            : (e.response?.data?.message ?? msg);
+        const serverMessage = e.response?.data?.message;
+
+        msg = getUserFriendlyErrorMessage(status, serverMessage);
 
         if (import.meta.env.DEV) {
           console.error('[PaymentPage] AxiosError:', {
             status,
+            serverMessage,
             message: e.message,
             url: e.config?.url,
             method: e.config?.method,

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
+import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
 
 import { useAccommodationStore } from '@/store/accommodationStore';
 import { nightsBetween, calcTotal } from '../../utils/price';
@@ -16,8 +17,6 @@ import RequestConfirmSection from './components/RequestConfirmSection';
 import { createBooking } from '@/api/booking';
 import {
   createPayment,
-  confirmPayment,
-  failPayment,
   type PaymentMethod as ApiPaymentMethod,
 } from '@/api/payment';
 
@@ -27,15 +26,16 @@ import {
   SubmitErrorBox,
 } from './payment.styles';
 
+const tossClientKey = import.meta.env.VITE_TOSS_CLIENT_KEY;
+const frontBaseUrl =
+  import.meta.env.VITE_FRONT_BASE_URL ?? window.location.origin;
+
 export default function PaymentPage() {
   const { id } = useParams<{ id: string }>();
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { detail, loading, error, load } = useAccommodationStore();
 
-  /** 결제수단 */
   const [paymentMethod, setPaymentMethod] = useState<UiPaymentMethod>('CARD');
-
   const [hostMessage, setHostMessage] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -73,25 +73,22 @@ export default function PaymentPage() {
     guests <= detail.maxGuests &&
     !submitting;
 
-  /** UI → 서버 PaymentMethod 매핑 */
   const toApiPaymentMethod = (m: UiPaymentMethod): ApiPaymentMethod => {
     if (m === 'CARD') return 'CARD';
-    // NAVERPAY / KAKAOPAY는 서버에서는 EASY_PAY
     return 'EASY_PAY';
   };
 
-  /** 예약 + 결제 생성 */
   const handleSubmit = async () => {
     if (!canSubmit) return;
-
-    let bookingIdForNav: number | null = null;
-    let paymentIdForNav: number | null = null;
 
     try {
       setSubmitting(true);
       setSubmitError(null);
 
-      // 1) 예약 생성
+      if (!tossClientKey) {
+        throw new Error('토스 클라이언트 키가 설정되지 않았습니다.');
+      }
+
       const booking = await createBooking({
         accommodationId: Number(id),
         checkInDate: checkIn!,
@@ -99,46 +96,32 @@ export default function PaymentPage() {
         numberOfGuests: guests,
       });
 
-      bookingIdForNav = booking.bookingId;
-
-      // 2) 결제 생성
       const payment = await createPayment({
         bookingId: booking.bookingId,
         paymentMethod: toApiPaymentMethod(paymentMethod),
       });
 
-      paymentIdForNav = payment.paymentId;
+      const tossPayments = await loadTossPayments(tossClientKey);
 
-      // 3) 결제 confirm (PG 연동 전이라 임시 키 생성)
-      const mockPaymentKey = `MOCK_${payment.paymentId}_${Date.now()}`;
+      const paymentSdk = tossPayments.payment({
+        customerKey: `booking_${booking.bookingId}`,
+      });
 
-      try {
-        await confirmPayment(payment.paymentId, {
-          paymentKey: mockPaymentKey,
-        });
-
-        // 결제 성공 페이지로 이동
-        navigate(
-          `/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
-        );
-      } catch {
-        // confirm 실패 → failPayment 호출(백엔드 상태 FAIL로)
-        try {
-          await failPayment(payment.paymentId);
-        } catch (failErr) {
-          // failPayment도 실패할 수 있으니 로그 남김
-          console.error('failPayment 호출 실패:', failErr);
-        }
-
-        // 실패 페이지로 이동
-        navigate(
-          `/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
-        );
-      }
+      await paymentSdk.requestPayment({
+        method: 'CARD',
+        amount: {
+          currency: 'KRW',
+          value: Number(payment.amount),
+        },
+        orderId: payment.orderId,
+        orderName: `${detail.title} 예약`,
+        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
+        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
+        customerName: '고객',
+      });
     } catch (e: unknown) {
       let msg = '예약/결제 요청에 실패했습니다.';
 
-      // createBooking / createPayment 단계에서의 에러
       if (axios.isAxiosError<{ message?: string }>(e)) {
         const status = e.response?.status;
         msg =
@@ -146,7 +129,6 @@ export default function PaymentPage() {
             ? '로그인이 필요합니다.'
             : (e.response?.data?.message ?? msg);
 
-        // 민감 정보 노출 방지: DEV에서만 최소 정보 로그
         if (import.meta.env.DEV) {
           console.error('[PaymentPage] AxiosError:', {
             status,
@@ -155,27 +137,20 @@ export default function PaymentPage() {
             method: e.config?.method,
           });
         }
+      } else if (e instanceof Error) {
+        msg = e.message;
+
+        if (import.meta.env.DEV) {
+          console.error('[PaymentPage] Error:', e.message);
+        }
       } else {
         msg = '알 수 없는 오류가 발생했습니다.';
 
-        // DEV에서만 로그 (객체 전체 말고 메시지 위주)
         if (import.meta.env.DEV) {
           console.error('[PaymentPage] Unknown error:', String(e));
         }
       }
 
-      // 예약이 만들어진 상태면(Booking-PENDING) 실패 페이지로 보내서 재결제 안내
-      if (bookingIdForNav) {
-        const params = new URLSearchParams();
-        params.set('bookingId', String(bookingIdForNav));
-
-        if (paymentIdForNav) {
-          params.set('paymentId', String(paymentIdForNav));
-        }
-        navigate(`/payment/fail?${params.toString()}`);
-        return;
-      }
-      // 예약도 못 만든 경우만 현재 페이지에 에러 표시
       setSubmitError(msg);
     } finally {
       setSubmitting(false);
@@ -184,7 +159,6 @@ export default function PaymentPage() {
 
   return (
     <PaymentPageLayout>
-      {/* 왼쪽: 숙소 요약 */}
       <BookingSummaryCard
         title={detail.title}
         thumbnailUrl={detail.images?.[0]?.imageUrl}
@@ -198,7 +172,6 @@ export default function PaymentPage() {
         total={price?.total}
       />
 
-      {/* 오른쪽: 결제 영역 */}
       <PaymentContent>
         <PaymentMethodSection
           value={paymentMethod}

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -41,6 +41,8 @@ export default function PaymentPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  const retryBookingId = searchParams.get('bookingId');
+
   const checkIn = searchParams.get('checkin');
   const checkOut = searchParams.get('checkout');
   const guests = Number(searchParams.get('numberOfGuests') ?? 1);
@@ -115,7 +117,9 @@ export default function PaymentPage() {
   const handleSubmit = async () => {
     if (!canSubmit) return;
 
-    let bookingIdForNav: number | null = null;
+    let bookingIdForNav: number | null = retryBookingId
+      ? Number(retryBookingId)
+      : null;
     let paymentIdForNav: number | null = null;
 
     try {
@@ -126,17 +130,19 @@ export default function PaymentPage() {
         throw new Error('토스 클라이언트 키가 설정되지 않았습니다.');
       }
 
-      const booking = await createBooking({
-        accommodationId: Number(id),
-        checkInDate: checkIn!,
-        checkOutDate: checkOut!,
-        numberOfGuests: guests,
-      });
+      if (!bookingIdForNav) {
+        const booking = await createBooking({
+          accommodationId: Number(id),
+          checkInDate: checkIn!,
+          checkOutDate: checkOut!,
+          numberOfGuests: guests,
+        });
 
-      bookingIdForNav = booking.bookingId;
+        bookingIdForNav = booking.bookingId;
+      }
 
       const payment = await createPayment({
-        bookingId: booking.bookingId,
+        bookingId: bookingIdForNav,
         paymentMethod: toApiPaymentMethod(paymentMethod),
       });
 
@@ -145,12 +151,13 @@ export default function PaymentPage() {
       const tossPayments = await loadTossPayments(tossClientKey);
 
       const paymentSdk = tossPayments.payment({
-        customerKey: `booking_${booking.bookingId}`,
+        customerKey: `booking_${bookingIdForNav}`,
       });
 
       const commonParams = new URLSearchParams({
-        bookingId: String(booking.bookingId),
+        bookingId: String(bookingIdForNav),
         paymentId: String(payment.paymentId),
+        accommodationId: String(id),
         checkin: String(checkIn),
         checkout: String(checkOut),
         guests: String(guests),
@@ -205,6 +212,7 @@ export default function PaymentPage() {
       if (bookingIdForNav) {
         const params = new URLSearchParams();
         params.set('bookingId', String(bookingIdForNav));
+        params.set('accommodationId', String(id));
 
         if (paymentIdForNav) {
           params.set('paymentId', String(paymentIdForNav));

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -148,8 +148,8 @@ export default function PaymentPage() {
         },
         orderId: payment.orderId,
         orderName: `${detail.title} 예약`,
-        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
-        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}`,
+        successUrl: `${frontBaseUrl}/payment/success?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}`,
+        failUrl: `${frontBaseUrl}/payment/fail?bookingId=${booking.bookingId}&paymentId=${payment.paymentId}&checkin=${checkIn}&checkout=${checkOut}&guests=${guests}`,
         customerName: '고객',
       });
     } catch (e: unknown) {

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -34,12 +34,16 @@ export default function PaymentSuccessPage() {
   useEffect(() => {
     const runConfirm = async () => {
       if (!paymentKey || !orderId || !amount) {
-        navigate(
-          `/payment/fail?bookingId=${bookingId ?? ''}&paymentId=${paymentId ?? ''}&message=${encodeURIComponent(
-            '결제 승인에 필요한 정보가 없습니다.',
-          )}`,
-          { replace: true },
-        );
+        const failParams = new URLSearchParams(sp.toString());
+        failParams.set('message', '결제 승인에 필요한 정보가 없습니다.');
+
+        // fail 페이지에서 불필요한 값 제거
+        failParams.delete('paymentKey');
+        failParams.delete('orderId');
+
+        navigate(`/payment/fail?${failParams.toString()}`, {
+          replace: true,
+        });
         return;
       }
 

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import axios from 'axios';
+
+import { confirmPayment } from '@/api/payment';
 import {
   PaymentSuccessContainer,
   PaymentSuccessTitle,
@@ -9,25 +13,82 @@ import {
 
 export default function PaymentSuccessPage() {
   const [sp] = useSearchParams();
+
   const bookingId = sp.get('bookingId');
+  const paymentKey = sp.get('paymentKey');
+  const orderId = sp.get('orderId');
+  const amount = sp.get('amount');
+
+  const [confirming, setConfirming] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const runConfirm = async () => {
+      if (!paymentKey || !orderId || !amount) {
+        setErrorMessage('결제 승인에 필요한 정보가 없습니다.');
+        setConfirming(false);
+        return;
+      }
+
+      try {
+        await confirmPayment({
+          paymentKey,
+          orderId,
+          amount: Number(amount),
+        });
+      } catch (e: unknown) {
+        if (axios.isAxiosError<{ message?: string }>(e)) {
+          setErrorMessage(
+            e.response?.data?.message ?? '결제 승인 처리에 실패했습니다.',
+          );
+        } else if (e instanceof Error) {
+          setErrorMessage(e.message);
+        } else {
+          setErrorMessage('결제 승인 처리 중 오류가 발생했습니다.');
+        }
+      } finally {
+        setConfirming(false);
+      }
+    };
+
+    runConfirm();
+  }, [paymentKey, orderId, amount]);
+
+  const title = errorMessage
+    ? '결제 승인에 실패했습니다'
+    : confirming
+      ? '결제 승인 중입니다'
+      : '결제가 완료되었습니다';
+
+  const description = errorMessage
+    ? errorMessage
+    : confirming
+      ? '결제 정보를 확인하고 있어요. 잠시만 기다려주세요.'
+      : '예약이 정상적으로 접수되었어요.';
 
   return (
     <PaymentSuccessContainer>
-      <PaymentSuccessTitle>결제가 완료되었습니다</PaymentSuccessTitle>
+      <PaymentSuccessTitle>{title}</PaymentSuccessTitle>
 
-      <PaymentSuccessDescription>
-        예약이 정상적으로 접수되었어요.
-      </PaymentSuccessDescription>
+      <PaymentSuccessDescription>{description}</PaymentSuccessDescription>
 
-      <PaymentSuccessButtonGroup>
-        {bookingId && (
-          <PaymentSuccessLink to={`/bookings/${bookingId}`}>
-            예약 상세로 이동
-          </PaymentSuccessLink>
-        )}
+      {!confirming && (
+        <PaymentSuccessButtonGroup>
+          {bookingId && !errorMessage && (
+            <PaymentSuccessLink to={`/bookings/${bookingId}`}>
+              예약 상세로 이동
+            </PaymentSuccessLink>
+          )}
 
-        <PaymentSuccessLink to="/">홈으로</PaymentSuccessLink>
-      </PaymentSuccessButtonGroup>
+          <PaymentSuccessLink to="/">홈으로</PaymentSuccessLink>
+
+          {errorMessage && (
+            <PaymentSuccessLink to="/payment/fail">
+              실패 페이지로 이동
+            </PaymentSuccessLink>
+          )}
+        </PaymentSuccessButtonGroup>
+      )}
     </PaymentSuccessContainer>
   );
 }

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 
 import { confirmPayment } from '@/api/payment';
@@ -17,20 +17,29 @@ import {
 
 export default function PaymentSuccessPage() {
   const [sp] = useSearchParams();
+  const navigate = useNavigate();
 
   const bookingId = sp.get('bookingId');
+  const paymentId = sp.get('paymentId');
   const paymentKey = sp.get('paymentKey');
   const orderId = sp.get('orderId');
   const amount = sp.get('amount');
 
+  const checkIn = sp.get('checkin');
+  const checkOut = sp.get('checkout');
+  const guests = sp.get('guests');
+
   const [confirming, setConfirming] = useState(true);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const runConfirm = async () => {
       if (!paymentKey || !orderId || !amount) {
-        setErrorMessage('결제 승인에 필요한 정보가 없습니다.');
-        setConfirming(false);
+        navigate(
+          `/payment/fail?bookingId=${bookingId ?? ''}&paymentId=${paymentId ?? ''}&message=${encodeURIComponent(
+            '결제 승인에 필요한 정보가 없습니다.',
+          )}`,
+          { replace: true },
+        );
         return;
       }
 
@@ -41,79 +50,90 @@ export default function PaymentSuccessPage() {
           amount: Number(amount),
         });
       } catch (e: unknown) {
+        let errorMessage = '결제 승인 처리 중 오류가 발생했습니다.';
+
         if (axios.isAxiosError<{ message?: string }>(e)) {
-          setErrorMessage(
-            e.response?.data?.message ?? '결제 승인 처리에 실패했습니다.',
-          );
+          errorMessage =
+            e.response?.data?.message ?? '결제 승인 처리에 실패했습니다.';
         } else if (e instanceof Error) {
-          setErrorMessage(e.message);
-        } else {
-          setErrorMessage('결제 승인 처리 중 오류가 발생했습니다.');
+          errorMessage = e.message;
         }
+
+        navigate(
+          `/payment/fail?bookingId=${bookingId ?? ''}&paymentId=${paymentId ?? ''}&message=${encodeURIComponent(
+            errorMessage,
+          )}`,
+          { replace: true },
+        );
+        return;
       } finally {
         setConfirming(false);
       }
     };
 
     runConfirm();
-  }, [paymentKey, orderId, amount]);
+  }, [paymentKey, orderId, amount, bookingId, paymentId, navigate]);
 
-  const title = errorMessage
-    ? '결제 승인에 실패했습니다'
-    : confirming
-      ? '결제를 확인하고 있습니다'
-      : '결제가 완료되었습니다';
-
-  const description = errorMessage
-    ? errorMessage
-    : confirming
-      ? '결제 정보를 확인하고 있어요. 잠시만 기다려주세요.'
-      : '예약이 정상적으로 접수되었어요. 아래에서 예약 정보를 확인해보세요.';
+  if (confirming) {
+    return (
+      <PaymentSuccessContainer>
+        <PaymentSuccessTitle>결제를 확인하고 있습니다</PaymentSuccessTitle>
+        <PaymentSuccessDescription>
+          결제 정보를 확인하고 있어요. 잠시만 기다려주세요.
+        </PaymentSuccessDescription>
+      </PaymentSuccessContainer>
+    );
+  }
 
   return (
     <PaymentSuccessContainer>
-      <PaymentSuccessTitle>{title}</PaymentSuccessTitle>
-      <PaymentSuccessDescription>{description}</PaymentSuccessDescription>
+      <PaymentSuccessTitle>결제가 완료되었습니다</PaymentSuccessTitle>
 
-      {!confirming && !errorMessage && (
-        <PaymentSuccessSummaryCard>
-          {bookingId && (
-            <PaymentSuccessSummaryRow>
-              <PaymentSuccessSummaryLabel>예약 번호</PaymentSuccessSummaryLabel>
-              <PaymentSuccessSummaryValue>
-                #{bookingId}
-              </PaymentSuccessSummaryValue>
-            </PaymentSuccessSummaryRow>
-          )}
+      <PaymentSuccessDescription>
+        예약이 정상적으로 접수되었어요. 아래에서 예약 정보를 확인해보세요.
+      </PaymentSuccessDescription>
 
-          {amount && (
-            <PaymentSuccessSummaryRow>
-              <PaymentSuccessSummaryLabel>결제 금액</PaymentSuccessSummaryLabel>
-              <PaymentSuccessSummaryValue>
-                ₩{Number(amount).toLocaleString()}
-              </PaymentSuccessSummaryValue>
-            </PaymentSuccessSummaryRow>
-          )}
-        </PaymentSuccessSummaryCard>
-      )}
+      <PaymentSuccessSummaryCard>
+        {checkIn && (
+          <PaymentSuccessSummaryRow>
+            <PaymentSuccessSummaryLabel>체크인</PaymentSuccessSummaryLabel>
+            <PaymentSuccessSummaryValue>{checkIn}</PaymentSuccessSummaryValue>
+          </PaymentSuccessSummaryRow>
+        )}
 
-      {!confirming && (
-        <PaymentSuccessButtonGroup>
-          {bookingId && !errorMessage && (
-            <PaymentSuccessLink to={`/bookings/${bookingId}`}>
-              예약 상세 보기
-            </PaymentSuccessLink>
-          )}
+        {checkOut && (
+          <PaymentSuccessSummaryRow>
+            <PaymentSuccessSummaryLabel>체크아웃</PaymentSuccessSummaryLabel>
+            <PaymentSuccessSummaryValue>{checkOut}</PaymentSuccessSummaryValue>
+          </PaymentSuccessSummaryRow>
+        )}
 
-          <PaymentSuccessLink to="/">홈으로</PaymentSuccessLink>
+        {guests && (
+          <PaymentSuccessSummaryRow>
+            <PaymentSuccessSummaryLabel>게스트</PaymentSuccessSummaryLabel>
+            <PaymentSuccessSummaryValue>{guests}명</PaymentSuccessSummaryValue>
+          </PaymentSuccessSummaryRow>
+        )}
 
-          {errorMessage && (
-            <PaymentSuccessLink to="/payment/fail">
-              실패 페이지로 이동
-            </PaymentSuccessLink>
-          )}
-        </PaymentSuccessButtonGroup>
-      )}
+        {amount && (
+          <PaymentSuccessSummaryRow>
+            <PaymentSuccessSummaryLabel>결제 금액</PaymentSuccessSummaryLabel>
+            <PaymentSuccessSummaryValue>
+              ₩{Number(amount).toLocaleString()}
+            </PaymentSuccessSummaryValue>
+          </PaymentSuccessSummaryRow>
+        )}
+      </PaymentSuccessSummaryCard>
+
+      <PaymentSuccessButtonGroup>
+        {bookingId && (
+          <PaymentSuccessLink to={`/bookings/${bookingId}`}>
+            예약 상세보기
+          </PaymentSuccessLink>
+        )}
+
+        <PaymentSuccessLink to="/">홈으로</PaymentSuccessLink>
+      </PaymentSuccessButtonGroup>
     </PaymentSuccessContainer>
   );
 }

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -59,17 +59,18 @@ export default function PaymentSuccessPage() {
           errorMessage = e.message;
         }
 
-        navigate(
-          `/payment/fail?bookingId=${bookingId ?? ''}` +
-            `&paymentId=${paymentId ?? ''}` +
-            `&message=${encodeURIComponent(errorMessage)}` +
-            `&title=${encodeURIComponent(sp.get('title') ?? '')}` +
-            `&checkin=${encodeURIComponent(sp.get('checkin') ?? '')}` +
-            `&checkout=${encodeURIComponent(sp.get('checkout') ?? '')}` +
-            `&guests=${encodeURIComponent(sp.get('guests') ?? '')}` +
-            `&amount=${encodeURIComponent(sp.get('amount') ?? '')}`,
-          { replace: true },
-        );
+        const failParams = new URLSearchParams(sp.toString());
+
+        failParams.set('message', errorMessage);
+
+        // Toss successUrl에서 들어온 paymentKey, orderId는 fail 페이지에서 불필요
+        failParams.delete('paymentKey');
+        failParams.delete('orderId');
+
+        navigate(`/payment/fail?${failParams.toString()}`, {
+          replace: true,
+        });
+
         return;
       } finally {
         setConfirming(false);

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -20,7 +20,6 @@ export default function PaymentSuccessPage() {
   const navigate = useNavigate();
 
   const bookingId = sp.get('bookingId');
-  const paymentId = sp.get('paymentId');
   const paymentKey = sp.get('paymentKey');
   const orderId = sp.get('orderId');
   const amount = sp.get('amount');
@@ -32,12 +31,12 @@ export default function PaymentSuccessPage() {
   const [confirming, setConfirming] = useState(true);
 
   useEffect(() => {
+    let isMounted = true;
+
     const runConfirm = async () => {
       if (!paymentKey || !orderId || !amount) {
         const failParams = new URLSearchParams(sp.toString());
         failParams.set('message', '결제 승인에 필요한 정보가 없습니다.');
-
-        // fail 페이지에서 불필요한 값 제거
         failParams.delete('paymentKey');
         failParams.delete('orderId');
 
@@ -64,25 +63,27 @@ export default function PaymentSuccessPage() {
         }
 
         const failParams = new URLSearchParams(sp.toString());
-
         failParams.set('message', errorMessage);
-
-        // Toss successUrl에서 들어온 paymentKey, orderId는 fail 페이지에서 불필요
         failParams.delete('paymentKey');
         failParams.delete('orderId');
 
         navigate(`/payment/fail?${failParams.toString()}`, {
           replace: true,
         });
-
         return;
       } finally {
-        setConfirming(false);
+        if (isMounted) {
+          setConfirming(false);
+        }
       }
     };
 
     runConfirm();
-  }, [paymentKey, orderId, amount, bookingId, paymentId, navigate]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [paymentKey, orderId, amount, navigate, sp]);
 
   if (confirming) {
     return (

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -9,6 +9,10 @@ import {
   PaymentSuccessDescription,
   PaymentSuccessButtonGroup,
   PaymentSuccessLink,
+  PaymentSuccessSummaryCard,
+  PaymentSuccessSummaryRow,
+  PaymentSuccessSummaryLabel,
+  PaymentSuccessSummaryValue,
 } from './paymentSuccess.styles';
 
 export default function PaymentSuccessPage() {
@@ -57,26 +61,47 @@ export default function PaymentSuccessPage() {
   const title = errorMessage
     ? '결제 승인에 실패했습니다'
     : confirming
-      ? '결제 승인 중입니다'
+      ? '결제를 확인하고 있습니다'
       : '결제가 완료되었습니다';
 
   const description = errorMessage
     ? errorMessage
     : confirming
       ? '결제 정보를 확인하고 있어요. 잠시만 기다려주세요.'
-      : '예약이 정상적으로 접수되었어요.';
+      : '예약이 정상적으로 접수되었어요. 아래에서 예약 정보를 확인해보세요.';
 
   return (
     <PaymentSuccessContainer>
       <PaymentSuccessTitle>{title}</PaymentSuccessTitle>
-
       <PaymentSuccessDescription>{description}</PaymentSuccessDescription>
+
+      {!confirming && !errorMessage && (
+        <PaymentSuccessSummaryCard>
+          {bookingId && (
+            <PaymentSuccessSummaryRow>
+              <PaymentSuccessSummaryLabel>예약 번호</PaymentSuccessSummaryLabel>
+              <PaymentSuccessSummaryValue>
+                #{bookingId}
+              </PaymentSuccessSummaryValue>
+            </PaymentSuccessSummaryRow>
+          )}
+
+          {amount && (
+            <PaymentSuccessSummaryRow>
+              <PaymentSuccessSummaryLabel>결제 금액</PaymentSuccessSummaryLabel>
+              <PaymentSuccessSummaryValue>
+                ₩{Number(amount).toLocaleString()}
+              </PaymentSuccessSummaryValue>
+            </PaymentSuccessSummaryRow>
+          )}
+        </PaymentSuccessSummaryCard>
+      )}
 
       {!confirming && (
         <PaymentSuccessButtonGroup>
           {bookingId && !errorMessage && (
             <PaymentSuccessLink to={`/bookings/${bookingId}`}>
-              예약 상세로 이동
+              예약 상세 보기
             </PaymentSuccessLink>
           )}
 

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -60,9 +60,14 @@ export default function PaymentSuccessPage() {
         }
 
         navigate(
-          `/payment/fail?bookingId=${bookingId ?? ''}&paymentId=${paymentId ?? ''}&message=${encodeURIComponent(
-            errorMessage,
-          )}`,
+          `/payment/fail?bookingId=${bookingId ?? ''}` +
+            `&paymentId=${paymentId ?? ''}` +
+            `&message=${encodeURIComponent(errorMessage)}` +
+            `&title=${encodeURIComponent(sp.get('title') ?? '')}` +
+            `&checkin=${encodeURIComponent(sp.get('checkin') ?? '')}` +
+            `&checkout=${encodeURIComponent(sp.get('checkout') ?? '')}` +
+            `&guests=${encodeURIComponent(sp.get('guests') ?? '')}` +
+            `&amount=${encodeURIComponent(sp.get('amount') ?? '')}`,
           { replace: true },
         );
         return;

--- a/src/pages/payment/paymentFail.styles.ts
+++ b/src/pages/payment/paymentFail.styles.ts
@@ -49,3 +49,38 @@ export const PaymentFailNotice = styled.div`
   font-size: 13px;
   line-height: 1.6;
 `;
+
+export const PaymentFailSummaryCard = styled.div`
+  margin-top: 24px;
+  padding: 24px;
+  border: 1px solid #e9e9e9;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+export const PaymentFailSummaryTitle = styled.h2`
+  font-size: 18px;
+  font-weight: 700;
+  margin-bottom: 16px;
+`;
+
+export const PaymentFailSummaryRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  & + & {
+    margin-top: 12px;
+  }
+`;
+
+export const PaymentFailSummaryLabel = styled.span`
+  color: #666;
+  font-size: 15px;
+`;
+
+export const PaymentFailSummaryValue = styled.span`
+  color: #222;
+  font-size: 15px;
+  font-weight: 600;
+`;

--- a/src/pages/payment/paymentSuccess.styles.ts
+++ b/src/pages/payment/paymentSuccess.styles.ts
@@ -2,27 +2,74 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
 export const PaymentSuccessContainer = styled.div`
-  padding: 24px;
+  padding: 40px 24px;
   max-width: 720px;
   margin: 0 auto;
 `;
 
 export const PaymentSuccessTitle = styled.h1`
-  font-size: 24px;
+  font-size: 32px;
   font-weight: 800;
+  line-height: 1.3;
 `;
 
 export const PaymentSuccessDescription = styled.p`
   margin-top: 12px;
   color: #666;
+  font-size: 16px;
+  line-height: 1.6;
+`;
+
+/* ⭐ 요약 카드 (추가된 부분) */
+export const PaymentSuccessSummaryCard = styled.div`
+  margin-top: 28px;
+  padding: 24px;
+  border: 1px solid #e9e9e9;
+  border-radius: 16px;
+  background: #fff;
+`;
+
+export const PaymentSuccessSummaryRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  & + & {
+    margin-top: 14px;
+  }
+`;
+
+export const PaymentSuccessSummaryLabel = styled.span`
+  color: #666;
+  font-size: 15px;
+`;
+
+export const PaymentSuccessSummaryValue = styled.span`
+  font-weight: 700;
+  font-size: 16px;
+  color: #222;
 `;
 
 export const PaymentSuccessButtonGroup = styled.div`
   display: flex;
   gap: 12px;
-  margin-top: 20px;
+  margin-top: 24px;
+  flex-wrap: wrap;
 `;
 
 export const PaymentSuccessLink = styled(Link)`
-  text-decoration: underline;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 140px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  background: #222;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+
+  &:hover {
+    opacity: 0.92;
+  }
 `;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -25,6 +25,7 @@ export const router = createBrowserRouter([
       { path: 'landing', element: <LandingPage /> },
       { path: 'accommodation/:id', element: <AccommodationDetailPage /> },
       { path: 'payment/:id', element: <PaymentPage /> },
+      { path: 'payment/retry/:id', element: <PaymentPage /> },
       { path: 'payment/success', element: <PaymentSuccessPage /> },
       { path: 'payment/fail', element: <PaymentFailPage /> },
       { path: 'search', element: <SearchPage /> },


### PR DESCRIPTION
## 🔗 반영 브랜치

(#33) feature/payment-> dev


## 📝 작업 내용
Mock 기반으로 구현되어 있던 결제 흐름을 토스페이먼츠 테스트 결제 승인 흐름에 맞게 확장했습니다.

### 주요 변경 사항
- Payment 엔티티에 `orderId` 필드 추가
- 결제 생성 시 `orderId` 생성 및 저장
- 재결제(retry) 시 새로운 `orderId` 재발급
- PaymentRepository에 `orderId` 기준 조회 메서드 추가
- 결제 생성 응답 DTO에 `orderId` 포함
- 결제 승인 요청 DTO를 `paymentKey`, `orderId`, `amount` 기반으로 변경
- 결제 승인 API를 `/api/payments/confirm` 구조로 변경
- 결제 승인 시 `orderId`, `amount`, `payer` 검증 추가
- 토스 결제 승인 API 호출용 `TossPaymentClient` 추가
- 토스 설정값(`secretKey`, `confirmUrl`) 프로퍼티 추가
- RestTemplate을 Bean으로 분리하여 주입 구조로 개선
- 토스 승인 응답 검증 로직 추가
- 결제 타임아웃 기준을 토스 흐름에 맞게 9분으로 조정

### 결제 흐름
- 예약 생성
- 결제 생성 (`READY`, `orderId` 발급)
- 프론트 토스 결제창 호출
- successUrl 진입 후 `/api/payments/confirm` 호출
- 백엔드에서 토스 승인 API 재검증
- 승인 성공 시 Payment `SUCCESS`
- instant booking 숙소는 Booking `CONFIRMED`

## 참고 사항
- 현재는 테스트 결제 연동 단계이며 실제 운영 결제는 아님
- webhook, 취소 API, 부분 환불, PG 추상화는 후속 작업 예정
- failUrl/창 닫기 상황에서는 Payment가 즉시 실패 처리되지 않고 timeout 스케줄러에 의해 정리될 수 있음

## 확인 사항
- [x] 토스 테스트 결제창 오픈 확인
- [x] successUrl → 백엔드 confirm 흐름 확인
- [x] 결제 성공 시 Payment 상태 업데이트 확인
- [x] timeout 설정 9분 반영

<img width="604" height="611" alt="스크린샷 2026-03-25 225052" src="https://github.com/user-attachments/assets/ee84c64c-af3f-4266-8f7c-84871a8d6c2d" />
<img width="639" height="658" alt="스크린샷 2026-03-25 225059" src="https://github.com/user-attachments/assets/2a910345-0f42-4a37-93cc-bd78f0459211" />
<img width="997" height="828" alt="스크린샷 2026-03-25 225027" src="https://github.com/user-attachments/assets/6efe9ebd-4d50-416d-af60-0094ffd51afa" />
<img width="1892" height="900" alt="스크린샷 2026-03-26 020944" src="https://github.com/user-attachments/assets/60e9fd5d-fb1d-4822-9f2e-a014d9609e11" />
<img width="2811" height="1355" alt="스크린샷 2026-03-26 023518" src="https://github.com/user-attachments/assets/62674d6b-f873-4f91-b8f4-2516346dd8dd" />



## 💬 리뷰 요구사항(선택 사항)

