### PR TITLE
Refactor: 날짜 선택 공통 컴포넌트 분리 및 BookingDatePicker 에어비앤비 스타일로 개선 

### DIFF
--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,48 @@
+---
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*)
+description: 변경사항을 분석해 한국어 커밋 메시지 초안을 제안하고, 확인 후 커밋
+---
+
+## Context
+
+- 현재 git 상태: !`git status`
+- 변경 내용 (staged + unstaged): !`git diff HEAD`
+- 현재 브랜치: !`git branch --show-current`
+- 최근 커밋 이력: !`git log --oneline -10`
+
+## 커밋 메시지 규칙
+
+타입은 아래 중 하나를 선택:
+
+| 타입       | 사용 시점                |
+| ---------- | ------------------------ |
+| `feat`     | 새 기능 추가             |
+| `fix`      | 버그 수정                |
+| `refactor` | 기능 변화 없는 코드 개선 |
+| `style`    | UI/스타일 변경           |
+| `chore`    | 설정, 의존성, 기타 잡무  |
+| `docs`     | 문서 수정                |
+
+형식: `타입: 한국어로 작업 내용 요약`
+
+예시:
+
+- `feat: 로그인 페이지 6자리 코드 입력 UI 추가`
+- `fix: 관리자 대시보드 날짜 파라미터 오류 수정`
+- `refactor: AuthContext 역할 분리 및 useAuth 훅 정리`
+
+## 진행 순서
+
+1. 변경사항을 분석해 커밋 메시지 초안을 **제안만** 한다 (커밋 X)
+2. 사용자에게 아래 형식으로 확인을 요청한다:
+
+```
+커밋 메시지 초안:
+  feat: (작업 내용)
+
+이대로 커밋할까요? 수정이 필요하면 알려주세요.
+```
+
+3. 사용자가 승인하면 그때 `git add` + `git commit` 실행
+4. push는 하지 않는다
+5. `.env`, `.env.local` 등 민감한 파일은 절대 포함하지 않는다

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_KAKAO_MAP_KEY=your_kakao_map_key

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -17,6 +17,42 @@ import type {
   AccommodationSearchResponse,
 } from './types';
 
+// TEMP MOCK: DB 연동 전 상세/달력 UI 검증용 (검증 후 삭제)
+const TEST_MOCK_ACCOMMODATION_ID = '999001';
+const TEST_MOCK_ACCOMMODATION_DETAIL: AccommodationDetailDTO = {
+  accommodationId: Number(TEST_MOCK_ACCOMMODATION_ID),
+  hostId: 1,
+  hostNickname: '테스트 호스트',
+  title: '테스트 숙소 (달력 검증용)',
+  description:
+    'DB 연결 전 상세 페이지 달력 동작 확인을 위한 임시 목 데이터입니다.',
+  accommodationType: 'entire_place',
+  address: '서울특별시 강남구 테헤란로 123',
+  city: '서울',
+  country: '대한민국',
+  maxGuests: 4,
+  pricePerNight: 120000,
+  cleaningFee: 15000,
+  serviceFeePercentage: 10,
+  instantBooking: false,
+  checkInTime: '15:00',
+  checkOutTime: '11:00',
+  images: [
+    {
+      imageId: 1,
+      imageUrl:
+        'https://a0.muscache.com/im/pictures/miso/Hosting-598015/original/a0ea4842-d25e-4f9f-93ed-c85b5aad0a01.jpeg',
+      isPrimary: true,
+      displayOrder: 0,
+    },
+  ],
+  amenities: [],
+  reviewSummary: {
+    average: 4.8,
+    count: 12,
+  },
+};
+
 // ============================================
 // 숙소 등록 API
 // ============================================
@@ -97,6 +133,10 @@ export async function fetchAccommodationDetail(
   // 입력값 검증: 숫자만 포함되어 있는지 확인 (Path Traversal 방지)
   if (!id || !/^\d+$/.test(id)) {
     throw new Error(`Invalid id format: ${id}`);
+  }
+
+  if (id === TEST_MOCK_ACCOMMODATION_ID) {
+    return TEST_MOCK_ACCOMMODATION_DETAIL;
   }
 
   const data = await client.get<AccommodationDetailDTO, AccommodationDetailDTO>(

--- a/src/components/AccommodationCard/AccommodationCard.tsx
+++ b/src/components/AccommodationCard/AccommodationCard.tsx
@@ -33,6 +33,7 @@ export interface AccommodationCardProps {
   rating?: number | null;
   isFavorite?: boolean;
   onFavoriteClick?: () => void;
+  onCardClick?: () => void;
 }
 
 const formatDateRange = (start: Date, end: Date): string => {
@@ -65,6 +66,7 @@ const AccommodationCard = ({
   rating,
   isFavorite = false,
   onFavoriteClick,
+  onCardClick,
 }: AccommodationCardProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const hasDate = !!date;
@@ -130,7 +132,7 @@ const AccommodationCard = ({
 
   return (
     <>
-      <CardContainer>
+      <CardContainer onClick={onCardClick}>
         <CardImage src={image} alt={title} />
         {badge && <CardBadge>{badge}</CardBadge>}
         <CardHeartButton onClick={handleHeartClick} $isFavorite={isFavorite}>

--- a/src/components/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown.tsx
@@ -32,7 +32,7 @@ type ProfileDropdownProps = {
 // 메뉴 텍스트 상수 (향후 i18n 적용 시 쉽게 교체 가능)
 const MENU_LABELS = {
   wishlist: '위시리스트',
-  trips: '여행',
+  trips: '예약',
   messages: '메시지',
   profile: '프로필',
   accountSettings: '계정 관리',
@@ -82,7 +82,7 @@ const ProfileDropdown = ({ onClose, buttonRef }: ProfileDropdownProps) => {
           <Heart />
           {MENU_LABELS.wishlist}
         </DropdownItem>
-        <DropdownItem>
+        <DropdownItem onClick={() => handleNavigate('/profile?menu=trips')}>
           <Home />
           {MENU_LABELS.trips}
         </DropdownItem>

--- a/src/components/SearchBar/SearchBar.styles.ts
+++ b/src/components/SearchBar/SearchBar.styles.ts
@@ -135,36 +135,6 @@ export const SearchButton = styled.button<{ $isCompact?: boolean }>`
   }
 `;
 
-// ── 날짜 팝업 ──────────────────────────────────────────────
-
-export const DatePopup = styled.div`
-  position: absolute;
-  top: calc(100% + ${({ theme }) => theme.spacing.md});
-  left: 50%;
-  transform: translateX(-50%);
-  background: ${({ theme }) => theme.colors.common.white};
-  border-radius: ${({ theme }) => theme.radius.lg};
-  box-shadow: ${({ theme }) => theme.shadow.lg};
-  padding: ${({ theme }) => theme.spacing.lg};
-  z-index: ${({ theme }) => theme.zIndex.searchBar};
-  white-space: normal;
-
-  ${media.mobile} {
-    left: 0;
-    transform: none;
-  }
-`;
-
-export const DayPickerWrapper = styled.div`
-  .rdp-root {
-    --rdp-accent-color: ${({ theme }) => theme.colors.primary.main};
-    --rdp-accent-color-dark: ${({ theme }) => theme.colors.primary.hover};
-    --rdp-background-color: ${({ theme }) => theme.colors.primary.main}20;
-    font-family: inherit;
-    font-size: ${({ theme }) => theme.font.size.sm};
-  }
-`;
-
 // ── 여행자 팝업 ────────────────────────────────────────────
 
 export const GuestPopup = styled.div`

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,5 +1,17 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useNavigate } from 'react-router-dom';
+import { format, startOfDay } from 'date-fns';
+import { Search, Minus, Plus } from 'lucide-react';
+
+import { useDateRangePicker } from '../date-range/useDateRangePicker';
+import DateRangePopover from '../date-range/DateRangePopover';
+import RegionPopup from './RegionPopup';
 import {
   SearchBarContainer,
   SearchField,
@@ -17,10 +29,6 @@ import {
   CounterButton,
   CounterValue,
 } from './SearchBar.styles';
-import { Search, Minus, Plus } from 'lucide-react';
-import { format } from 'date-fns';
-import RegionPopup from './RegionPopup';
-import DatePopup from './DatePopup';
 
 interface SearchBarProps {
   isCompact?: boolean;
@@ -74,15 +82,12 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
   const [showGuestPopup, setShowGuestPopup] = useState(false);
   const [showRegionPopup, setShowRegionPopup] = useState(false);
   const [showDatePopup, setShowDatePopup] = useState(false);
+  const [dateFieldRect, setDateFieldRect] = useState<DOMRect | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedLocation, setSelectedLocation] = useState<{
     province: string;
     city: string;
     district?: string;
-  } | null>(null);
-  const [dateRange, setDateRange] = useState<{
-    startDate: Date;
-    endDate: Date;
   } | null>(null);
   const [guests, setGuests] = useState({
     adults: 0,
@@ -90,33 +95,31 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
     infants: 0,
     pets: 0,
   });
-  const guestFieldRef = useRef<HTMLDivElement>(null);
-  const dateFieldRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const datePopupRef = useRef<HTMLDivElement>(null);
 
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dateFieldRef = useRef<HTMLDivElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const regionPopupRef = useRef<HTMLDivElement>(null);
+
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const { range, disabledMatchers, minStart, handleSelect, reset } =
+    useDateRangePicker({
+      minDate: today,
+      onComplete: () => setShowDatePopup(false),
+    });
+
+  // 여행자 팝업: 외부 클릭 시 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Node;
-
       if (
         popupRef.current &&
-        !popupRef.current.contains(target) &&
-        !guestFieldRef.current?.contains(target)
+        !popupRef.current.contains(event.target as Node)
       ) {
         setShowGuestPopup(false);
       }
-      if (
-        datePopupRef.current &&
-        !datePopupRef.current.contains(target) &&
-        !dateFieldRef.current?.contains(target)
-      ) {
-        setShowDatePopup(false);
-      }
     };
 
-    if (showGuestPopup || showDatePopup) {
+    if (showGuestPopup) {
       document.addEventListener('mousedown', handleClickOutside);
     } else {
       document.removeEventListener('mousedown', handleClickOutside);
@@ -125,10 +128,21 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [showGuestPopup, showDatePopup]);
+  }, [showGuestPopup]);
 
-  // Click outside for RegionPopup
-  const regionPopupRef = useRef<HTMLDivElement>(null);
+  // 날짜 팝업: ESC로 닫기 (portal 렌더링)
+  useEffect(() => {
+    if (!showDatePopup) return;
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') setShowDatePopup(false);
+    }
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [showDatePopup]);
+
+  // 지역 팝업: 외부 클릭 시 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
@@ -138,10 +152,16 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
         setShowRegionPopup(false);
       }
     };
-    if (showRegionPopup)
+
+    if (showRegionPopup) {
       document.addEventListener('mousedown', handleClickOutside);
-    else document.removeEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
   }, [showRegionPopup]);
 
   const updateGuest = useCallback((type: GuestType, delta: number) => {
@@ -153,6 +173,30 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
 
   const totalGuests =
     guests.adults + guests.children + guests.infants + guests.pets;
+
+  const dateLabel = range?.from
+    ? range.to
+      ? `${format(range.from, 'M월 d일')} - ${format(range.to, 'M월 d일')}`
+      : `${format(range.from, 'M월 d일')} ~`
+    : '날짜 추가';
+
+  const compactDateLabel =
+    range?.from && range?.to
+      ? `${format(range.from, 'M.d')}-${format(range.to, 'M.d')}`
+      : '언제든지';
+
+  const handleDateFieldClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (isCompact) return;
+
+    if (!showDatePopup && range?.from && range?.to) {
+      reset();
+    }
+
+    setDateFieldRect(e.currentTarget.getBoundingClientRect());
+    setShowDatePopup((prev) => !prev);
+    setShowRegionPopup(false);
+    setShowGuestPopup(false);
+  };
 
   return (
     <SearchBarContainer $isCompact={isCompact}>
@@ -215,7 +259,10 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
             onSelect={(province, city, district) => {
               setSelectedLocation({ province, city, district });
               setShowRegionPopup(false);
-              setShowDatePopup(true); // Automatically open date picker after region selection
+              if (dateFieldRef.current) {
+                setDateFieldRect(dateFieldRef.current.getBoundingClientRect());
+              }
+              setShowDatePopup(true);
             }}
           />
         )}
@@ -225,49 +272,20 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
 
       <SearchField
         ref={dateFieldRef}
-        onClick={() => {
-          setShowDatePopup(!showDatePopup);
-          setShowRegionPopup(false);
-          setShowGuestPopup(false);
-        }}
+        onClick={handleDateFieldClick}
         $hasPopup={showDatePopup}
         $isCompact={isCompact}
       >
         {!isCompact && <SearchFieldLabel>날짜</SearchFieldLabel>}
         <SearchFieldContent>
-          {!isCompact && (
-            <span>
-              {dateRange
-                ? `${format(dateRange.startDate, 'M월 d일')} - ${format(dateRange.endDate, 'M월 d일')}`
-                : '날짜 추가'}
-            </span>
-          )}
-          {isCompact && (
-            <span>
-              {dateRange
-                ? `${format(dateRange.startDate, 'M.d')}-${format(dateRange.endDate, 'M.d')}`
-                : '언제든지'}
-            </span>
-          )}
+          {!isCompact && <span>{dateLabel}</span>}
+          {isCompact && <span>{compactDateLabel}</span>}
         </SearchFieldContent>
-        {showDatePopup && (
-          <DatePopup
-            ref={datePopupRef}
-            startDate={dateRange?.startDate}
-            endDate={dateRange?.endDate}
-            onChange={(startDate, endDate) => {
-              setDateRange({ startDate, endDate });
-              setShowDatePopup(false);
-              setShowGuestPopup(true); // Automatically open guest popup after date selection
-            }}
-          />
-        )}
       </SearchField>
 
       <SearchDivider $isCompact={isCompact} />
 
       <SearchField
-        ref={guestFieldRef}
         onClick={() => {
           setShowGuestPopup(!showGuestPopup);
           setShowRegionPopup(false);
@@ -321,6 +339,7 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
         $isCompact={isCompact}
         onClick={() => {
           const params = new URLSearchParams();
+
           if (searchQuery.trim()) {
             params.append('title', searchQuery.trim());
           }
@@ -336,22 +355,16 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
           ) {
             params.append('district', selectedLocation.district);
           }
-          if (dateRange?.startDate) {
-            params.append(
-              'checkInDate',
-              format(dateRange.startDate, 'yyyy-MM-dd'),
-            );
+          if (range?.from) {
+            params.append('checkInDate', format(range.from, 'yyyy-MM-dd'));
           }
-          if (dateRange?.endDate) {
-            params.append(
-              'checkOutDate',
-              format(dateRange.endDate, 'yyyy-MM-dd'),
-            );
+          if (range?.to) {
+            params.append('checkOutDate', format(range.to, 'yyyy-MM-dd'));
           }
 
-          const totalGuests = guests.adults + guests.children;
-          if (totalGuests > 0) {
-            params.append('numberOfBeds', totalGuests.toString());
+          const bookingGuests = guests.adults + guests.children;
+          if (bookingGuests > 0) {
+            params.append('numberOfBeds', bookingGuests.toString());
           }
 
           navigate(`/search?${params.toString()}`);
@@ -360,6 +373,15 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
         <Search size={18} />
         {!isCompact && <span>검색</span>}
       </SearchButton>
+
+      <DateRangePopover
+        open={showDatePopup && !isCompact}
+        anchorRect={dateFieldRect}
+        range={range}
+        disabledMatchers={disabledMatchers}
+        minDate={minStart}
+        onSelect={handleSelect}
+      />
     </SearchBarContainer>
   );
 };

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -40,7 +40,7 @@ const Sidebar = ({ isOpen, onClose, isScrolled = false }: SidebarProps) => {
 
   const menuItems = [
     { icon: Heart, text: '위시리스트', path: '/wishlist' },
-    { icon: Plane, text: '여행', path: undefined },
+    { icon: Plane, text: '예약', path: '/profile?menu=trips' },
     { icon: MessageSquare, text: '메시지', path: '/messages' },
     { icon: User, text: '프로필', path: '/profile' },
     { icon: Settings, text: '계정 관리', path: '/account' },

--- a/src/components/accommodation/BookingDatePicker.styles.ts
+++ b/src/components/accommodation/BookingDatePicker.styles.ts
@@ -1,53 +1,198 @@
 import styled from 'styled-components';
 
+// 닫힌 상태 트리거 — Wrapper 높이 기준을 잡아줌
 export const Wrapper = styled.div`
   position: relative;
 `;
 
-export const TriggerButton = styled.button`
-  width: 100%;
-  text-align: left;
+export const CompactRow = styled.div`
+  display: flex;
   border: 1px solid ${({ theme }) => theme.colors.border.primary};
   border-radius: ${({ theme }) => theme.radius.md};
-  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.sm};
+  overflow: hidden;
+`;
+
+export const CompactBox = styled.button`
+  flex: 1;
+  text-align: left;
+  border: none;
+  padding: ${({ theme }) => `${theme.spacing.md} ${theme.spacing.sm}`};
   background: ${({ theme }) => theme.colors.common.white};
   cursor: pointer;
-  transition: ${({ theme }) => theme.transition.colors.normal};
+  outline: none;
+  transition: background-color 0.15s ease;
 
-  &:hover {
-    border-color: ${({ theme }) => theme.colors.primary.main};
+  & + & {
+    border-left: 1px solid ${({ theme }) => theme.colors.border.light};
   }
 
-  &:focus {
-    border-color: ${({ theme }) => theme.colors.primary.main};
-    box-shadow: 0 0 0 2px ${({ theme }) => theme.colors.primary.main}33;
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.hover};
   }
 `;
 
-export const TriggerLabel = styled.div`
+// CompactRow / InputBox 공통 라벨·값 컴포넌트
+export const DateFieldLabel = styled.div`
   font-size: ${({ theme }) => theme.font.size.xs};
   color: ${({ theme }) => theme.colors.text.secondary};
   margin-bottom: ${({ theme }) => theme.spacing.xxs};
 `;
 
-export const TriggerValue = styled.div`
+export const DateFieldValue = styled.div<{ $placeholder?: boolean }>`
+  font-size: ${({ theme }) => theme.font.size.sm};
   font-weight: ${({ theme }) => theme.font.weight.medium};
-  font-size: ${({ theme }) => theme.font.size.md};
-  color: ${({ theme }) => theme.colors.text.primary};
+  color: ${({ theme, $placeholder }) =>
+    $placeholder ? theme.colors.text.tertiary : theme.colors.text.primary};
 `;
 
-export const PopoverContainer = styled.div`
+// 열린 상태 패널 — top:0 으로 CompactRow 위에 오버레이
+// right:0 + min-width:660px → 카드 오른쪽 끝 정렬, 왼쪽으로 확장
+export const Panel = styled.div<{ $open: boolean }>`
   position: absolute;
-  z-index: ${({ theme }) => theme.zIndex.popover};
-  background: ${({ theme }) => theme.colors.common.white};
-  border: 1px solid ${({ theme }) => theme.colors.border.light};
-  border-radius: ${({ theme }) => theme.radius.md};
-  box-shadow: ${({ theme }) => theme.shadow.lg};
-  padding: ${({ theme }) => theme.spacing.sm};
+  top: 0;
+  right: 0;
   min-width: 660px;
+  max-height: ${({ $open }) => ($open ? '580px' : '0')};
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  background: ${({ theme }) => theme.colors.common.white};
+  border: ${({ $open, theme }) =>
+    $open ? `1px solid ${theme.colors.border.light}` : 'none'};
+  border-radius: ${({ theme }) => theme.radius.md};
+  box-shadow: ${({ $open }) =>
+    $open ? '0 10px 24px rgba(0,0,0,0.15)' : 'none'};
+  z-index: ${({ theme }) => theme.zIndex.popover};
 `;
 
-export const dayPickerStyles = {
-  months: { display: 'flex', flexWrap: 'nowrap' },
-  month: { width: 320, margin: '0 8px' },
+export const PanelHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.md};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const NightSummary = styled.div`
+  flex-shrink: 0;
+  min-width: 160px;
+`;
+
+export const NightCount = styled.div`
+  font-size: ${({ theme }) => theme.font.size.xl};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.text.primary};
+  line-height: 1.2;
+`;
+
+export const NightRange = styled.div`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  margin-top: ${({ theme }) => theme.spacing.xxs};
+`;
+
+export const InputsGroup = styled.div`
+  flex: 1;
+  display: flex;
+  gap: ${({ theme }) => theme.spacing.xs};
+`;
+
+export const InputBox = styled.button<{ $active?: boolean }>`
+  flex: 1;
+  position: relative;
+  text-align: left;
+  border: ${({ $active, theme }) =>
+    $active
+      ? `2px solid ${theme.colors.text.primary}`
+      : `1px solid ${theme.colors.border.primary}`};
+  border-radius: ${({ theme }) => theme.radius.md};
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  background: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+  outline: none;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+
+  &:hover {
+    border-color: ${({ $active, theme }) =>
+      $active ? theme.colors.text.primary : theme.colors.text.secondary};
+    background: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+// InputBox 전용: X 버튼 공간 확보용 padding-right 추가
+export const InputValue = styled(DateFieldValue)`
+  padding-right: ${({ theme }) => theme.spacing.xl};
+`;
+
+export const ClearIconButton = styled.button`
+  position: absolute;
+  right: ${({ theme }) => theme.spacing.sm};
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: ${({ theme }) => theme.radius.full};
+  background: ${({ theme }) => theme.colors.border.primary};
+  color: ${({ theme }) => theme.colors.common.white};
+  cursor: pointer;
+  padding: 0;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.text.secondary};
+  }
+`;
+
+export const FooterBar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.light};
+`;
+
+export const FooterActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+`;
+
+export const ClearDatesButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.primary};
+  padding: ${({ theme }) => `${theme.spacing.xs} ${theme.spacing.sm}`};
+  text-decoration: underline;
+  border-radius: ${({ theme }) => theme.radius.sm};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.hover};
+  }
+`;
+
+export const CloseButton = styled.button`
+  border: none;
+  cursor: pointer;
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.text.primary};
+  padding: ${({ theme }) => `${theme.spacing.xs} ${theme.spacing.lg}`};
+  border-radius: ${({ theme }) => theme.radius.md};
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+export const calendarStyles = {
+  months: { display: 'flex', flexWrap: 'nowrap' as const },
+  month: { width: 290, margin: '0 8px' },
 } as const;

--- a/src/components/accommodation/BookingDatePicker.tsx
+++ b/src/components/accommodation/BookingDatePicker.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState, useRef } from 'react';
-import { createPortal } from 'react-dom';
-import 'react-day-picker/dist/style.css';
+import { useEffect, useRef, useState } from 'react';
+import { format, differenceInCalendarDays } from 'date-fns';
+import { DayPicker, type DateRange } from 'react-day-picker';
 import ko from 'date-fns/locale/ko';
-import { DayPicker, type DateRange, type Matcher } from 'react-day-picker';
-import { format, parse, addDays, startOfDay } from 'date-fns';
-import { useTheme } from 'styled-components';
+import { X } from 'lucide-react';
+import 'react-day-picker/dist/style.css';
 
+import { useDateRangePicker } from '../date-range/useDateRangePicker';
 import * as S from './BookingDatePicker.styles';
 
 type Props = {
@@ -15,125 +15,160 @@ type Props = {
   minDate?: Date;
 };
 
-const FMT = 'yyyy-MM-dd';
-const toDate = (s?: string) => (s ? parse(s, FMT, new Date()) : undefined);
-const toStr = (d?: Date) => (d ? format(d, FMT) : undefined);
-
 export default function BookingDatePicker({
   checkIn,
   checkOut,
   onChange,
   minDate,
 }: Props) {
-  const theme = useTheme();
-  const today = useMemo(() => startOfDay(new Date()), []);
-  const minStart = useMemo(
-    () => startOfDay(minDate ?? today),
-    [minDate, today],
-  );
-
   const [open, setOpen] = useState(false);
-  const [buttonRect, setButtonRect] = useState<DOMRect | null>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [range, setRange] = useState<DateRange | undefined>(() => {
-    const from = toDate(checkIn);
-    const to = toDate(checkOut);
-    return from || to ? { from, to } : undefined;
-  });
+  const { range, disabledMatchers, minStart, handleSelect, reset } =
+    useDateRangePicker({
+      checkIn,
+      checkOut,
+      minDate,
+      onChange,
+      onComplete: () => setOpen(false),
+    });
 
-  useEffect(() => {
-    const from = toDate(checkIn);
-    const to = toDate(checkOut);
-    setRange(from || to ? { from, to } : undefined);
-  }, [checkIn, checkOut]);
+  // 체크인 선택 중 vs 체크아웃 선택 중
+  const isPickingEnd = !!(range?.from && !range?.to);
 
-  // 스크롤 시 위치 업데이트
-  useEffect(() => {
-    if (!open || !buttonRef.current) return;
-
-    function updatePosition() {
-      if (buttonRef.current) {
-        setButtonRect(buttonRef.current.getBoundingClientRect());
-      }
-    }
-
-    updatePosition();
-    window.addEventListener('scroll', updatePosition, true);
-    window.addEventListener('resize', updatePosition);
-
-    return () => {
-      window.removeEventListener('scroll', updatePosition, true);
-      window.removeEventListener('resize', updatePosition);
-    };
-  }, [open]);
-
-  // ESC 키만 처리
   useEffect(() => {
     if (!open) return;
+    function handleOutside(e: MouseEvent) {
+      if (
+        wrapperRef.current &&
+        !wrapperRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [open]);
 
+  useEffect(() => {
+    if (!open) return;
     function handleEscape(e: KeyboardEvent) {
       if (e.key === 'Escape') setOpen(false);
     }
-
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
   }, [open]);
 
-  const label =
+  // 체크인 박스 클릭: 초기화 후 체크인부터 다시 선택
+  const handleCheckInClick = () => {
+    reset();
+    setOpen(true);
+  };
+
+  // 체크아웃 박스 클릭: 체크인이 있으면 체크아웃만 재선택, 없으면 처음부터
+  const handleCheckOutClick = () => {
+    if (range?.from) {
+      handleSelect({ from: range.from, to: undefined } as DateRange);
+    } else {
+      reset();
+    }
+    setOpen(true);
+  };
+
+  const handleClearFrom = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    reset();
+    setOpen(false);
+  };
+
+  const handleClearTo = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // range.to가 있을 때만 버튼이 렌더링되므로 range.from도 반드시 존재
+    handleSelect({ from: range!.from, to: undefined } as DateRange);
+    setOpen(true);
+  };
+
+  const nights =
     range?.from && range?.to
-      ? `${format(range.from, 'MM.dd')} - ${format(range.to, 'MM.dd')}`
-      : range?.from
-        ? `${format(range.from, 'MM.dd')} - 체크아웃`
-        : '날짜 선택';
+      ? differenceInCalendarDays(range.to, range.from)
+      : 0;
 
-  const handleSelect = (newRange: DateRange | undefined) => {
-    setRange(newRange);
-    onChange(toStr(newRange?.from), toStr(newRange?.to));
+  const fmt = (d: Date) => format(d, 'yyyy. M. d.');
 
-    if (newRange?.from && newRange?.to) {
-      const isSameDay = newRange.from.getTime() === newRange.to.getTime();
-      if (!isSameDay) setTimeout(() => setOpen(false), 200);
-    }
-  };
+  return (
+    <S.Wrapper ref={wrapperRef}>
+      {/* 닫힌 상태: 컴팩트 트리거 — Wrapper 높이 기준 */}
+      <S.CompactRow>
+        <S.CompactBox type="button" onClick={handleCheckInClick}>
+          <S.DateFieldLabel>체크인</S.DateFieldLabel>
+          <S.DateFieldValue $placeholder={!range?.from}>
+            {range?.from ? fmt(range.from) : '날짜 선택'}
+          </S.DateFieldValue>
+        </S.CompactBox>
+        <S.CompactBox type="button" onClick={handleCheckOutClick}>
+          <S.DateFieldLabel>체크아웃</S.DateFieldLabel>
+          <S.DateFieldValue $placeholder={!range?.to}>
+            {range?.to ? fmt(range.to) : '날짜 선택'}
+          </S.DateFieldValue>
+        </S.CompactBox>
+      </S.CompactRow>
 
-  const toggleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (!open) {
-      setRange(undefined);
-      onChange(undefined, undefined);
-    }
+      {/* 열린 상태: top:0으로 CompactRow를 덮으며 통합 패널 펼침 */}
+      <S.Panel $open={open}>
+        <S.PanelHeader>
+          {nights > 0 && range?.from && range?.to && (
+            <S.NightSummary>
+              <S.NightCount>{nights}박</S.NightCount>
+              <S.NightRange>
+                {format(range.from, 'yyyy년 M월 d일')} -{' '}
+                {format(range.to, 'yyyy년 M월 d일')}
+              </S.NightRange>
+            </S.NightSummary>
+          )}
 
-    setButtonRect(e.currentTarget.getBoundingClientRect());
-    setOpen((v) => !v);
-  };
+          <S.InputsGroup>
+            <S.InputBox
+              type="button"
+              $active={!isPickingEnd}
+              onClick={handleCheckInClick}
+            >
+              <S.DateFieldLabel>체크인</S.DateFieldLabel>
+              <S.InputValue $placeholder={!range?.from}>
+                {range?.from ? fmt(range.from) : '날짜 추가'}
+              </S.InputValue>
+              {range?.from && (
+                <S.ClearIconButton
+                  type="button"
+                  onClick={handleClearFrom}
+                  aria-label="체크인 날짜 지우기"
+                >
+                  <X size={10} />
+                </S.ClearIconButton>
+              )}
+            </S.InputBox>
 
-  const isPickingEnd = !!(range?.from && !range?.to);
+            <S.InputBox
+              type="button"
+              $active={isPickingEnd}
+              onClick={handleCheckOutClick}
+            >
+              <S.DateFieldLabel>체크아웃</S.DateFieldLabel>
+              <S.InputValue $placeholder={!range?.to}>
+                {range?.to ? fmt(range.to) : '날짜 추가'}
+              </S.InputValue>
+              {range?.to && (
+                <S.ClearIconButton
+                  type="button"
+                  onClick={handleClearTo}
+                  aria-label="체크아웃 날짜 지우기"
+                >
+                  <X size={10} />
+                </S.ClearIconButton>
+              )}
+            </S.InputBox>
+          </S.InputsGroup>
+        </S.PanelHeader>
 
-  const disabledMatchers: Matcher[] = useMemo(() => {
-    const base: Matcher[] = [{ before: minStart }];
-
-    if (isPickingEnd && range?.from) {
-      const checkInDay = startOfDay(range.from);
-      base.push({ before: addDays(checkInDay, 1) });
-    }
-
-    return base;
-  }, [isPickingEnd, range?.from, minStart]);
-
-  const popover =
-    open &&
-    buttonRect &&
-    createPortal(
-      <S.PopoverContainer
-        style={{
-          top:
-            buttonRect.top +
-            buttonRect.height +
-            Number(theme.spacing.sm.replace('px', '')) +
-            window.scrollY,
-          left: buttonRect.left + window.scrollX,
-        }}
-      >
         <DayPicker
           mode="range"
           numberOfMonths={2}
@@ -143,22 +178,26 @@ export default function BookingDatePicker({
           fromDate={minStart}
           disabled={disabledMatchers}
           pagedNavigation
-          styles={S.dayPickerStyles}
+          styles={S.calendarStyles}
         />
-      </S.PopoverContainer>,
-      document.body,
-    );
 
-  return (
-    <>
-      <S.Wrapper>
-        <S.TriggerButton ref={buttonRef} type="button" onClick={toggleOpen}>
-          <S.TriggerLabel>날짜</S.TriggerLabel>
-          <S.TriggerValue>{label}</S.TriggerValue>
-        </S.TriggerButton>
-      </S.Wrapper>
-
-      {popover}
-    </>
+        <S.FooterBar>
+          <S.FooterActions>
+            <S.ClearDatesButton
+              type="button"
+              onClick={() => {
+                reset();
+                setOpen(true);
+              }}
+            >
+              날짜 지우기
+            </S.ClearDatesButton>
+            <S.CloseButton type="button" onClick={() => setOpen(false)}>
+              닫기
+            </S.CloseButton>
+          </S.FooterActions>
+        </S.FooterBar>
+      </S.Panel>
+    </S.Wrapper>
   );
 }

--- a/src/components/date-range/DateRangePopover.styles.ts
+++ b/src/components/date-range/DateRangePopover.styles.ts
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+/**
+ * createPortal(document.body)로 렌더링되므로 position: fixed 사용.
+ * top/left는 useLayoutEffect에서 실측 DOM 폭 기반으로 보정됨.
+ * sticky 헤더(SearchBar)와 일반 스크롤 위치(BookingCard) 모두에서 정상 동작.
+ */
+export const PopoverContainer = styled.div<{ $singleMonth?: boolean }>`
+  position: fixed;
+  z-index: ${({ theme }) => theme.zIndex.popover};
+  background: ${({ theme }) => theme.colors.common.white};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.md};
+  box-shadow: ${({ theme }) => theme.shadow.lg};
+  padding: ${({ theme }) => theme.spacing.sm};
+  min-width: ${({ $singleMonth }) => ($singleMonth ? '350px' : '660px')};
+`;
+
+export const dayPickerStyles = {
+  months: { display: 'flex', flexWrap: 'nowrap' as const },
+  month: { width: 320, margin: '0 8px' },
+} as const;

--- a/src/components/date-range/DateRangePopover.tsx
+++ b/src/components/date-range/DateRangePopover.tsx
@@ -1,0 +1,83 @@
+import { createPortal } from 'react-dom';
+import { useLayoutEffect, useRef, useState } from 'react';
+import { DayPicker, type DateRange, type Matcher } from 'react-day-picker';
+import ko from 'date-fns/locale/ko';
+import { useTheme } from 'styled-components';
+import 'react-day-picker/dist/style.css';
+
+import * as S from './DateRangePopover.styles';
+
+const EDGE_MARGIN = 16;
+// 2개월 달력(월 320*2 + 마진 16*2 + 패딩 16)을 담을 최소 뷰포트 너비
+const TWO_MONTH_MIN_VIEWPORT = 720;
+
+interface Props {
+  open: boolean;
+  /** 트리거 요소의 getBoundingClientRect() 결과 */
+  anchorRect: DOMRect | null;
+  range: DateRange | undefined;
+  disabledMatchers: Matcher[];
+  /** DayPicker fromDate: 선택 가능한 최솟값 */
+  minDate?: Date;
+  onSelect: (r: DateRange | undefined) => void;
+}
+
+export default function DateRangePopover({
+  open,
+  anchorRect,
+  range,
+  disabledMatchers,
+  minDate,
+  onSelect,
+}: Props) {
+  const theme = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [adjustedLeft, setAdjustedLeft] = useState<number | null>(null);
+
+  const numberOfMonths = window.innerWidth >= TWO_MONTH_MIN_VIEWPORT ? 2 : 1;
+
+  // 실제 렌더된 popover 너비(width)로 clamp 계산.
+  // elRect.right가 아닌 width를 사용해야 anchorRect 기준 계산이 정확하고
+  // 스크롤로 anchorRect가 바뀌어도 corrected 값이 달라지지 않아 튐이 없음.
+  // useLayoutEffect는 페인트 전 동기 실행 → 시각적 깜빡임 없음.
+  useLayoutEffect(() => {
+    if (!open) {
+      setAdjustedLeft(null);
+      return;
+    }
+    if (!anchorRect || !containerRef.current) return;
+
+    const { width } = containerRef.current.getBoundingClientRect();
+    const corrected = Math.max(
+      EDGE_MARGIN,
+      Math.min(anchorRect.left, window.innerWidth - width - EDGE_MARGIN),
+    );
+    setAdjustedLeft(corrected);
+  }, [open, anchorRect]);
+
+  if (!open || !anchorRect) return null;
+
+  const gap = parseInt(theme.spacing.sm, 10);
+  const left = adjustedLeft ?? anchorRect.left;
+
+  return createPortal(
+    <S.PopoverContainer
+      ref={containerRef}
+      $singleMonth={numberOfMonths === 1}
+      style={{ top: anchorRect.bottom + gap, left }}
+    >
+      <DayPicker
+        mode="range"
+        numberOfMonths={numberOfMonths}
+        selected={range}
+        onSelect={onSelect}
+        locale={ko}
+        fromDate={minDate}
+        disabled={disabledMatchers}
+        pagedNavigation
+        styles={S.dayPickerStyles}
+      />
+    </S.PopoverContainer>,
+    document.body,
+  );
+}

--- a/src/components/date-range/useDateRangePicker.ts
+++ b/src/components/date-range/useDateRangePicker.ts
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useState } from 'react';
+import { type DateRange, type Matcher } from 'react-day-picker';
+import { addDays, format, parse, startOfDay } from 'date-fns';
+
+const FMT = 'yyyy-MM-dd';
+
+export const toDate = (s?: string): Date | undefined =>
+  s ? parse(s, FMT, new Date()) : undefined;
+
+export const toStr = (d?: Date): string | undefined =>
+  d ? format(d, FMT) : undefined;
+
+interface Options {
+  checkIn?: string;
+  checkOut?: string;
+  /** 선택 가능한 최소 날짜. 미지정 시 오늘 기준 */
+  minDate?: Date;
+  /** checkIn/checkOut 문자열로 변환된 값 전달 */
+  onChange?: (ci?: string, co?: string) => void;
+  /** from+to 모두 선택되고 서로 다른 날 확정 후 200ms 뒤 호출 */
+  onComplete?: () => void;
+}
+
+export interface UseDateRangePickerReturn {
+  range: DateRange | undefined;
+  /** DayPicker disabled prop에 전달할 Matcher 배열 */
+  disabledMatchers: Matcher[];
+  /** DayPicker fromDate prop에 전달할 최솟값 */
+  minStart: Date;
+  handleSelect: (r: DateRange | undefined) => void;
+  /** 팝업 열기 전 기존 선택 초기화 (재선택 흐름) */
+  reset: () => void;
+}
+
+export function useDateRangePicker({
+  checkIn,
+  checkOut,
+  minDate,
+  onChange,
+  onComplete,
+}: Options): UseDateRangePickerReturn {
+  const today = useMemo(() => startOfDay(new Date()), []);
+  const minStart = useMemo(
+    () => startOfDay(minDate ?? today),
+    [minDate, today],
+  );
+
+  const [range, setRange] = useState<DateRange | undefined>(() => {
+    const from = toDate(checkIn);
+    const to = toDate(checkOut);
+    return from || to ? { from, to } : undefined;
+  });
+
+  // 외부 props 변경 시 동기화 (상세 페이지 store 연동)
+  useEffect(() => {
+    const from = toDate(checkIn);
+    const to = toDate(checkOut);
+    setRange(from || to ? { from, to } : undefined);
+  }, [checkIn, checkOut]);
+
+  const isPickingEnd = !!(range?.from && !range?.to);
+
+  const disabledMatchers = useMemo<Matcher[]>(() => {
+    const base: Matcher[] = [{ before: minStart }];
+    if (isPickingEnd && range?.from) {
+      // 체크인 다음 날부터 체크아웃 선택 가능
+      base.push({ before: addDays(startOfDay(range.from), 1) });
+    }
+    return base;
+  }, [isPickingEnd, range?.from, minStart]);
+
+  const handleSelect = (newRange: DateRange | undefined) => {
+    // from === to → 첫 클릭 (시작일만 선택된 상태로 정규화)
+    const normalized: DateRange | undefined =
+      newRange?.from &&
+      newRange?.to &&
+      newRange.from.getTime() === newRange.to.getTime()
+        ? { from: newRange.from, to: undefined }
+        : newRange;
+
+    setRange(normalized);
+    onChange?.(toStr(normalized?.from), toStr(normalized?.to));
+
+    if (normalized?.from && normalized?.to) {
+      setTimeout(() => onComplete?.(), 200);
+    }
+  };
+
+  const reset = () => {
+    setRange(undefined);
+    onChange?.(undefined, undefined);
+  };
+
+  return { range, disabledMatchers, minStart, handleSelect, reset };
+}

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -59,7 +59,9 @@ export default function AccommodationDetailPage() {
       });
     fetchAccommodationReviews(id)
       .then(setReviews)
-      .catch(() => {});
+      .catch((err) => {
+        console.error('리뷰 로딩 실패:', err);
+      });
   }, [id, load]);
 
   /* 

--- a/src/pages/accommodation/AccommodationDetailPage.tsx
+++ b/src/pages/accommodation/AccommodationDetailPage.tsx
@@ -59,9 +59,7 @@ export default function AccommodationDetailPage() {
       });
     fetchAccommodationReviews(id)
       .then(setReviews)
-      .catch((err) => {
-        console.error('리뷰 로딩 실패:', err);
-      });
+      .catch(() => {});
   }, [id, load]);
 
   /* 

--- a/src/pages/accommodation/components/BookingCard.tsx
+++ b/src/pages/accommodation/components/BookingCard.tsx
@@ -63,7 +63,6 @@ export default function BookingCard({
 
         <S.FormSection>
           <S.InputGroup>
-            <S.Label>날짜</S.Label>
             <BookingDatePicker
               checkIn={checkIn ?? undefined}
               checkOut={checkOut ?? undefined}

--- a/src/pages/main/AccommodationSection.tsx
+++ b/src/pages/main/AccommodationSection.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import AccommodationCard from '@/components/AccommodationCard/AccommodationCard';
 import type { Accommodation } from '@/types/accommodation';
 import {
@@ -21,6 +22,7 @@ const AccommodationSection = ({
   title,
   accommodations,
 }: AccommodationSectionProps) => {
+  const navigate = useNavigate();
   const listRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(true);
@@ -100,6 +102,7 @@ const AccommodationSection = ({
               price={accommodation.price}
               nights={accommodation.nights}
               rating={accommodation.rating}
+              onCardClick={() => navigate(`/accommodation/${accommodation.id}`)}
             />
           ))}
         </CardList>

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -13,6 +13,16 @@ import {
 const PLACEHOLDER_IMAGE =
   'https://a0.muscache.com/im/pictures/miso/Hosting-598015/original/a0ea4842-d25e-4f9f-93ed-c85b5aad0a01.jpeg';
 
+// TEMP MOCK: DB 연동 전 상세/달력 UI 검증용 (검증 후 삭제)
+const TEST_MOCK_ACCOMMODATION_ID = 999001;
+const TEST_MOCK_ACCOMMODATION: Accommodation = {
+  id: TEST_MOCK_ACCOMMODATION_ID,
+  image: PLACEHOLDER_IMAGE,
+  badge: '테스트',
+  title: '테스트 숙소 (달력 검증용)',
+  price: 120000,
+};
+
 const MainPage = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [accommodations, setAccommodations] = useState<Accommodation[]>([]);
@@ -32,11 +42,16 @@ const MainPage = () => {
           title: item.accommodationName,
           price: item.accommodationPrice,
         }));
-        setAccommodations(mapped);
+        const withoutMockDup = mapped.filter(
+          (item) => item.id !== TEST_MOCK_ACCOMMODATION_ID,
+        );
+        setAccommodations([TEST_MOCK_ACCOMMODATION, ...withoutMockDup]);
       })
       .catch((err) => {
         console.error('숙소 목록 조회 실패:', err);
-        setHasError(true);
+        // DB 연결이 어려운 상황에서도 상세/달력 테스트를 위해 목 카드 유지
+        setAccommodations([TEST_MOCK_ACCOMMODATION]);
+        setHasError(false);
       })
       .finally(() => {
         setIsLoading(false);

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ComponentType } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import IntroSection from './sections/IntroSection';
 import PastTripsSection from './sections/PastTripsSection';
@@ -46,10 +47,22 @@ const menuItems: MenuItem[] = [
 
 const ProfilePage = () => {
   const { user } = useAuth();
+  const [searchParams] = useSearchParams();
   const [activeMenu, setActiveMenu] = useState<MenuKey>('intro');
 
   const userName = user?.nickname || '예은';
   const userInitial = userName.charAt(0);
+
+  useEffect(() => {
+    const menuParam = searchParams.get('menu');
+    if (
+      menuParam === 'intro' ||
+      menuParam === 'trips' ||
+      menuParam === 'connections'
+    ) {
+      setActiveMenu(menuParam);
+    }
+  }, [searchParams]);
 
   const renderIcon = (iconType: string) => {
     switch (iconType) {


### PR DESCRIPTION
## 🔗 반영 브랜치
```
`refactor/calendar → dev`
```

## 📝 작업 내용
1. 달력 모달 공통 컴포넌트 분리 및 UI 변경
2. 메인페이지 숙소 클릭 시 상세 페이지로 이동하도록 경로 설정
3. 상단바 메뉴바 > 예약 클릭 시 profile > 예약으로 이동하도록 경로 설정

<img width="752" height="579" alt="스크린샷 2026-04-23 오후 9 45 01" src="https://github.com/user-attachments/assets/2b8bab85-23e6-4a85-bc01-4bdf4e2426e5" />

## 💬 리뷰 요구사항(선택 사항)
.
