### PR TITLE
Feat: 결제 페이지 UI 개선 및 호스트 메시지 채팅 연동

### DIFF
--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,3 +1,5 @@
+﻿import client from './client';
+
 const getBaseUrl = () =>
   import.meta.env.VITE_BACKEND_BASE_URL || 'http://localhost:8080';
 
@@ -12,7 +14,6 @@ function authHeaders(accessToken: string | null): HeadersInit {
   return headers;
 }
 
-// 대화 목록 응답 한 건
 export type ConversationResponseDTO = {
   conversationId: number;
   accommodationId: number;
@@ -32,7 +33,6 @@ export type ConversationCreateResponseDTO = {
   conversationId: number;
 };
 
-// 메시지 응답 한 건
 export type MessageResponseDTO = {
   id: number;
   conversationId: number;
@@ -41,7 +41,6 @@ export type MessageResponseDTO = {
   createdAt: string;
 };
 
-// 메시지 목록 응답
 type ChatMessageListResponseDTO = {
   messages: Array<{
     messageId: number;
@@ -54,7 +53,6 @@ type ChatMessageListResponseDTO = {
   hasMore: boolean;
 };
 
-// 응답이 { success, data } 래핑인 경우
 type ApiResponse<T> = {
   success: boolean;
   data: T;
@@ -92,7 +90,6 @@ function normalizeCreatedAt(value: unknown): string {
   return '';
 }
 
-// 에러 응답 시 JSON에서 message 추출 후 사용자용 메시지로 throw
 async function throwApiError(res: Response, fallback: string): Promise<never> {
   const text = await res.text();
   try {
@@ -108,10 +105,6 @@ async function throwApiError(res: Response, fallback: string): Promise<never> {
   }
 }
 
-/**
- * 대화 목록 조회
- * - 인증: Authorization Bearer 토큰 사용 (accessToken 전달)
- */
 export async function fetchConversations(
   accessToken: string | null,
 ): Promise<ConversationResponseDTO[]> {
@@ -132,21 +125,11 @@ export async function fetchConversations(
 
 export async function createOrGetConversation(
   req: ConversationCreateRequestDTO,
-  accessToken: string | null,
 ): Promise<ConversationCreateResponseDTO> {
-  const url = `${getBaseUrl()}/api/conversations`;
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: authHeaders(accessToken),
-    body: JSON.stringify(req),
-  });
-
-  if (!res.ok) {
-    await throwApiError(res, '대화방을 생성하지 못했습니다.');
-  }
-
-  const body = await res.json();
-  return unwrap<ConversationCreateResponseDTO>(body);
+  return client.post<
+    ConversationCreateResponseDTO,
+    ConversationCreateResponseDTO
+  >('/api/conversations', req);
 }
 
 export type FetchMessagesResult = {
@@ -155,11 +138,6 @@ export type FetchMessagesResult = {
   hasMore: boolean;
 };
 
-/**
- * 특정 대화의 메시지 목록 조회
- * 백엔드: GET /api/conversations/{id}/messages → { messages, nextCursor, hasMore }
- * @param before - 이 ID보다 오래된 메시지 조회 (스크롤 시 이전 페이지용), 없으면 최근 size개
- */
 export async function fetchMessages(
   conversationId: number,
   accessToken: string | null,
@@ -199,7 +177,7 @@ export async function fetchMessages(
     }
     return m as unknown as MessageResponseDTO;
   });
-  // 백엔드는 최신순(Id 내림차순)으로 반환 → 채팅 UI용으로 오래된 순으로 뒤집기
+
   const messages = mapped.reverse();
   return {
     messages,

--- a/src/api/messages.ts
+++ b/src/api/messages.ts
@@ -1,12 +1,13 @@
 const getBaseUrl = () =>
-  import.meta.env.VITE_BACKEND_BASE_URL || "http://localhost:8080";
+  import.meta.env.VITE_BACKEND_BASE_URL || 'http://localhost:8080';
 
 function authHeaders(accessToken: string | null): HeadersInit {
   const headers: HeadersInit = {
-    "Content-Type": "application/json",
+    'Content-Type': 'application/json',
   };
   if (accessToken) {
-    (headers as Record<string, string>)["Authorization"] = `Bearer ${accessToken}`;
+    (headers as Record<string, string>)['Authorization'] =
+      `Bearer ${accessToken}`;
   }
   return headers;
 }
@@ -22,6 +23,15 @@ export type ConversationResponseDTO = {
   lastMessageTime: string;
 };
 
+export type ConversationCreateRequestDTO = {
+  hostId: number;
+  accommodationId: number;
+};
+
+export type ConversationCreateResponseDTO = {
+  conversationId: number;
+};
+
 // 메시지 응답 한 건
 export type MessageResponseDTO = {
   id: number;
@@ -31,7 +41,7 @@ export type MessageResponseDTO = {
   createdAt: string;
 };
 
-// 메시지 목록 응답 
+// 메시지 목록 응답
 type ChatMessageListResponseDTO = {
   messages: Array<{
     messageId: number;
@@ -54,10 +64,10 @@ type ApiResponse<T> = {
 function unwrap<T>(body: unknown): T {
   if (
     body &&
-    typeof body === "object" &&
-    "success" in body &&
+    typeof body === 'object' &&
+    'success' in body &&
     (body as ApiResponse<T>).success &&
-    "data" in body
+    'data' in body
   ) {
     return (body as ApiResponse<T>).data;
   }
@@ -65,7 +75,7 @@ function unwrap<T>(body: unknown): T {
 }
 
 function normalizeCreatedAt(value: unknown): string {
-  if (typeof value === "string") return value;
+  if (typeof value === 'string') return value;
 
   if (Array.isArray(value) && value.length >= 3) {
     const [y, mon = 1, d = 1, h = 0, min = 0, s = 0] = value;
@@ -75,11 +85,11 @@ function normalizeCreatedAt(value: unknown): string {
       Number(d),
       Number(h),
       Number(min),
-      Number(s)
+      Number(s),
     ).toISOString();
   }
 
-  return "";
+  return '';
 }
 
 // 에러 응답 시 JSON에서 message 추출 후 사용자용 메시지로 throw
@@ -88,7 +98,7 @@ async function throwApiError(res: Response, fallback: string): Promise<never> {
   try {
     const json = JSON.parse(text) as { message?: string; success?: boolean };
     const msg =
-      typeof json.message === "string" && json.message.length > 0
+      typeof json.message === 'string' && json.message.length > 0
         ? json.message
         : fallback;
     throw new Error(msg);
@@ -103,21 +113,40 @@ async function throwApiError(res: Response, fallback: string): Promise<never> {
  * - 인증: Authorization Bearer 토큰 사용 (accessToken 전달)
  */
 export async function fetchConversations(
-  accessToken: string | null
+  accessToken: string | null,
 ): Promise<ConversationResponseDTO[]> {
   const url = `${getBaseUrl()}/api/conversations`;
   const res = await fetch(url, {
-    method: "GET",
+    method: 'GET',
     headers: authHeaders(accessToken),
   });
 
   if (!res.ok) {
-    await throwApiError(res, "대화 목록을 불러오지 못했습니다.");
+    await throwApiError(res, '대화 목록을 불러오지 못했습니다.');
   }
 
   const body = await res.json();
   const data = unwrap<ConversationResponseDTO[]>(body);
   return Array.isArray(data) ? data : [];
+}
+
+export async function createOrGetConversation(
+  req: ConversationCreateRequestDTO,
+  accessToken: string | null,
+): Promise<ConversationCreateResponseDTO> {
+  const url = `${getBaseUrl()}/api/conversations`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: JSON.stringify(req),
+  });
+
+  if (!res.ok) {
+    await throwApiError(res, '대화방을 생성하지 못했습니다.');
+  }
+
+  const body = await res.json();
+  return unwrap<ConversationCreateResponseDTO>(body);
 }
 
 export type FetchMessagesResult = {
@@ -135,18 +164,18 @@ export async function fetchMessages(
   conversationId: number,
   accessToken: string | null,
   before?: number | null,
-  size: number = 10
+  size: number = 10,
 ): Promise<FetchMessagesResult> {
   const params = new URLSearchParams({ size: String(size) });
-  if (before != null) params.set("before", String(before));
+  if (before != null) params.set('before', String(before));
   const url = `${getBaseUrl()}/api/conversations/${conversationId}/messages?${params}`;
   const res = await fetch(url, {
-    method: "GET",
+    method: 'GET',
     headers: authHeaders(accessToken),
   });
 
   if (!res.ok) {
-    await throwApiError(res, "메시지를 불러오지 못했습니다.");
+    await throwApiError(res, '메시지를 불러오지 못했습니다.');
   }
 
   const body = await res.json();
@@ -156,7 +185,10 @@ export async function fetchMessages(
 
   const mapped = arr.map((m): MessageResponseDTO => {
     const row = m as Record<string, unknown>;
-    if (typeof row.messageId !== "undefined" && typeof row.messageText !== "undefined") {
+    if (
+      typeof row.messageId !== 'undefined' &&
+      typeof row.messageText !== 'undefined'
+    ) {
       return {
         id: row.messageId as number,
         conversationId: row.conversationId as number,

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+﻿import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import axios from 'axios';
 import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
@@ -8,13 +8,6 @@ import { useAccommodationStore } from '@/store/accommodationStore';
 import { nightsBetween, calcTotal } from '../../utils/price';
 
 import BookingSummaryCard from './components/BookngSummaryCard';
-import PaymentMethodSection, {
-  type UiPaymentMethod,
-} from './components/PaymentMethodSection';
-
-import HostMessageSection from './components/HostMessageSection';
-import RequestConfirmSection from './components/RequestConfirmSection';
-
 import { createBooking } from '@/api/booking';
 import {
   createPayment,
@@ -24,12 +17,39 @@ import {
 import {
   PaymentPageLayout,
   PaymentContent,
+  SectionCard,
+  SectionTitle,
+  IntroRow,
+  IntroIcon,
+  IntroTextWrap,
+  IntroTitle,
+  IntroDescription,
+  BrandCard,
+  BrandHeader,
+  BrandDot,
+  BrandTitle,
+  BrandSubText,
+  MethodPillRow,
+  MethodPill,
+  MessageGuide,
+  MessageBox,
+  SummaryCard,
+  SummaryRow,
+  SummaryLabel,
+  SummaryValue,
+  SummaryDivider,
+  AgreementLabel,
+  AgreementCheckbox,
   SubmitErrorBox,
+  SubmitButton,
+  SubmitHint,
 } from './payment.styles';
 
 const tossClientKey = import.meta.env.VITE_TOSS_CLIENT_KEY;
 const frontBaseUrl =
   import.meta.env.VITE_FRONT_BASE_URL ?? window.location.origin;
+
+const formatWon = (value: number) => `₩${value.toLocaleString()}`;
 
 export default function PaymentPage() {
   const navigate = useNavigate();
@@ -38,16 +58,17 @@ export default function PaymentPage() {
   const { detail, loading, error, load } = useAccommodationStore();
   const { user } = useAuth();
 
-  const [paymentMethod, setPaymentMethod] = useState<UiPaymentMethod>('CARD');
   const [hostMessage, setHostMessage] = useState('');
+  const [agreementChecked, setAgreementChecked] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const retryBookingId = searchParams.get('bookingId');
-
   const checkIn = searchParams.get('checkin');
   const checkOut = searchParams.get('checkout');
-  const guests = Number(searchParams.get('numberOfGuests') ?? 1);
+  const guests = Number(
+    searchParams.get('numberOfGuests') ?? searchParams.get('guests') ?? 1,
+  );
 
   useEffect(() => {
     if (id) load(id);
@@ -65,10 +86,25 @@ export default function PaymentPage() {
     );
   }, [detail, checkIn, checkOut, nights]);
 
-  if (!id) return <div>잘못된 접근</div>;
+  const stayAmount = useMemo(() => {
+    if (!detail || nights <= 0) return 0;
+    return detail.pricePerNight * nights;
+  }, [detail, nights]);
+
+  const extraAmount = useMemo(() => {
+    if (!price) return 0;
+    return Math.max(price.total - stayAmount, 0);
+  }, [price, stayAmount]);
+
+  const serviceFeeAmount = useMemo(() => {
+    if (!price || !detail) return 0;
+    return Math.max(price.total - stayAmount - detail.cleaningFee, 0);
+  }, [price, stayAmount, detail]);
+
+  if (!id) return <div>잘못된 접근입니다.</div>;
   if (loading) return <div>불러오는 중...</div>;
-  if (error) return <div>에러: {error}</div>;
-  if (!detail) return <div>데이터 없음</div>;
+  if (error) return <div>오류: {error}</div>;
+  if (!detail) return <div>숙소 정보를 찾을 수 없습니다.</div>;
 
   const canSubmit =
     !!price &&
@@ -76,12 +112,10 @@ export default function PaymentPage() {
     !!checkOut &&
     guests >= 1 &&
     guests <= detail.maxGuests &&
+    agreementChecked &&
     !submitting;
 
-  const toApiPaymentMethod = (m: UiPaymentMethod): ApiPaymentMethod => {
-    if (m === 'CARD') return 'CARD';
-    return 'EASY_PAY';
-  };
+  const paymentMethod: ApiPaymentMethod = 'EASY_PAY';
 
   const getUserFriendlyErrorMessage = (
     status?: number,
@@ -94,26 +128,26 @@ export default function PaymentPage() {
     }
 
     if (status === 409) {
-      if (message.includes('겹치는 예약')) {
+      if (message.includes('겹치') || message.includes('중복')) {
         return '선택한 날짜에 이미 예약이 있어요. 다른 날짜를 선택해주세요.';
       }
 
-      if (message.includes('이미 결제 진행 중')) {
+      if (message.includes('결제 진행 중')) {
         return '이미 결제가 진행 중인 예약입니다. 잠시 후 다시 확인해주세요.';
       }
 
-      if (message.includes('이미 결제 완료된 예약')) {
+      if (message.includes('결제 완료')) {
         return '이미 결제가 완료된 예약입니다.';
       }
 
-      return '요청을 처리할 수 없어요. 입력한 정보를 다시 확인해주세요.';
+      return '요청을 처리할 수 없어요. 입력한 내용을 다시 확인해주세요.';
     }
 
     if (status === 400) {
-      return '입력한 정보가 올바르지 않습니다. 다시 확인해주세요.';
+      return '입력한 정보가 올바르지 않아요. 다시 확인해주세요.';
     }
 
-    return message || '예약/결제 요청에 실패했습니다.';
+    return message || '예약 또는 결제 요청에 실패했습니다.';
   };
 
   const handleSubmit = async () => {
@@ -145,13 +179,12 @@ export default function PaymentPage() {
 
       const payment = await createPayment({
         bookingId: bookingIdForNav,
-        paymentMethod: toApiPaymentMethod(paymentMethod),
+        paymentMethod,
       });
 
       paymentIdForNav = payment.paymentId;
 
       const tossPayments = await loadTossPayments(tossClientKey);
-
       const paymentSdk = tossPayments.payment({
         customerKey: `booking_${bookingIdForNav}`,
       });
@@ -180,7 +213,7 @@ export default function PaymentPage() {
         customerName: user?.nickname ?? '고객',
       });
     } catch (e: unknown) {
-      let msg = '예약/결제 요청에 실패했습니다.';
+      let msg = '예약 또는 결제 요청에 실패했습니다.';
 
       if (axios.isAxiosError<{ message?: string }>(e)) {
         const status = e.response?.status;
@@ -249,24 +282,102 @@ export default function PaymentPage() {
         guests={guests}
         nights={nights}
         pricePerNight={detail.pricePerNight}
+        cleaningFee={detail.cleaningFee}
+        serviceFee={serviceFeeAmount}
         total={price?.total}
       />
 
       <PaymentContent>
-        <PaymentMethodSection
-          value={paymentMethod}
-          onChange={setPaymentMethod}
-        />
+        <SectionCard>
+          <SectionTitle>1. 간편결제로 결제</SectionTitle>
 
-        <HostMessageSection
-          value={hostMessage}
-          onChange={setHostMessage}
-          hostName={detail.hostNickname ?? '호스트'}
-        />
+          <IntroRow>
+            <IntroIcon>✓</IntroIcon>
+            <IntroTextWrap>
+              <IntroTitle>간편한 토스 결제창이 열려요</IntroTitle>
+              <IntroDescription>
+                카카오페이, 네이버페이 등 결제 수단을 토스 결제창 안에서 선택할
+                수 있어요.
+              </IntroDescription>
+            </IntroTextWrap>
+          </IntroRow>
 
-        {submitError && <SubmitErrorBox>{submitError}</SubmitErrorBox>}
+          <BrandCard>
+            <BrandHeader>
+              <BrandDot />
+              <BrandTitle>TossPayments</BrandTitle>
+            </BrandHeader>
+            <BrandSubText>
+              자체 결제수단, 카카오페이, 네이버페이, 카드 결제를 지원합니다.
+            </BrandSubText>
+            <MethodPillRow>
+              <MethodPill>간편결제</MethodPill>
+              <MethodPill>카카오페이</MethodPill>
+              <MethodPill>네이버페이</MethodPill>
+              <MethodPill>카드</MethodPill>
+            </MethodPillRow>
+          </BrandCard>
+        </SectionCard>
 
-        <RequestConfirmSection disabled={!canSubmit} onSubmit={handleSubmit} />
+        <SectionCard>
+          <SectionTitle>2. 호스트에게 남길 메시지 작성</SectionTitle>
+          <MessageGuide>
+            {detail.hostNickname ?? '호스트'}에게 전달하고 싶은 요청 사항이나
+            도착 예정 시간을 남겨보세요.
+          </MessageGuide>
+
+          <MessageBox
+            value={hostMessage}
+            onChange={(e) => setHostMessage(e.target.value)}
+            placeholder="호스트에게 전달하고 싶은 말을 남겨주세요."
+            maxLength={300}
+          />
+        </SectionCard>
+
+        <SectionCard>
+          <SectionTitle>3. 최종 결제 정보 확인</SectionTitle>
+
+          <SummaryCard>
+            <SummaryRow>
+              <SummaryLabel>숙박 금액</SummaryLabel>
+              <SummaryValue>{formatWon(stayAmount)}</SummaryValue>
+            </SummaryRow>
+
+            <SummaryRow>
+              <SummaryLabel>수수료/청소비</SummaryLabel>
+              <SummaryValue>{formatWon(extraAmount)}</SummaryValue>
+            </SummaryRow>
+
+            <SummaryDivider />
+
+            <SummaryRow $isTotal>
+              <SummaryLabel>총 결제 금액</SummaryLabel>
+              <SummaryValue>{formatWon(price?.total ?? 0)}</SummaryValue>
+            </SummaryRow>
+          </SummaryCard>
+
+          <AgreementLabel>
+            <AgreementCheckbox
+              type="checkbox"
+              checked={agreementChecked}
+              onChange={(e) => setAgreementChecked(e.target.checked)}
+            />
+            <span>결제 진행 및 환불 규정을 확인했습니다.</span>
+          </AgreementLabel>
+
+          {submitError && <SubmitErrorBox>{submitError}</SubmitErrorBox>}
+
+          <SubmitButton
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            $disabled={!canSubmit}
+          >
+            {submitting ? '결제창으로 이동 중...' : '간편결제로 결제하기'}
+          </SubmitButton>
+
+          <SubmitHint>버튼을 누르면 안전한 결제창으로 이동합니다.</SubmitHint>
+        </SectionCard>
       </PaymentContent>
     </PaymentPageLayout>
   );

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -9,10 +9,12 @@ import { nightsBetween, calcTotal } from '../../utils/price';
 
 import BookingSummaryCard from './components/BookngSummaryCard';
 import { createBooking } from '@/api/booking';
+import { createOrGetConversation } from '@/api/messages';
 import {
   createPayment,
   type PaymentMethod as ApiPaymentMethod,
 } from '@/api/payment';
+import { getOrCreateStompClient, sendMessageOverWs } from '@/api/chatWebSocket';
 
 import {
   PaymentPageLayout,
@@ -56,7 +58,7 @@ export default function PaymentPage() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const { detail, loading, error, load } = useAccommodationStore();
-  const { user } = useAuth();
+  const { user, accessToken } = useAuth();
 
   const [hostMessage, setHostMessage] = useState('');
   const [agreementChecked, setAgreementChecked] = useState(false);
@@ -150,6 +152,25 @@ export default function PaymentPage() {
     return message || '예약 또는 결제 요청에 실패했습니다.';
   };
 
+  const sendHostMessageToConversation = async () => {
+    const trimmedMessage = hostMessage.trim();
+
+    if (!trimmedMessage || !accessToken) {
+      return;
+    }
+
+    const conversation = await createOrGetConversation(
+      {
+        hostId: detail.hostId,
+        accommodationId: Number(id),
+      },
+      accessToken,
+    );
+
+    const stompClient = await getOrCreateStompClient(accessToken);
+    sendMessageOverWs(stompClient, conversation.conversationId, trimmedMessage);
+  };
+
   const handleSubmit = async () => {
     if (!canSubmit) return;
 
@@ -175,6 +196,19 @@ export default function PaymentPage() {
         });
 
         bookingIdForNav = booking.bookingId;
+      }
+
+      if (hostMessage.trim()) {
+        try {
+          await sendHostMessageToConversation();
+        } catch (chatError) {
+          if (import.meta.env.DEV) {
+            console.warn(
+              '[PaymentPage] Failed to send host message:',
+              chatError,
+            );
+          }
+        }
       }
 
       const payment = await createPayment({

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -159,13 +159,10 @@ export default function PaymentPage() {
       return;
     }
 
-    const conversation = await createOrGetConversation(
-      {
-        hostId: detail.hostId,
-        accommodationId: Number(id),
-      },
-      accessToken,
-    );
+    const conversation = await createOrGetConversation({
+      hostId: detail.hostId,
+      accommodationId: Number(id),
+    });
 
     const stompClient = await getOrCreateStompClient(accessToken);
     sendMessageOverWs(stompClient, conversation.conversationId, trimmedMessage);

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -5,7 +5,7 @@ import { loadTossPayments } from '@tosspayments/tosspayments-sdk';
 import { useAuth } from '@/contexts/AuthContext';
 
 import { useAccommodationStore } from '@/store/accommodationStore';
-import { nightsBetween, calcTotal } from '../../utils/price';
+import { nightsBetween, calcTotal, formatKRW } from '../../utils/price';
 
 import BookingSummaryCard from './components/BookngSummaryCard';
 import { createBooking } from '@/api/booking';
@@ -50,8 +50,6 @@ import {
 const tossClientKey = import.meta.env.VITE_TOSS_CLIENT_KEY;
 const frontBaseUrl =
   import.meta.env.VITE_FRONT_BASE_URL ?? window.location.origin;
-
-const formatWon = (value: number) => `₩${value.toLocaleString()}`;
 
 export default function PaymentPage() {
   const navigate = useNavigate();
@@ -376,19 +374,19 @@ export default function PaymentPage() {
           <SummaryCard>
             <SummaryRow>
               <SummaryLabel>숙박 금액</SummaryLabel>
-              <SummaryValue>{formatWon(stayAmount)}</SummaryValue>
+              <SummaryValue>₩{formatKRW(stayAmount)}</SummaryValue>
             </SummaryRow>
 
             <SummaryRow>
               <SummaryLabel>수수료/청소비</SummaryLabel>
-              <SummaryValue>{formatWon(extraAmount)}</SummaryValue>
+              <SummaryValue>₩{formatKRW(extraAmount)}</SummaryValue>
             </SummaryRow>
 
             <SummaryDivider />
 
             <SummaryRow $isTotal>
               <SummaryLabel>총 결제 금액</SummaryLabel>
-              <SummaryValue>{formatWon(price?.total ?? 0)}</SummaryValue>
+              <SummaryValue>₩{formatKRW(price?.total ?? 0)}</SummaryValue>
             </SummaryRow>
           </SummaryCard>
 

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -118,6 +118,8 @@ export default function PaymentPage() {
     !submitting;
 
   const paymentMethod: ApiPaymentMethod = 'EASY_PAY';
+  // Toss SDK 통합 결제창은 CARD method로 진입해 카드/간편결제를 함께 노출한다.
+  const tossMethod = 'CARD' as const;
 
   const getUserFriendlyErrorMessage = (
     status?: number,
@@ -235,7 +237,7 @@ export default function PaymentPage() {
       });
 
       await paymentSdk.requestPayment({
-        method: 'CARD',
+        method: tossMethod,
         amount: {
           currency: 'KRW',
           value: Number(payment.amount),

--- a/src/pages/payment/components/BookngSummaryCard.tsx
+++ b/src/pages/payment/components/BookngSummaryCard.tsx
@@ -1,4 +1,4 @@
-import * as S from '../payment.styles';
+﻿import * as S from '../payment.styles';
 
 type Props = {
   title: string;
@@ -10,6 +10,8 @@ type Props = {
   guests: number;
   nights: number;
   pricePerNight: number;
+  cleaningFee: number;
+  serviceFee: number;
   total?: number;
 };
 
@@ -23,48 +25,62 @@ export default function BookingSummaryCard({
   guests,
   nights,
   pricePerNight,
+  cleaningFee,
+  serviceFee,
   total,
 }: Props) {
   return (
-    <S.SummaryCard>
-      <S.SummaryTop>
-        {thumbnailUrl && <S.Thumbnail src={thumbnailUrl} />}
+    <S.SideCard>
+      <S.SideTop>
+        {thumbnailUrl && <S.Thumbnail src={thumbnailUrl} alt={title} />}
         <div>
-          <S.SummaryTitle>{title}</S.SummaryTitle>
-          <S.SummaryMeta>
+          <S.SideTitle>{title}</S.SideTitle>
+          <S.SideMeta>
             ★ {averageRating.toFixed(1)} (후기 {reviewCount}개)
-          </S.SummaryMeta>
+          </S.SideMeta>
         </div>
-      </S.SummaryTop>
+      </S.SideTop>
 
       <S.Divider />
 
-      <S.SummaryRow>
+      <S.SideInfoRow>
         <span>날짜</span>
         <span>
-          {checkIn} ~ {checkOut}
+          {checkIn} - {checkOut}
         </span>
-      </S.SummaryRow>
+      </S.SideInfoRow>
 
-      <S.SummaryRow>
+      <S.SideInfoRow>
         <span>게스트</span>
         <span>{guests}명</span>
-      </S.SummaryRow>
+      </S.SideInfoRow>
 
       <S.Divider />
 
-      <S.SummaryRow>
-        <span>
-          ₩{pricePerNight.toLocaleString()} × {nights}박
-        </span>
-      </S.SummaryRow>
+      <S.SidePriceRow>
+        ₩ {pricePerNight.toLocaleString()} × {nights}박
+      </S.SidePriceRow>
+
+      {nights > 0 && (
+        <>
+          <S.SideInfoRow>
+            <span>청소비</span>
+            <span>₩{cleaningFee.toLocaleString()}</span>
+          </S.SideInfoRow>
+
+          <S.SideInfoRow>
+            <span>서비스 수수료</span>
+            <span>₩{serviceFee.toLocaleString()}</span>
+          </S.SideInfoRow>
+        </>
+      )}
 
       {total && (
-        <S.TotalRow>
+        <S.SideTotalRow>
           <span>총액 KRW</span>
-          <span>₩{total.toLocaleString()}</span>
-        </S.TotalRow>
+          <strong>₩{total.toLocaleString()}</strong>
+        </S.SideTotalRow>
       )}
-    </S.SummaryCard>
+    </S.SideCard>
   );
 }

--- a/src/pages/payment/payment.styles.ts
+++ b/src/pages/payment/payment.styles.ts
@@ -1,147 +1,416 @@
 import styled from 'styled-components';
 
-export const SummaryCard = styled.div`
-  border: 1px solid #ddd;
-  border-radius: 16px;
-  padding: 20px;
-`;
-
-export const SectionCard = styled.div`
-  border: 1px solid #ddd;
-  border-radius: 16px;
-  padding: 20px;
-`;
-
-export const SectionTitle = styled.h2`
-  font-size: 18px;
-  font-weight: 700;
-  margin-bottom: 16px;
-`;
-
-export const Divider = styled.hr`
-  margin: 16px 0;
-  border: none;
-  border-top: 1px solid #eee;
-`;
-
-export const SummaryRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin: 6px 0;
-`;
-
-export const TotalRow = styled(SummaryRow)`
-  font-weight: 800;
-  margin-top: 12px;
-`;
-
-export const RadioItem = styled.label`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 12px;
-`;
-
-export const CardForm = styled.div`
-  margin: 12px 0;
-`;
-
-export const Row = styled.div`
-  display: flex;
-  gap: 8px;
-`;
-
-export const Input = styled.input`
-  width: 100%;
-  padding: 10px;
-  border-radius: 8px;
-  border: 1px solid #ccc;
-`;
-
-export const TextArea = styled.textarea`
-  width: 100%;
-  min-height: 120px;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid #ccc;
-`;
-
-export const PrimaryButton = styled.button`
-  width: 100%;
-  margin-top: 16px;
-  padding: 14px;
-  border-radius: 12px;
-  border: none;
-  font-weight: 700;
-  background: #ff385c;
-  color: white;
-  cursor: pointer;
-
-  &:disabled {
-    background: #ccc;
-    cursor: not-allowed;
-  }
-`;
-
-export const SmallText = styled.p`
-  font-size: 14px;
-  color: #666;
-`;
-
-export const SummaryTop = styled.div`
-  display: flex;
-  gap: 12px;
-`;
-
-export const Thumbnail = styled.img`
-  width: 80px;
-  height: 80px;
-  border-radius: 12px;
-  object-fit: cover;
-`;
-
-export const SummaryTitle = styled.h3`
-  font-weight: 700;
-`;
-
-export const SummaryMeta = styled.div`
-  font-size: 14px;
-  color: #666;
-`;
-
-export const HostInfo = styled.div`
-  display: flex;
-  gap: 12px;
-  margin-bottom: 12px;
-`;
-
-export const HostAvatar = styled.div`
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  background: #ddd;
-`;
-
 export const PaymentPageLayout = styled.div`
+  max-width: 1240px;
+  margin: 36px auto 88px;
+  padding: 0 24px;
   display: grid;
-  grid-template-columns: 360px minmax(0, 700px);
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
   gap: 24px;
-  padding: 24px;
-  padding-top: 24px;
-  justify-content: center;
+  align-items: start;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+  }
+
+  @media (max-width: 768px) {
+    padding: 0 16px;
+    margin-top: 24px;
+  }
 `;
 
 export const PaymentContent = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
+`;
+
+export const SectionCard = styled.section`
+  border: 1px solid #e9e3dd;
+  background: #fffdfb;
+  border-radius: 20px;
+  padding: 22px 24px;
+  box-shadow: 0 4px 18px rgba(28, 19, 12, 0.04);
+
+  @media (max-width: 768px) {
+    padding: 20px 18px;
+  }
+`;
+
+export const SectionTitle = styled.h3`
+  margin: 0 0 16px;
+  font-size: 27px;
+  line-height: 1.3;
+  font-weight: 700;
+  color: #2e2a27;
+
+  @media (max-width: 768px) {
+    font-size: 22px;
+  }
+`;
+
+export const IntroRow = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+`;
+
+export const IntroIcon = styled.div`
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #d9d5d1;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 700;
+  flex-shrink: 0;
+`;
+
+export const IntroTextWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+export const IntroTitle = styled.div`
+  font-size: 15px;
+  font-weight: 700;
+  color: #3c3733;
+`;
+
+export const IntroDescription = styled.p`
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #8f867f;
+`;
+
+export const BrandCard = styled.div`
+  border: 1px solid #ede6e0;
+  border-radius: 14px;
+  padding: 18px 18px 16px;
+  background: #fff;
+`;
+
+export const BrandHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+`;
+
+export const BrandDot = styled.span`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #1570ef 0%, #3f8cff 100%);
+  box-shadow: 8px 0 0 #5aa8ff;
+`;
+
+export const BrandTitle = styled.div`
+  font-size: 18px;
+  font-weight: 800;
+  color: #4a4541;
+`;
+
+export const BrandSubText = styled.p`
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #8f867f;
+`;
+
+export const MethodPillRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+`;
+
+export const MethodPill = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f7f2ee;
+  color: #736a63;
+  font-size: 12px;
+  font-weight: 600;
+`;
+
+export const MessageGuide = styled.p`
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #8f867f;
+`;
+
+export const MessageBox = styled.textarea`
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  border: 1px solid #e5ded8;
+  border-radius: 12px;
+  padding: 14px 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: none;
+  background: #fff;
+  color: #2e2a27;
+
+  &::placeholder {
+    color: #b0a7a0;
+  }
+
+  &:focus {
+    border-color: #d5c7be;
+    box-shadow: 0 0 0 3px rgba(213, 199, 190, 0.18);
+  }
+`;
+
+export const SummaryCard = styled.div`
+  border: 1px solid #ede6e0;
+  border-radius: 14px;
+  padding: 8px 16px;
+  background: #fff;
+`;
+
+export const SummaryRow = styled.div<{ $isTotal?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  font-size: ${({ $isTotal }) => ($isTotal ? '16px' : '14px')};
+  font-weight: ${({ $isTotal }) => ($isTotal ? 700 : 500)};
+  color: ${({ $isTotal }) => ($isTotal ? '#2f2a26' : '#4f4945')};
+`;
+
+export const SummaryLabel = styled.span`
+  color: inherit;
+`;
+
+export const SummaryValue = styled.span`
+  color: inherit;
+`;
+
+export const SummaryDivider = styled.div`
+  height: 1px;
+  background: #f0e8e2;
+`;
+
+export const AgreementLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #736a63;
+  cursor: pointer;
+`;
+
+export const AgreementCheckbox = styled.input`
+  width: 14px;
+  height: 14px;
+  accent-color: #ff4f73;
 `;
 
 export const SubmitErrorBox = styled.div`
-  padding: 12px;
+  margin-top: 14px;
   border-radius: 12px;
-  border: 1px solid #fca5a5;
-  background: #fef2f2;
-  color: #991b1b;
+  padding: 12px 14px;
+  background: #fff3f5;
+  border: 1px solid #f6c6cf;
+  color: #d3405c;
+  font-size: 13px;
+  line-height: 1.5;
+`;
+
+export const SubmitButton = styled.button<{ $disabled: boolean }>`
+  width: 100%;
+  margin-top: 18px;
+  border: none;
+  border-radius: 12px;
+  padding: 16px 20px;
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  background: ${({ $disabled }) => ($disabled ? '#f8b7c4' : '#ff4c74')};
+  box-shadow: none;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    opacity: ${({ $disabled }) => ($disabled ? 1 : 0.94)};
+    transform: ${({ $disabled }) => ($disabled ? 'none' : 'translateY(-1px)')};
+  }
+`;
+
+export const SubmitHint = styled.p`
+  margin: 10px 0 0;
+  text-align: center;
+  font-size: 12px;
+  color: #9b928b;
+`;
+
+export const SideCard = styled.aside`
+  position: sticky;
+  top: 28px;
+  border: 1px solid #e9e3dd;
+  border-radius: 16px;
+  background: #fffdfb;
+  padding: 18px 16px 20px;
+  box-shadow: 0 4px 18px rgba(28, 19, 12, 0.04);
+
+  @media (max-width: 1024px) {
+    position: static;
+  }
+`;
+
+export const SideTop = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 18px;
+`;
+
+export const Thumbnail = styled.img`
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  object-fit: cover;
+  flex-shrink: 0;
+`;
+
+export const SideTitle = styled.h2`
+  margin: 0 0 6px;
+  font-size: 20px;
+  line-height: 1.35;
+  font-weight: 700;
+  color: #2e2a27;
+`;
+
+export const SideMeta = styled.p`
+  margin: 0;
+  font-size: 13px;
+  color: #8b8179;
+`;
+
+export const Divider = styled.div`
+  height: 1px;
+  background: #f0e8e2;
+  margin: 14px 0;
+`;
+
+export const SideInfoRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 8px 0;
   font-size: 14px;
+  color: #3f3935;
+`;
+
+export const SidePriceRow = styled.div`
+  padding: 12px 0 8px;
+  font-size: 14px;
+  color: #3f3935;
+`;
+
+export const SideTotalRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 12px;
+  font-size: 15px;
+  color: #2f2a26;
+
+  strong {
+    font-size: 16px;
+    font-weight: 700;
+  }
+`;
+
+export const SummaryTop = SideTop;
+export const SummaryTitle = SideTitle;
+export const SummaryMeta = SideMeta;
+export const TotalRow = SideTotalRow;
+
+export const HostInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+`;
+
+export const HostAvatar = styled.div`
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #e9e2db;
+`;
+
+export const SmallText = styled.p`
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: #8f867f;
+`;
+
+export const TextArea = MessageBox;
+
+export const PrimaryButton = styled.button`
+  width: 100%;
+  border: none;
+  border-radius: 12px;
+  padding: 14px 18px;
+  font-size: 16px;
+  font-weight: 700;
+  color: #fff;
+  background: #ff4c74;
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+    background: #f8b7c4;
+  }
+`;
+
+export const RadioItem = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+  font-size: 14px;
+  color: #3f3935;
+`;
+
+export const CardForm = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0 12px 28px;
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  border: 1px solid #e5ded8;
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 14px;
+  outline: none;
+`;
+
+export const Row = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 `;


### PR DESCRIPTION
## 🔗 반영 브랜치

(#45) feature/payment -> dev

## 📝 작업 내용

## 작업 내용
- 결제 페이지 UI를 전반적으로 정리해 스크린샷 기준의 카드형 레이아웃으로 개선했습니다.
- 깨져 있던 결제 페이지 한글 문구를 정상화하고 결제 플로우 문구를 다듬었습니다.
- 왼쪽 예약 요약 카드에 숙박비, 청소비, 서비스 수수료, 총액이 보이도록 가격 내역을 확장했습니다.
- 결제 페이지에서 입력한 호스트 메시지가 실제 채팅방으로 전달되도록 연결했습니다.
- 결제 진행 시 대화방이 없으면 생성하고, 있으면 기존 대화방을 재사용하도록 구현했습니다.
- 생성/조회한 `conversationId`를 기반으로 웹소켓 메시지 전송을 연결했습니다.

## 변경 파일
- `src/pages/payment/PaymentPage.tsx`
- `src/pages/payment/components/BookngSummaryCard.tsx`
- `src/pages/payment/payment.styles.ts`
- `src/api/messages.ts`

## 확인 방법
1. 숙소 상세 페이지에서 결제 페이지로 이동합니다.
2. 결제 페이지 레이아웃과 문구가 정상적으로 보이는지 확인합니다.
3. 왼쪽 요약 카드에 숙박비, 청소비, 서비스 수수료, 총액이 표시되는지 확인합니다.
4. `호스트에게 남길 메시지`에 내용을 입력한 뒤 결제 버튼을 누릅니다.
5. 채팅 목록 또는 해당 대화방에서 메시지가 생성되는지 확인합니다.

## 참고
- 호스트 메시지 전송은 결제 전에 시도됩니다.
- 채팅 전송이 실패해도 결제 흐름은 계속 진행되도록 처리했습니다.

<img width="1886" height="889" alt="스크린샷 2026-04-16 210808" src="https://github.com/user-attachments/assets/4e7cea2f-cda5-41ea-bd6c-963d2cd3e8e7" />

<img width="1874" height="833" alt="스크린샷 2026-04-16 211718" src="https://github.com/user-attachments/assets/3150a821-52a2-4668-ba68-7111346b5cb5" />


## 💬 리뷰 요구사항(선택 사항)

