### PR TITLE
Fix: 숙소 상세 정보 및 결제 페이지 대표 이미지 표시 개선

### DIFF
--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -1,6 +1,7 @@
 import client from './client';
 import type {
   AccommodationDetailDTO,
+  AccommodationImageCategoryDTO,
   HostelReviewDTO,
   ReviewListResponse,
 } from './types';
@@ -14,10 +15,24 @@ export async function fetchAccommodationDetail(
     throw new Error(`Invalid id format: ${id}`);
   }
 
-  const data = await client.get(
-    `/api/accommodations/${encodeURIComponent(id)}`
-  ) as AccommodationDetailDTO;
+  const data = (await client.get(
+    `/api/accommodations/${encodeURIComponent(id)}`,
+  )) as AccommodationDetailDTO;
   return data;
+}
+
+export async function fetchAccommodationImageCategories(
+  id: string,
+): Promise<AccommodationImageCategoryDTO[]> {
+  if (!id || !/^\d+$/.test(id)) {
+    throw new Error(`Invalid id format: ${id}`);
+  }
+
+  const data = (await client.get(
+    `/api/accommodations/${encodeURIComponent(id)}/image-categories`,
+  )) as AccommodationImageCategoryDTO[];
+
+  return Array.isArray(data) ? data : [];
 }
 
 // 숙소 리뷰 조회
@@ -37,26 +52,28 @@ export async function fetchAccommodationReviews(
   let reviewsToUse: HostelReviewDTO[] = [];
 
   // 더미 데이터 정의
-  const MOCK_REVIEWS: HostelReviewDTO[] = Array.from({ length: 3 }).map((_, i) => ({
-    id: 100 + i,
-    bookingId: 200 + i,
-    userNickName: `더미 유저 ${i + 1}`,
-    userProfileImageUrl: `https://i.pravatar.cc/150?u=${100 + i}`,
-    ratingOverall: 4.5 + (i * 0.1),
-    ratingCleanliness: 5,
-    ratingAccuracy: 4,
-    ratingCheckin: 5,
-    ratingCommunication: 5,
-    ratingLocation: 4,
-    reviewComment: `정말 멋진 숙소였습니다! (테스트 후기 ${i + 1})`,
-    comment: null,
-  }));
+  const MOCK_REVIEWS: HostelReviewDTO[] = Array.from({ length: 3 }).map(
+    (_, i) => ({
+      id: 100 + i,
+      bookingId: 200 + i,
+      userNickName: `더미 유저 ${i + 1}`,
+      userProfileImageUrl: `https://i.pravatar.cc/150?u=${100 + i}`,
+      ratingOverall: 4.5 + i * 0.1,
+      ratingCleanliness: 5,
+      ratingAccuracy: 4,
+      ratingCheckin: 5,
+      ratingCommunication: 5,
+      ratingLocation: 4,
+      reviewComment: `정말 멋진 숙소였습니다! (테스트 후기 ${i + 1})`,
+      comment: null,
+    }),
+  );
 
   try {
     // client.ts의 인터셉터가 response.data를 반환하므로, payload 자체가 배열임
-    const reviews = await client.get(
-      `/api/review/accommodation/${safeAccId}`
-    ) as HostelReviewDTO[];
+    const reviews = (await client.get(
+      `/api/review/accommodation/${safeAccId}`,
+    )) as HostelReviewDTO[];
 
     if (Array.isArray(reviews)) {
       reviewsToUse = reviews;
@@ -110,7 +127,8 @@ export async function fetchAccommodationReviews(
       author: {
         userId: 0,
         nickName: r.userNickName || `게스트 ${r.id}`,
-        profileImageUrl: r.userProfileImageUrl || `https://i.pravatar.cc/150?u=${r.id}`,
+        profileImageUrl:
+          r.userProfileImageUrl || `https://i.pravatar.cc/150?u=${r.id}`,
       },
       rating: Number(r.ratingOverall),
       content: r.reviewComment,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -7,6 +7,13 @@ export type AccommodationImageDTO = {
   displayOrder: number;
 };
 
+export type AccommodationImageCategoryDTO = {
+  categoryId: number | null;
+  categoryName: string;
+  displayOrder: number;
+  images: AccommodationImageDTO[];
+};
+
 export type AmenityDTO = {
   amenityId: number;
   name: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -138,15 +138,20 @@ export type PublicUserProfileResponse = {
 };
 
 export type AccommodationDetailInfoDTO = {
-  summary?: string;
-  space?: string;
-  access?: string;
-  notes?: string;
-  // Assuming these numeric fields are inside detail info based on typical patterns,
-  // as they are missing from the top-level DTO provided by the user.
-  bedrooms?: number;
-  beds?: number;
-  bathrooms?: number;
+  roomCount?: number;
+  bedroomCount?: number;
+  bedCount?: number;
+  bathroomCount?: number;
+  airConditionerCount?: number;
+  hairDryerCount?: number;
+  refrigeratorCount?: number;
+  televisionCount?: number;
+  washerCount?: number;
+  dryerCount?: number;
+  wifiAvailable?: boolean;
+  parkingAvailable?: boolean;
+  petAvailable?: boolean;
+  kitchenAvailable?: boolean;
 };
 
 export type AccommodationDetailDTO = {

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -13,9 +13,13 @@ import { useLightbox } from './hooks/useLightbox';
 
 import type {
   AccommodationImageDTO,
+  AccommodationImageCategoryDTO,
   ReviewListResponse,
 } from '../../api/types';
-import { fetchAccommodationReviews } from '../../api/accommodation';
+import {
+  fetchAccommodationImageCategories,
+  fetchAccommodationReviews,
+} from '../../api/accommodation';
 
 type ThumbImage = AccommodationImageDTO & { idx: number };
 
@@ -23,6 +27,9 @@ export default function AccommodationDetailPage() {
   const { id = '1' } = useParams();
   const navigate = useNavigate();
   const [reviews, setReviews] = useState<ReviewListResponse | null>(null);
+  const [imageCategories, setImageCategories] = useState<
+    AccommodationImageCategoryDTO[]
+  >([]);
 
   // 전체 사진 모달 상태
   const [isAllPhotosOpen, setIsAllPhotosOpen] = useState(false);
@@ -44,6 +51,12 @@ export default function AccommodationDetailPage() {
 
   useEffect(() => {
     load(id);
+    fetchAccommodationImageCategories(id)
+      .then(setImageCategories)
+      .catch((err) => {
+        console.error('이미지 카테고리 로딩 실패:', err);
+        setImageCategories([]);
+      });
     fetchAccommodationReviews(id)
       .then(setReviews)
       .catch((err) => {
@@ -183,6 +196,7 @@ export default function AccommodationDetailPage() {
         isOpen={isAllPhotosOpen}
         onClose={closeAllPhotos}
         images={images}
+        categories={imageCategories}
       />
     </S.Container>
   );

--- a/src/pages/accommodation/accommodationDetail.styles.ts
+++ b/src/pages/accommodation/accommodationDetail.styles.ts
@@ -20,7 +20,7 @@ export const Header = styled.header`
 
 export const Title = styled.h1`
   margin: 0 0 ${({ theme }) => theme.spacing.sm};
-  font-size: ${({ theme }) => theme.font.size["2xl"]};
+  font-size: ${({ theme }) => theme.font.size['2xl']};
   line-height: ${({ theme }) => theme.font.lineHeight.tight};
   font-weight: ${({ theme }) => theme.font.weight.extrabold};
   color: ${({ theme }) => theme.colors.text.primary};
@@ -308,7 +308,7 @@ export const LightboxClose = styled.button`
   border: none;
   background: transparent;
   color: ${({ theme }) => theme.colors.common.white};
-  font-size: ${({ theme }) => theme.font.size["2xl"]};
+  font-size: ${({ theme }) => theme.font.size['2xl']};
   cursor: pointer;
   transition: ${({ theme }) => theme.transition.colors.normal};
 
@@ -422,6 +422,25 @@ export const PhotoModalBody = styled.div`
   margin: 0 auto;
   padding: ${({ theme }) => theme.spacing.xl};
   width: 100%;
+`;
+
+export const CategorySectionList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const CategorySection = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.md};
+`;
+
+export const CategoryTitle = styled.h3`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
 `;
 
 export const PhotoGrid = styled.div`

--- a/src/pages/accommodation/components/AllPhotosModal.tsx
+++ b/src/pages/accommodation/components/AllPhotosModal.tsx
@@ -1,16 +1,24 @@
-import { useEffect } from 'react';
+﻿import { useEffect } from 'react';
 import * as S from '../accommodationDetail.styles';
-import type { AccommodationImageDTO } from '../../../api/types';
+import type {
+  AccommodationImageCategoryDTO,
+  AccommodationImageDTO,
+} from '../../../api/types';
 import { ChevronLeft } from 'lucide-react';
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
   images: AccommodationImageDTO[];
+  categories?: AccommodationImageCategoryDTO[];
 };
 
-export default function AllPhotosModal({ isOpen, onClose, images }: Props) {
-  // 모달이 열리면 바디 스크롤 막기
+export default function AllPhotosModal({
+  isOpen,
+  onClose,
+  images,
+  categories = [],
+}: Props) {
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -24,6 +32,11 @@ export default function AllPhotosModal({ isOpen, onClose, images }: Props) {
 
   if (!isOpen) return null;
 
+  const validCategories = categories.filter(
+    (category) => category.images.length > 0,
+  );
+  const hasCategorizedImages = validCategories.length > 0;
+
   return (
     <S.PhotoModalOverlay>
       <S.PhotoModalHeader>
@@ -33,13 +46,35 @@ export default function AllPhotosModal({ isOpen, onClose, images }: Props) {
       </S.PhotoModalHeader>
 
       <S.PhotoModalBody>
-        <S.PhotoGrid>
-          {images.map((img) => (
-            <S.PhotoItem key={img.imageId}>
-              <img src={img.imageUrl} alt={`숙소 이미지 ${img.imageId}`} />
-            </S.PhotoItem>
-          ))}
-        </S.PhotoGrid>
+        {hasCategorizedImages ? (
+          <S.CategorySectionList>
+            {validCategories.map((category) => (
+              <S.CategorySection
+                key={category.categoryId ?? category.categoryName}
+              >
+                <S.CategoryTitle>{category.categoryName}</S.CategoryTitle>
+                <S.PhotoGrid>
+                  {category.images.map((img) => (
+                    <S.PhotoItem key={img.imageId}>
+                      <img
+                        src={img.imageUrl}
+                        alt={`${category.categoryName} 이미지 ${img.imageId}`}
+                      />
+                    </S.PhotoItem>
+                  ))}
+                </S.PhotoGrid>
+              </S.CategorySection>
+            ))}
+          </S.CategorySectionList>
+        ) : (
+          <S.PhotoGrid>
+            {images.map((img) => (
+              <S.PhotoItem key={img.imageId}>
+                <img src={img.imageUrl} alt={`숙소 이미지 ${img.imageId}`} />
+              </S.PhotoItem>
+            ))}
+          </S.PhotoGrid>
+        )}
       </S.PhotoModalBody>
     </S.PhotoModalOverlay>
   );

--- a/src/pages/accommodation/components/AllPhotosModal.tsx
+++ b/src/pages/accommodation/components/AllPhotosModal.tsx
@@ -36,6 +36,8 @@ export default function AllPhotosModal({
     (category) => category.images.length > 0,
   );
   const hasCategorizedImages = validCategories.length > 0;
+  const getCategoryLabel = (categoryName: string) =>
+    !categoryName || categoryName === '미분류' ? '숙소 내부' : categoryName;
 
   return (
     <S.PhotoModalOverlay>
@@ -52,13 +54,15 @@ export default function AllPhotosModal({
               <S.CategorySection
                 key={category.categoryId ?? category.categoryName}
               >
-                <S.CategoryTitle>{category.categoryName}</S.CategoryTitle>
+                <S.CategoryTitle>
+                  {getCategoryLabel(category.categoryName)}
+                </S.CategoryTitle>
                 <S.PhotoGrid>
                   {category.images.map((img) => (
                     <S.PhotoItem key={img.imageId}>
                       <img
                         src={img.imageUrl}
-                        alt={`${category.categoryName} 이미지 ${img.imageId}`}
+                        alt={`${getCategoryLabel(category.categoryName)} ${img.imageId}`}
                       />
                     </S.PhotoItem>
                   ))}

--- a/src/pages/accommodation/components/InfoSection.tsx
+++ b/src/pages/accommodation/components/InfoSection.tsx
@@ -1,4 +1,4 @@
-import * as S from '../accommodationDetail.styles';
+﻿import * as S from '../accommodationDetail.styles';
 import type { AccommodationDetailDTO } from '../../../api/types';
 
 type Props = {
@@ -8,19 +8,16 @@ type Props = {
 export default function InfoSection({ detail }: Props) {
   return (
     <S.Left>
-      {/* 숙소 정보 */}
       <S.Section>
-        {/* HostDTO가 제거되어 닉네임을 알 수 없음 */}
-        <S.H2>호스트 : 알 수 없음</S.H2>
+        <S.H2>호스트: 알 수 없음</S.H2>
         <S.Meta>
-          최대 {detail.maxGuests}명 · 침실 {detail.detail?.bedrooms ?? 0}개 ·
-          침대 {detail.detail?.beds ?? 0}개 · 욕실{' '}
-          {detail.detail?.bathrooms ?? 0}개
+          최대 {detail.maxGuests}명 · 침실 {detail.detail?.bedroomCount ?? 0}개
+          · 침대 {detail.detail?.bedCount ?? 0}개 · 욕실{' '}
+          {detail.detail?.bathroomCount ?? 0}개
         </S.Meta>
         <S.P>{detail.description}</S.P>
       </S.Section>
 
-      {/* 편의시설 */}
       <S.Section>
         <S.H3>편의시설</S.H3>
         <S.AmenityList>

--- a/src/pages/accommodation/components/InfoSection.tsx
+++ b/src/pages/accommodation/components/InfoSection.tsx
@@ -9,7 +9,7 @@ export default function InfoSection({ detail }: Props) {
   return (
     <S.Left>
       <S.Section>
-        <S.H2>호스트: 알 수 없음</S.H2>
+        <S.H2>호스트: {detail.hostNickname || '알 수 없음'}</S.H2>
         <S.Meta>
           최대 {detail.maxGuests}명 · 침실 {detail.detail?.bedroomCount ?? 0}개
           · 침대 {detail.detail?.bedCount ?? 0}개 · 욕실{' '}

--- a/src/pages/payment/PaymentPage.tsx
+++ b/src/pages/payment/PaymentPage.tsx
@@ -65,6 +65,15 @@ export default function PaymentPage() {
     );
   }, [detail, checkIn, checkOut, nights]);
 
+  const summaryThumbnailUrl = useMemo(() => {
+    if (!detail?.images?.length) return undefined;
+
+    return (
+      detail.images.find((image) => image.isPrimary)?.imageUrl ??
+      detail.images[0]?.imageUrl
+    );
+  }, [detail]);
+
   if (!id) return <div>잘못된 접근</div>;
   if (loading) return <div>불러오는 중...</div>;
   if (error) return <div>에러: {error}</div>;
@@ -241,7 +250,7 @@ export default function PaymentPage() {
     <PaymentPageLayout>
       <BookingSummaryCard
         title={detail.title}
-        thumbnailUrl={detail.images?.[0]?.imageUrl}
+        thumbnailUrl={summaryThumbnailUrl}
         averageRating={detail.reviewSummary?.average ?? 0}
         reviewCount={detail.reviewSummary?.count ?? 0}
         checkIn={checkIn}


### PR DESCRIPTION
## 🔗 반영 브랜치

(#47 ) feature/accommodation-detail-page -> dev


## 📝 작업 내용
- 숙소 상세 페이지에서 침실, 침대, 욕실 개수가 백엔드 응답 필드명과 맞지 않아 `0개`로 보이던 문제를 수정했습니다.
- 숙소 상세 페이지의 `사진 모두 보기` 모달이 카테고리별 이미지 API를 활용해 이미지를 섹션별로 보여주도록 개선했습니다.
- 카테고리명이 없거나 `미분류`인 경우 사용자에게 더 자연스럽게 보이도록 `숙소 내부`로 표시되게 변경했습니다.
- 결제 페이지 왼쪽 숙소 요약 카드의 썸네일이 대표 이미지를 우선 사용하고, 대표 이미지가 없을 경우 첫 번째 이미지를 사용하도록 수정했습니다.

## 변경 파일
- `src/api/types.ts`
- `src/api/accommodation.ts`
- `src/pages/accommodation/AccommodationDetailPage.tsx`
- `src/pages/accommodation/components/InfoSection.tsx`
- `src/pages/accommodation/components/AllPhotosModal.tsx`
- `src/pages/accommodation/accommodationDetail.styles.ts`
- `src/pages/payment/PaymentPage.tsx`

## 확인 방법
1. 숙소 상세 페이지에 진입합니다.
2. 침실, 침대, 욕실 정보가 실제 값으로 표시되는지 확인합니다.
3. `사진 모두 보기`를 눌러 카테고리별 이미지가 섹션 형태로 보이는지 확인합니다.
4. 카테고리 없는 사진이 있을 경우 `숙소 내부 사진`으로 표시되는지 확인합니다.
5. 결제 페이지로 이동합니다.
6. 왼쪽 숙소 요약 카드 썸네일이 대표 이미지 우선으로 노출되는지 확인합니다.
7. 대표 이미지가 없는 경우 첫 번째 이미지가 표시되는지 확인합니다.

## 참고
- 카테고리별 이미지 API 응답이 없거나 비어 있는 경우에는 기존 전체 이미지 목록 방식으로 fallback 되도록 처리했습니다.

<img width="675" height="762" alt="image" src="https://github.com/user-attachments/assets/cc4bb3d4-35f0-4171-b9a9-6f0ea6ba0911" />




## 💬 리뷰 요구사항(선택 사항)


