### PR TITLE
Refactor 리뷰 페이지 레이아웃 통합 및 기능 고도화

### DIFF
--- a/src/components/reviews/GuestReviewModal.tsx
+++ b/src/components/reviews/GuestReviewModal.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
-import styled from "styled-components";
-import type { UserReviewCreateRequest } from "@/api/types";
+import { useState } from 'react';
+import styled from 'styled-components';
+import type { UserReviewCreateRequest } from '@/api/types';
+import axios from 'axios';
 
 // 재사용 가능한 모달 스타일들 (ReviewFormModal 참조)
 const ModalOverlay = styled.div`
@@ -68,7 +69,8 @@ const Button = styled.button<{ $primary?: boolean }>`
   border: none;
   background-color: ${({ $primary, theme }) =>
     $primary ? theme.colors.primary.main : theme.colors.background.active};
-  color: ${({ $primary, theme }) => ($primary ? theme.colors.common.white : theme.colors.text.primary)};
+  color: ${({ $primary, theme }) =>
+    $primary ? theme.colors.common.white : theme.colors.text.primary};
 
   &:hover {
     opacity: 0.9;
@@ -90,15 +92,20 @@ interface GuestReviewModalProps {
   onSubmit: (data: UserReviewCreateRequest) => Promise<void>;
 }
 
-const GuestReviewModal = ({ bookingId, guestId, onClose, onSubmit }: GuestReviewModalProps) => {
+const GuestReviewModal = ({
+  bookingId,
+  guestId,
+  onClose,
+  onSubmit,
+}: GuestReviewModalProps) => {
   const [rating, setRating] = useState<number>(5);
-  const [reviewComment, setReviewComment] = useState("");
+  const [reviewComment, setReviewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!reviewComment.trim()) {
-      alert("리뷰 내용을 입력해주세요.");
+      alert('리뷰 내용을 입력해주세요.');
       return;
     }
 
@@ -112,8 +119,12 @@ const GuestReviewModal = ({ bookingId, guestId, onClose, onSubmit }: GuestReview
       });
       onClose();
     } catch (error) {
-      console.error("리뷰 제출 실패:", error);
-      alert("리뷰 제출에 실패했습니다. 다시 시도해주세요.");
+      console.error('리뷰 제출 실패:', error);
+      let errorMessage = '리뷰 제출에 실패했습니다. 다시 시도해주세요.';
+      if (axios.isAxiosError(error) && error.response?.data?.message) {
+        errorMessage = error.response.data.message;
+      }
+      alert(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
@@ -126,7 +137,10 @@ const GuestReviewModal = ({ bookingId, guestId, onClose, onSubmit }: GuestReview
         <form onSubmit={handleSubmit}>
           <FormGroup>
             <Label>평점</Label>
-            <Select value={rating} onChange={(e) => setRating(Number(e.target.value))}>
+            <Select
+              value={rating}
+              onChange={(e) => setRating(Number(e.target.value))}
+            >
               <option value={5}>5 - 아주 훌륭해요!</option>
               <option value={4}>4 - 좋아요</option>
               <option value={3}>3 - 보통이에요</option>
@@ -149,7 +163,7 @@ const GuestReviewModal = ({ bookingId, guestId, onClose, onSubmit }: GuestReview
               취소
             </Button>
             <Button type="submit" $primary disabled={isSubmitting}>
-              {isSubmitting ? "제출 중..." : "제출하기"}
+              {isSubmitting ? '제출 중...' : '제출하기'}
             </Button>
           </ButtonGroup>
         </form>

--- a/src/components/reviews/ReviewFormModal.tsx
+++ b/src/components/reviews/ReviewFormModal.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
-import styled from "styled-components";
-import { Star } from "lucide-react";
-import type { AccommodationReviewRequest } from "@/api/types";
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Star } from 'lucide-react';
+import type { AccommodationReviewRequest } from '@/api/types';
+import axios from 'axios';
 
 interface ReviewFormModalProps {
   bookingId: number;
@@ -10,11 +11,11 @@ interface ReviewFormModalProps {
 }
 
 const RATING_CATEGORIES = [
-  { id: "cleanliness", label: "청결도" },
-  { id: "accuracy", label: "정확성" },
-  { id: "checkin", label: "체크인" },
-  { id: "communication", label: "의사소통" },
-  { id: "location", label: "위치" },
+  { id: 'cleanliness', label: '청결도' },
+  { id: 'accuracy', label: '정확성' },
+  { id: 'checkin', label: '체크인' },
+  { id: 'communication', label: '의사소통' },
+  { id: 'location', label: '위치' },
 ] as const;
 
 type RatingState = {
@@ -39,7 +40,7 @@ export default function ReviewFormModal({
     communication: 0,
     location: 0,
   });
-  const [comment, setComment] = useState("");
+  const [comment, setComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleRatingChange = (key: keyof RatingState, value: number) => {
@@ -51,11 +52,11 @@ export default function ReviewFormModal({
 
     // 간단한 유효성 검사
     if (Object.values(ratings).some((val) => val === 0)) {
-      alert("모든 항목에 별점을 입력해주세요.");
+      alert('모든 항목에 별점을 입력해주세요.');
       return;
     }
     if (comment.trim().length < 10) {
-      alert("리뷰 내용을 10자 이상 작성해주세요.");
+      alert('리뷰 내용을 10자 이상 작성해주세요.');
       return;
     }
 
@@ -73,8 +74,12 @@ export default function ReviewFormModal({
       });
       onClose();
     } catch (error) {
-      console.error("리뷰 제출 실패:", error);
-      alert("리뷰 제출에 실패했습니다. 다시 시도해주세요.");
+      console.error('리뷰 제출 실패:', error);
+      let errorMessage = '리뷰 제출에 실패했습니다. 다시 시도해주세요.';
+      if (axios.isAxiosError(error) && error.response?.data?.message) {
+        errorMessage = error.response.data.message;
+      }
+      alert(errorMessage);
     } finally {
       setIsSubmitting(false);
     }
@@ -101,7 +106,7 @@ export default function ReviewFormModal({
             <RatingLabel>전체 평점</RatingLabel>
             <StarRating
               rating={ratings.overall}
-              onChange={(val) => handleRatingChange("overall", val)}
+              onChange={(val) => handleRatingChange('overall', val)}
               size={32}
             />
           </FormGroup>
@@ -138,7 +143,7 @@ export default function ReviewFormModal({
               취소
             </SecondaryButton>
             <SubmitButton type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "제출 중..." : "리뷰 제출"}
+              {isSubmitting ? '제출 중...' : '리뷰 제출'}
             </SubmitButton>
           </FormActions>
         </ModalBody>
@@ -169,7 +174,7 @@ function StarRating({ rating, onChange, size = 24 }: StarRatingProps) {
         >
           <Star
             size={size}
-            fill={star <= (hoverRating || rating) ? "currentColor" : "none"}
+            fill={star <= (hoverRating || rating) ? 'currentColor' : 'none'}
             stroke="currentColor"
           />
         </StarIconButton>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import type { ComponentType } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import IntroSection from './sections/IntroSection';
 import PastTripsSection from './sections/PastTripsSection';
 import ConnectionsSection from './sections/ConnectionsSection';
+import ReviewsPage from './reviews/ReviewsPage';
 import {
   PageContainer,
   ContentWrapper,
@@ -18,15 +19,16 @@ import {
   MainContent,
 } from './profile.styles';
 
-type MenuKey = 'intro' | 'trips' | 'connections';
+type MenuKey = 'intro' | 'trips' | 'connections' | 'reviews';
 
 interface MenuItem {
   key: MenuKey;
   icon: string;
   label: string;
-  component:
+  component?:
     | ComponentType<{ userName: string; userInitial: string }>
     | ComponentType;
+  path?: string;
 }
 
 const menuItems: MenuItem[] = [
@@ -43,26 +45,41 @@ const menuItems: MenuItem[] = [
     label: '인연',
     component: ConnectionsSection,
   },
+  {
+    key: 'reviews',
+    icon: 'clipboard',
+    label: '리뷰',
+    component: ReviewsPage,
+    path: '/profile/reviews',
+  },
 ];
 
 const ProfilePage = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [activeMenu, setActiveMenu] = useState<MenuKey>('intro');
 
   const userName = user?.nickname || '예은';
   const userInitial = userName.charAt(0);
 
   useEffect(() => {
+    if (location.pathname === '/profile/reviews') {
+      setActiveMenu('reviews');
+      return;
+    }
+
     const menuParam = searchParams.get('menu');
     if (
       menuParam === 'intro' ||
       menuParam === 'trips' ||
-      menuParam === 'connections'
+      menuParam === 'connections' ||
+      menuParam === 'reviews'
     ) {
       setActiveMenu(menuParam);
     }
-  }, [searchParams]);
+  }, [searchParams, location.pathname]);
 
   const renderIcon = (iconType: string) => {
     switch (iconType) {
@@ -84,6 +101,12 @@ const ProfilePage = () => {
             <span style={{ fontSize: 28 }}>👥</span>
           </MenuIcon>
         );
+      case 'clipboard':
+        return (
+          <MenuIcon>
+            <span style={{ fontSize: 28 }}>📋</span>
+          </MenuIcon>
+        );
       default:
         return null;
     }
@@ -102,7 +125,17 @@ const ProfilePage = () => {
               <SidebarMenuItem
                 key={item.key}
                 $active={activeMenu === item.key}
-                onClick={() => setActiveMenu(item.key)}
+                onClick={() => {
+                  if (item.path) {
+                    navigate(item.path);
+                  } else {
+                    if (location.pathname === '/profile/reviews') {
+                      navigate(`/profile?menu=${item.key}`);
+                    } else {
+                      setActiveMenu(item.key);
+                    }
+                  }
+                }}
               >
                 {renderIcon(item.icon)}
                 <MenuItemText>{item.label}</MenuItemText>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -126,15 +126,8 @@ const ProfilePage = () => {
                 key={item.key}
                 $active={activeMenu === item.key}
                 onClick={() => {
-                  if (item.path) {
-                    navigate(item.path);
-                  } else {
-                    if (location.pathname === '/profile/reviews') {
-                      navigate(`/profile?menu=${item.key}`);
-                    } else {
-                      setActiveMenu(item.key);
-                    }
-                  }
+                  const targetPath = item.path || `/profile?menu=${item.key}`;
+                  navigate(targetPath);
                 }}
               >
                 {renderIcon(item.icon)}

--- a/src/pages/profile/reviews/ReviewsPage.tsx
+++ b/src/pages/profile/reviews/ReviewsPage.tsx
@@ -86,8 +86,8 @@ const ReviewsPage = () => {
     try {
       setIsLoading(true);
       if (activeTab === 'by-me') {
-        // 1. 내 전체 예약 목록 로드
-        const allBookings = await fetchUserBookings();
+        // 1. 내 전체 예약 목록 중 이용 완료된 예약만 로드
+        const allBookings = await fetchUserBookings('COMPLETED');
         setBookings(allBookings);
 
         // 2. 예약된 숙소(accId) 추출 및 중복 제거
@@ -125,10 +125,10 @@ const ReviewsPage = () => {
         setAccommodationNames(newNames);
         setWrittenReviewBookingIds(writtenBookingIds);
 
-        // 호스트인 경우 게스트 리뷰를 위해 hostBookings 도 추가 로드
+        // 호스트인 경우 게스트 리뷰를 위해 완료된 hostBookings 도 추가 로드
         if (isHost) {
           try {
-            const hBookings = await fetchHostBookings();
+            const hBookings = await fetchHostBookings('COMPLETED');
             setHostBookings(hBookings);
           } catch (err) {
             console.error('호스트 예약 정보 로드 실패:', err);

--- a/src/pages/profile/reviews/ReviewsPage.tsx
+++ b/src/pages/profile/reviews/ReviewsPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { fetchUserBookings, fetchHostBookings } from '@/api/booking';
 import {
@@ -20,12 +19,6 @@ import ReviewFormModal from '@/components/reviews/ReviewFormModal';
 import GuestReviewModal from '@/components/reviews/GuestReviewModal';
 import ReviewItem from '@/components/reviews/ReviewItem';
 import {
-  PageContainer,
-  ContentWrapper,
-  Breadcrumb,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-  BreadcrumbCurrent,
   PageTitle,
   TabContainer,
   Tab,
@@ -47,7 +40,6 @@ import {
 type TabKey = 'about-me' | 'by-me';
 
 const ReviewsPage = () => {
-  const navigate = useNavigate();
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState<TabKey>('by-me');
 
@@ -167,193 +159,175 @@ const ReviewsPage = () => {
   );
 
   return (
-    <PageContainer>
-      <ContentWrapper>
-        <Breadcrumb>
-          <BreadcrumbLink onClick={() => navigate('/profile')}>
-            프로필
-          </BreadcrumbLink>
-          <BreadcrumbSeparator>&gt;</BreadcrumbSeparator>
-          <BreadcrumbCurrent>후기</BreadcrumbCurrent>
-        </Breadcrumb>
+    <>
+      <PageTitle>
+        {activeTab === 'by-me' ? '내가 작성한 후기' : '나에 대한 후기'}
+      </PageTitle>
 
-        <PageTitle>
-          {activeTab === 'by-me' ? '내가 작성한 후기' : '나에 대한 후기'}
-        </PageTitle>
+      <TabContainer>
+        <Tab
+          $active={activeTab === 'about-me'}
+          onClick={() => setActiveTab('about-me')}
+        >
+          나에 대한 후기
+        </Tab>
+        <Tab
+          $active={activeTab === 'by-me'}
+          onClick={() => setActiveTab('by-me')}
+        >
+          내가 작성한 후기
+        </Tab>
+      </TabContainer>
 
-        <TabContainer>
-          <Tab
-            $active={activeTab === 'about-me'}
-            onClick={() => setActiveTab('about-me')}
-          >
-            나에 대한 후기
-          </Tab>
-          <Tab
-            $active={activeTab === 'by-me'}
-            onClick={() => setActiveTab('by-me')}
-          >
-            내가 작성한 후기
-          </Tab>
-        </TabContainer>
-
-        {activeTab === 'by-me' && (
-          <>
-            <SectionTitle>
-              작성해야 할 후기 ({pendingBookings.length})
-            </SectionTitle>
-            {isLoading ? (
-              <SectionDescription>불러오는 중...</SectionDescription>
-            ) : pendingBookings.length === 0 ? (
-              <SectionDescription>
-                현재 작성할 후기가 없습니다. 여행을 한번 다녀올 때가 된 것
-                같네요!
-              </SectionDescription>
-            ) : (
-              <ReviewList>
-                {pendingBookings.map((booking) => (
-                  <ReviewListItem key={`pending-${booking.bookingId}`}>
-                    <div>
-                      <BookingTitle>
-                        {accommodationNames[booking.accommodationId] ||
-                          `숙소 ID: ${booking.accommodationId}`}
-                      </BookingTitle>
-                      <BookingDetails>
-                        예약 번호: {booking.bookingId} | 일정:{' '}
-                        {booking.checkInDate} ~ {booking.checkOutDate}
-                      </BookingDetails>
-                    </div>
-                    <ActionButton
-                      onClick={() => setReviewModalTarget(booking.bookingId)}
-                    >
-                      후기 작성
-                    </ActionButton>
-                  </ReviewListItem>
-                ))}
-              </ReviewList>
-            )}
-
-            <Divider />
-
-            <SectionTitle>
-              내가 작성한 후기 ({writtenBookings.length})
-            </SectionTitle>
-            {isLoading ? (
-              <SectionDescription>불러오는 중...</SectionDescription>
-            ) : writtenBookings.length === 0 ? (
-              <SectionDescription>
-                아직 후기를 남기지 않으셨습니다.
-              </SectionDescription>
-            ) : (
-              <ReviewList>
-                {writtenBookings.map((booking) => (
-                  <ReviewListItem
-                    key={`written-${booking.bookingId}`}
-                    $isWritten
+      {activeTab === 'by-me' && (
+        <>
+          <SectionTitle>
+            작성해야 할 후기 ({pendingBookings.length})
+          </SectionTitle>
+          {isLoading ? (
+            <SectionDescription>불러오는 중...</SectionDescription>
+          ) : pendingBookings.length === 0 ? (
+            <SectionDescription>
+              현재 작성할 후기가 없습니다. 여행을 한번 다녀올 때가 된 것 같네요!
+            </SectionDescription>
+          ) : (
+            <ReviewList>
+              {pendingBookings.map((booking) => (
+                <ReviewListItem key={`pending-${booking.bookingId}`}>
+                  <div>
+                    <BookingTitle>
+                      {accommodationNames[booking.accommodationId] ||
+                        `숙소 ID: ${booking.accommodationId}`}
+                    </BookingTitle>
+                    <BookingDetails>
+                      예약 번호: {booking.bookingId} | 일정:{' '}
+                      {booking.checkInDate} ~ {booking.checkOutDate}
+                    </BookingDetails>
+                  </div>
+                  <ActionButton
+                    onClick={() => setReviewModalTarget(booking.bookingId)}
                   >
-                    <div>
-                      <BookingTitle>
-                        {accommodationNames[booking.accommodationId] ||
-                          `숙소 ID: ${booking.accommodationId}`}
-                      </BookingTitle>
-                      <BookingDetails>
-                        예약 번호: {booking.bookingId} | 일정:{' '}
-                        {booking.checkInDate} ~ {booking.checkOutDate}
-                      </BookingDetails>
-                      <StatusText>작성 완료</StatusText>
-                    </div>
-                  </ReviewListItem>
-                ))}
-              </ReviewList>
-            )}
+                    후기 작성
+                  </ActionButton>
+                </ReviewListItem>
+              ))}
+            </ReviewList>
+          )}
 
-            {isHost && (
-              <>
-                <Divider />
-                <SectionTitle>
-                  내 숙소 방문 게스트 ({hostBookings.length})
-                </SectionTitle>
-                <SectionDescription>
-                  게스트에 대한 리뷰를 작성해 보세요. 호스트 리뷰는 다른
-                  호스트들에게 큰 도움이 됩니다.
-                </SectionDescription>
-                {hostBookings.length === 0 ? (
-                  <SectionDescription>
-                    아직 방문한 게스트가 없습니다.
-                  </SectionDescription>
-                ) : (
-                  <ReviewList>
-                    {hostBookings.map((b) => (
-                      <HostReviewListItem key={`host-booking-${b.bookingId}`}>
-                        <div>
-                          <BookingTitle>
-                            숙소: {b.accommodationTitle}
-                          </BookingTitle>
-                          <BookingDetails>
-                            예약번호: {b.bookingId} | 일정: {b.checkInDate} ~{' '}
-                            {b.checkOutDate}
-                          </BookingDetails>
-                          <GuestDetails>
-                            방문 게스트 ID: {b.guestId} ({b.numberOfGuests}명)
-                          </GuestDetails>
-                        </div>
-                        <HostActionButton
-                          onClick={() =>
-                            setGuestReviewModalTarget({
-                              bookingId: b.bookingId,
-                              guestId: b.guestId,
-                            })
-                          }
-                        >
-                          게스트 리뷰 작성
-                        </HostActionButton>
-                      </HostReviewListItem>
-                    ))}
-                  </ReviewList>
-                )}
-              </>
-            )}
-          </>
-        )}
+          <Divider />
 
-        {activeTab === 'about-me' && (
-          <>
-            <SectionTitle>
-              나에 대한 후기 ({aboutMeReviews.length})
-            </SectionTitle>
-            {isLoading ? (
-              <SectionDescription>불러오는 중...</SectionDescription>
-            ) : aboutMeReviews.length === 0 ? (
+          <SectionTitle>
+            내가 작성한 후기 ({writtenBookings.length})
+          </SectionTitle>
+          {isLoading ? (
+            <SectionDescription>불러오는 중...</SectionDescription>
+          ) : writtenBookings.length === 0 ? (
+            <SectionDescription>
+              아직 후기를 남기지 않으셨습니다.
+            </SectionDescription>
+          ) : (
+            <ReviewList>
+              {writtenBookings.map((booking) => (
+                <ReviewListItem key={`written-${booking.bookingId}`} $isWritten>
+                  <div>
+                    <BookingTitle>
+                      {accommodationNames[booking.accommodationId] ||
+                        `숙소 ID: ${booking.accommodationId}`}
+                    </BookingTitle>
+                    <BookingDetails>
+                      예약 번호: {booking.bookingId} | 일정:{' '}
+                      {booking.checkInDate} ~ {booking.checkOutDate}
+                    </BookingDetails>
+                    <StatusText>작성 완료</StatusText>
+                  </div>
+                </ReviewListItem>
+              ))}
+            </ReviewList>
+          )}
+
+          {isHost && (
+            <>
+              <Divider />
+              <SectionTitle>
+                내 숙소 방문 게스트 ({hostBookings.length})
+              </SectionTitle>
               <SectionDescription>
-                아직 받은 후기가 없습니다.
+                게스트에 대한 리뷰를 작성해 보세요. 호스트 리뷰는 다른
+                호스트들에게 큰 도움이 됩니다.
               </SectionDescription>
-            ) : (
-              <ReviewItemContainer>
-                {aboutMeReviews.map((review, idx) => (
-                  <ReviewItem key={idx} review={review} />
-                ))}
-              </ReviewItemContainer>
-            )}
-          </>
-        )}
+              {hostBookings.length === 0 ? (
+                <SectionDescription>
+                  아직 방문한 게스트가 없습니다.
+                </SectionDescription>
+              ) : (
+                <ReviewList>
+                  {hostBookings.map((b) => (
+                    <HostReviewListItem key={`host-booking-${b.bookingId}`}>
+                      <div>
+                        <BookingTitle>
+                          숙소: {b.accommodationTitle}
+                        </BookingTitle>
+                        <BookingDetails>
+                          예약번호: {b.bookingId} | 일정: {b.checkInDate} ~{' '}
+                          {b.checkOutDate}
+                        </BookingDetails>
+                        <GuestDetails>
+                          방문 게스트 ID: {b.guestId} ({b.numberOfGuests}명)
+                        </GuestDetails>
+                      </div>
+                      <HostActionButton
+                        onClick={() =>
+                          setGuestReviewModalTarget({
+                            bookingId: b.bookingId,
+                            guestId: b.guestId,
+                          })
+                        }
+                      >
+                        게스트 리뷰 작성
+                      </HostActionButton>
+                    </HostReviewListItem>
+                  ))}
+                </ReviewList>
+              )}
+            </>
+          )}
+        </>
+      )}
 
-        {reviewModalTarget !== null && (
-          <ReviewFormModal
-            bookingId={reviewModalTarget}
-            onClose={() => setReviewModalTarget(null)}
-            onSubmit={handleReviewSubmit}
-          />
-        )}
+      {activeTab === 'about-me' && (
+        <>
+          <SectionTitle>나에 대한 후기 ({aboutMeReviews.length})</SectionTitle>
+          {isLoading ? (
+            <SectionDescription>불러오는 중...</SectionDescription>
+          ) : aboutMeReviews.length === 0 ? (
+            <SectionDescription>아직 받은 후기가 없습니다.</SectionDescription>
+          ) : (
+            <ReviewItemContainer>
+              {aboutMeReviews.map((review, idx) => (
+                <ReviewItem key={idx} review={review} />
+              ))}
+            </ReviewItemContainer>
+          )}
+        </>
+      )}
 
-        {guestReviewModalTarget !== null && (
-          <GuestReviewModal
-            bookingId={guestReviewModalTarget.bookingId}
-            guestId={guestReviewModalTarget.guestId}
-            onClose={() => setGuestReviewModalTarget(null)}
-            onSubmit={handleGuestReviewSubmit}
-          />
-        )}
-      </ContentWrapper>
-    </PageContainer>
+      {reviewModalTarget !== null && (
+        <ReviewFormModal
+          bookingId={reviewModalTarget}
+          onClose={() => setReviewModalTarget(null)}
+          onSubmit={handleReviewSubmit}
+        />
+      )}
+
+      {guestReviewModalTarget !== null && (
+        <GuestReviewModal
+          bookingId={guestReviewModalTarget.bookingId}
+          guestId={guestReviewModalTarget.guestId}
+          onClose={() => setGuestReviewModalTarget(null)}
+          onSubmit={handleGuestReviewSubmit}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/pages/profile/sections/IntroSection.tsx
+++ b/src/pages/profile/sections/IntroSection.tsx
@@ -1,5 +1,4 @@
-import { useNavigate } from "react-router-dom";
-import { ClipboardList } from "lucide-react";
+import { useNavigate } from 'react-router-dom';
 import {
   ContentTitle,
   EditButton,
@@ -13,11 +12,7 @@ import {
   ProfileCompleteTitle,
   ProfileCompleteDesc,
   PrimaryButton,
-  ReviewSection,
-  ReviewButton,
-  ReviewIcon,
-  ReviewText,
-} from "../profile.styles";
+} from '../profile.styles';
 
 interface IntroSectionProps {
   userName: string;
@@ -31,7 +26,7 @@ const IntroSection = ({ userName, userInitial }: IntroSectionProps) => {
     <>
       <ContentTitle>
         자기소개
-        <EditButton onClick={() => navigate("/profile/edit")}>수정</EditButton>
+        <EditButton onClick={() => navigate('/profile/edit')}>수정</EditButton>
       </ContentTitle>
 
       <ProfileCard>
@@ -50,21 +45,12 @@ const IntroSection = ({ userName, userInitial }: IntroSectionProps) => {
               다른 호스트와 게스트에게 나를 알릴 수 있도록 프로필 작성을 완료해
               주세요.
             </ProfileCompleteDesc>
-            <PrimaryButton onClick={() => navigate("/profile/edit")}>
+            <PrimaryButton onClick={() => navigate('/profile/edit')}>
               시작하기
             </PrimaryButton>
           </ProfileCompleteBox>
         </ProfileCardRight>
       </ProfileCard>
-
-      <ReviewSection>
-        <ReviewButton onClick={() => navigate("/profile/reviews")}>
-          <ReviewIcon>
-            <ClipboardList size={24} />
-          </ReviewIcon>
-          <ReviewText>내가 작성한 후기</ReviewText>
-        </ReviewButton>
-      </ReviewSection>
     </>
   );
 };

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -11,7 +11,6 @@ import MessagePage from '../pages/chat/MessagePage';
 import AccountPage from '../pages/account/AccountPage';
 import ProfilePage from '../pages/profile/ProfilePage';
 import ProfileEditPage from '../pages/profile/edit/ProfileEditPage';
-import ReviewsPage from '../pages/profile/reviews/ReviewsPage';
 import PaymentPage from '../pages/payment/PaymentPage';
 import PaymentSuccessPage from '../pages/payment/PaymentSuccessPage';
 import PaymentFailPage from '../pages/payment/PaymentFailPage';
@@ -37,7 +36,7 @@ export const router = createBrowserRouter([
       { path: 'account', element: <AccountPage /> },
       { path: 'profile', element: <ProfilePage /> },
       { path: 'profile/edit', element: <ProfileEditPage /> },
-      { path: 'profile/reviews', element: <ReviewsPage /> },
+      { path: 'profile/reviews', element: <ProfilePage /> },
       { path: 'users/:id', element: <UserPage /> },
     ],
   },


### PR DESCRIPTION
## 🔗 반영 브랜치

refactor/review → dev

## 작업 요약
- 리뷰 작성 과정에서 실패 원인을 유저가 명확히 알 수 없었던 문제를 해결
- 리뷰 작성 대상에 '이용 완료'되지 않은 예약들까지 노출되는 논리적 오류를 수정
- /profile/reviews 페이지 진입 시 프로필 사이드바 네비게이션이 사라지는 UX 불편함을 해소하고자 프로필 메인 레이아웃에 리뷰 탭을 통합

## 📝 작업 내용

1. 리뷰 작성 에러 핸들링 고도화 (ReviewFormModal, GuestReviewModal)
- 기존의 단순 하드코딩된 에러 알림 대신, axios.isAxiosError를 통해 백엔드에서 내려주는 상세 에러 메시지(error.response.data.message)를 추출하여 alert으로 띄워주도록 수정했습니다.
- "이미 작성된 리뷰입니다", "유효하지 않은 예약입니다" 등 명확한 피드백 제공 가능

<br>

2. 리뷰 작성 대상 목록 필터링 (ReviewsPage)
- fetchUserBookings, fetchHostBookings API 호출 시 파라미터가 비어있어 전체 예약 내역을 불러오던 문제를 수정했습니다.
- 이제 파라미터로 'COMPLETED'를 넘겨주어 오직 **"이용 완료"**된 예약 내역에 대해서만 리뷰 작성을 요청하도록 개선했습니다.

<br>

3. 프로필-리뷰 페이지 레이아웃(UX) 통합 (ProfilePage, ReviewsPage, IntroSection)
- 기존 /profile/reviews 접속 시 사이드바가 소실되는 문제를 해결하기 위해, ReviewsPage 컴포넌트를 ProfilePage의 하위 섹션으로 렌더링되도록 리팩토링했습니다.
- 프로필 페이지 좌측 사이드바에 [리뷰] 탭 메뉴를 새로 만들고, IntroSection 하단에 있던 기존 리뷰 작성 버튼은 제거하여 사용자 동선을 하나로 깔끔하게 통일했습니다.
<img width="1157" height="522" alt="image" src="https://github.com/user-attachments/assets/464d5e89-aefd-435c-a33b-71757a7369ba" />
