### PR TITLE
Feat: 프로필 수정 API 연동 및 기본 프로필 편집 UI 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ dist-ssr
 .env.development.local
 .env.production.local
 .env.test.local
+
+.claude

--- a/src/api/accommodation.ts
+++ b/src/api/accommodation.ts
@@ -61,10 +61,16 @@ const TEST_MOCK_ACCOMMODATION_DETAIL: AccommodationDetailDTO = {
 export async function createAccommodation(
   data: CreateAccommodationRequest,
 ): Promise<CreateAccommodationResponse> {
+  const { pricePerNight, cleaningFee, ...rest } = data;
+  const payload = {
+    ...rest,
+    price_per_night: pricePerNight,
+    cleaning_fee: cleaningFee ?? 0,
+  };
   const response = await client.post<
     CreateAccommodationResponse,
     CreateAccommodationResponse
-  >('/api/accommodations', data);
+  >('/api/accommodations', payload);
   return response;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -441,3 +441,19 @@ export interface AccommodationSearchResponse {
   totalElements: number;
   totalPages: number;
 }
+
+// [PATCH] /api/users/me/profile - 프로필 수정 요청
+export type UpdateMyProfileRequest = {
+  nickName?: string;
+  profileImageUrl?: string;
+};
+
+// [PATCH] /api/users/me/profile, [GET] /api/users/me - 내 프로필 응답
+export type MyProfileResponse = {
+  id: number;
+  email: string;
+  nickName: string;
+  profileImageUrl: string;
+  role: 'USER' | 'HOST' | 'ADMIN';
+  grade: 'BRONZE' | 'SILVER' | 'GOLD' | 'PLATINUM';
+};

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,8 +1,10 @@
 import client from './client';
 import type {
   ApiResponse,
+  MyProfileResponse,
   PublicUserProfileResponse,
   ReviewListResponse,
+  UpdateMyProfileRequest,
   UserReviewDTO,
 } from './types';
 
@@ -15,10 +17,10 @@ export async function fetchUserProfile(
     throw new Error(`Invalid userId format: ${userId}`);
   }
 
-    const response = await client.get(
-        `/api/users/${userId}/public-profile`
-    ) as ApiResponse<PublicUserProfileResponse>;
-    return response.data;
+  const response = (await client.get(
+    `/api/users/${userId}/public-profile`,
+  )) as ApiResponse<PublicUserProfileResponse>;
+  return response.data;
 }
 
 // 사용자 리뷰 조회 (호스트가 게스트에게 남긴 리뷰)
@@ -33,35 +35,46 @@ export async function fetchUserReviews(
     };
   }
 
-    try {
-        const reviews = await client.get(
-            `/api/review/users/${userId}`
-        ) as UserReviewDTO[];
+  try {
+    const reviews = (await client.get(
+      `/api/review/users/${userId}`,
+    )) as UserReviewDTO[];
 
     const count = reviews.length;
     const average =
       count > 0 ? reviews.reduce((acc, r) => acc + r.rating, 0) / count : 0;
 
-        return {
-            summary: { average, count },
-            reviews: reviews.map((r) => ({
-                reviewId: r.id || r.bookingId, // 백엔드 리뷰 DTO에 별도 ID가 없어 우선 bookingId 사용
-                author: {
-                    userId: 0,
-                    nickName: r.userNickName || "익명 사용자",
-                    profileImageUrl: r.userProfileImageUrl || null,
-                },
-                rating: r.rating,
-                content: r.reviewComment,
-                createdAt: "2024-01-01",
-                reply: r.comment,
-            })),
-        };
-    } catch (error) {
-        console.error("Failed to fetch user reviews:", error);
-        return {
-            summary: { average: 0, count: 0 },
-            reviews: [],
-        };
-    }
+    return {
+      summary: { average, count },
+      reviews: reviews.map((r) => ({
+        reviewId: r.id || r.bookingId, // 백엔드 리뷰 DTO에 별도 ID가 없어 우선 bookingId 사용
+        author: {
+          userId: 0,
+          nickName: r.userNickName || '익명 사용자',
+          profileImageUrl: r.userProfileImageUrl || null,
+        },
+        rating: r.rating,
+        content: r.reviewComment,
+        createdAt: '2024-01-01',
+        reply: r.comment,
+      })),
+    };
+  } catch (error) {
+    console.error('Failed to fetch user reviews:', error);
+    return {
+      summary: { average: 0, count: 0 },
+      reviews: [],
+    };
+  }
+}
+
+// 내 프로필 수정
+export async function updateMyProfile(
+  data: UpdateMyProfileRequest,
+): Promise<MyProfileResponse> {
+  const response = (await client.patch(
+    '/api/users/me/profile',
+    data,
+  )) as ApiResponse<MyProfileResponse>;
+  return response.data;
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -55,7 +55,9 @@ export async function fetchUserReviews(
         },
         rating: r.rating,
         content: r.reviewComment,
-        createdAt: '2024-01-01',
+        // 사용자 리뷰 API가 생성일을 내려주지 않아 빈 값으로 둔다.
+        // UI에서 createdAt이 없으면 날짜 표시를 생략한다.
+        createdAt: '',
         reply: r.comment,
       })),
     };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -69,6 +69,14 @@ const Header = ({ isScrolled = false }: HeaderProps) => {
     return '숙소'; // 기본값
   }, [location.pathname]);
 
+  const handleHostNavigation = () => {
+    if (!isAuthenticated) {
+      setIsLoginOpen(true);
+      return;
+    }
+    navigate('/hosting');
+  };
+
   return (
     <>
       <HeaderContainer $isScrolled={isScrolled}>
@@ -99,7 +107,7 @@ const Header = ({ isScrolled = false }: HeaderProps) => {
         </HeaderCenter>
 
         <HeaderRight>
-          <HostButton type="button" onClick={() => navigate('/hosting')}>
+          <HostButton type="button" onClick={handleHostNavigation}>
             호스트로 등록하기
           </HostButton>
 

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,24 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import type { ReactElement } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+type RequireAuthProps = {
+  children: ReactElement;
+};
+
+const RequireAuth = ({ children }: RequireAuthProps) => {
+  const location = useLocation();
+  const { isAuthenticated, isAuthLoading } = useAuth();
+
+  if (isAuthLoading) {
+    return null;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/" replace state={{ from: location }} />;
+  }
+
+  return children;
+};
+
+export default RequireAuth;

--- a/src/components/reviews/ReviewItem.tsx
+++ b/src/components/reviews/ReviewItem.tsx
@@ -15,6 +15,10 @@ export default function ReviewItem({
   const authorName = review.author?.nickName || '익명';
   const profileImage =
     review.author?.profileImageUrl || 'https://via.placeholder.com/48';
+  const subInfoParts = [
+    review.createdAt?.trim(),
+    showAccommodationName ? review.accommodationName : undefined,
+  ].filter(Boolean) as string[];
 
   return (
     <Container>
@@ -22,12 +26,9 @@ export default function ReviewItem({
         <Avatar src={profileImage} alt={authorName} />
         <Meta>
           <Author>{authorName}</Author>
-          <SubInfo>
-            {review.createdAt}
-            {showAccommodationName && review.accommodationName && (
-              <> · {review.accommodationName}</>
-            )}
-          </SubInfo>
+          {subInfoParts.length > 0 && (
+            <SubInfo>{subInfoParts.join(' · ')}</SubInfo>
+          )}
         </Meta>
       </Header>
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import type { ReactNode } from 'react';
 
-export type UserRole = "USER" | "HOST" | "ADMIN";
+export type UserRole = 'USER' | 'HOST' | 'ADMIN';
 
 export type User = {
   id: string;
@@ -38,6 +38,7 @@ type UserProfileResponse = {
 type AuthContextType = {
   user: User | null;
   isAuthenticated: boolean;
+  isAuthLoading: boolean;
   accessToken: string | null;
   login: (token: string) => Promise<void>;
   logout: () => void;
@@ -107,6 +108,7 @@ const fetchUserProfile = async (token: string): Promise<User | null> => {
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [isAuthLoading, setIsAuthLoading] = useState(true);
   const isLoadingRef = useRef(false);
 
   // 사용자 정보 로드 함수
@@ -137,26 +139,47 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   // 초기 로드 및 URL 토큰 처리
   useEffect(() => {
-    // 1. URL에서 토큰을 받아온 경우 (로그인 직후)
-    const params = new URLSearchParams(window.location.search);
-    const urlToken = params.get('accessToken');
-    const refreshToken = params.get('refreshToken');
+    let isMounted = true;
 
-    if (urlToken && refreshToken) {
-      localStorage.setItem('accessToken', urlToken);
-      localStorage.setItem('refreshToken', refreshToken);
-      loadUserInfo(urlToken);
-      // URL 정리
-      window.history.replaceState({}, document.title, window.location.pathname);
-      return;
-    }
+    const initializeAuth = async () => {
+      // 1. URL에서 토큰을 받아온 경우 (로그인 직후)
+      const params = new URLSearchParams(window.location.search);
+      const urlToken = params.get('accessToken');
+      const refreshToken = params.get('refreshToken');
 
-    // 2. localStorage에서 토큰 확인 (새로고침 시)
-    const storedToken = localStorage.getItem('accessToken');
-    if (storedToken && !user) {
-      loadUserInfo(storedToken);
-    }
-  }, [loadUserInfo, user]);
+      if (urlToken && refreshToken) {
+        localStorage.setItem('accessToken', urlToken);
+        localStorage.setItem('refreshToken', refreshToken);
+        await loadUserInfo(urlToken);
+        // URL 정리
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.pathname,
+        );
+        if (isMounted) {
+          setIsAuthLoading(false);
+        }
+        return;
+      }
+
+      // 2. localStorage에서 토큰 확인 (새로고침 시)
+      const storedToken = localStorage.getItem('accessToken');
+      if (storedToken) {
+        await loadUserInfo(storedToken);
+      }
+
+      if (isMounted) {
+        setIsAuthLoading(false);
+      }
+    };
+
+    initializeAuth();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadUserInfo]);
 
   const login = async (token: string) => {
     localStorage.setItem('accessToken', token);
@@ -175,6 +198,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       value={{
         user,
         isAuthenticated: !!user && !!accessToken,
+        isAuthLoading,
         accessToken,
         login,
         logout,

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -11,6 +11,7 @@ import Photos from './steps/Photos';
 import TitleStep from './steps/Title';
 import Description from './steps/Description';
 import Phase3Intro from './steps/Phase3Intro';
+import Pricing from './steps/Pricing';
 import BookingSettings from './steps/BookingSettings';
 import HostDetails from './steps/HostDetails';
 import Alert from '@/components/Alert/Alert';
@@ -55,6 +56,7 @@ type StepId =
   | 'TITLE'
   | 'DESCRIPTION'
   | 'PHASE3_INTRO'
+  | 'PRICING'
   | 'BOOKING_SETTINGS'
   | 'HOST_DETAILS';
 
@@ -119,6 +121,12 @@ const STEPS: StepConfig[] = [
     needsData: false,
   },
   {
+    id: 'PRICING',
+    component: Pricing,
+    showProgress: true,
+    needsData: true,
+  },
+  {
     id: 'BOOKING_SETTINGS',
     component: BookingSettings,
     showProgress: true,
@@ -168,6 +176,12 @@ const validateStep = (step: number, data: Partial<Listing>): string | null => {
     case STEP.TITLE:
       if (!data.title?.trim()) return '숙소 이름을 입력해주세요.';
       break;
+    case STEP.PRICING:
+      if (!data.pricing?.basePrice || data.pricing.basePrice <= 0)
+        return '1박 요금을 입력해주세요. (1원 이상)';
+      if ((data.pricing.cleaningFee ?? 0) < 0)
+        return '청소비는 0원 이상이어야 합니다.';
+      break;
     case STEP.HOST_DETAILS:
       if (!data.location?.streetAddress?.trim())
         return '주소를 검색하여 숙소 위치를 설정해주세요.';
@@ -197,6 +211,7 @@ const validateBeforeSubmit = (data: Partial<Listing>): string | null => {
     STEP.GUEST_CAPACITY,
     STEP.AMENITIES,
     STEP.TITLE,
+    STEP.PRICING,
     STEP.HOST_DETAILS,
   ];
 
@@ -305,8 +320,8 @@ const BecomeHostPage = () => {
           latitude: location.latitude,
           longitude: location.longitude,
           maxGuests: listingData.guests || 1,
-          pricePerNight: listingData.pricing?.basePrice || 50000,
-          cleaningFee: listingData.pricing?.cleaningFee || 0,
+          pricePerNight: listingData.pricing?.basePrice ?? 0,
+          cleaningFee: listingData.pricing?.cleaningFee,
           serviceFeePercentage: 5.0,
           instantBooking: listingData.bookingSettings === 'instant',
           checkInTime: listingData.checkInTime || '15:00:00',

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -323,7 +323,6 @@ const BecomeHostPage = () => {
           maxGuests: listingData.guests || 1,
           pricePerNight: listingData.pricing?.basePrice ?? 0,
           cleaningFee: listingData.pricing?.cleaningFee,
-          serviceFeePercentage: 5.0,
           instantBooking: listingData.bookingSettings === 'instant',
           checkInTime: listingData.checkInTime || '15:00:00',
           checkOutTime: listingData.checkOutTime || '11:00:00',

--- a/src/pages/hosting/steps/Pricing.tsx
+++ b/src/pages/hosting/steps/Pricing.tsx
@@ -33,11 +33,11 @@ const formatPrice = (price: number): string => {
 };
 
 const Pricing = ({ data, onDataChange }: StepProps) => {
-  const price = data.pricing?.basePrice || 50000;
-  const cleaningFee = data.pricing?.cleaningFee || 0;
+  const price = data.pricing?.basePrice ?? 0;
+  const cleaningFee = data.pricing?.cleaningFee ?? 0;
   const pricing = {
-    basePrice: data.pricing?.basePrice ?? 50000,
-    cleaningFee: data.pricing?.cleaningFee ?? 0,
+    basePrice: price,
+    cleaningFee,
   };
 
   const handlePriceChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -81,7 +81,7 @@ const Pricing = ({ data, onDataChange }: StepProps) => {
           <CurrencyLabel>₩</CurrencyLabel>
           <PriceInput
             type="text"
-            value={formatPrice(price)}
+            value={price > 0 ? formatPrice(price) : ''}
             onChange={handlePriceChange}
             placeholder="0"
           />

--- a/src/pages/profile/edit/ProfileEditPage.tsx
+++ b/src/pages/profile/edit/ProfileEditPage.tsx
@@ -30,7 +30,18 @@ import {
   AddInterestButton,
   SelectedInterestTag,
   AddInterestTextButton,
+  FormRow,
+  FormLabel,
+  FormInput,
+  ReadonlyField,
+  ReadonlyBadge,
+  FormFooter,
+  SaveMessage,
+  SaveProfileButton,
 } from './profileEdit.styles';
+import { useAuth } from '@/contexts/AuthContext';
+import { updateMyProfile } from '@/api/user';
+import type { UpdateMyProfileRequest } from '@/api/types';
 import {
   Camera,
   Briefcase,
@@ -160,8 +171,17 @@ const PROFILE_MODAL_CONFIG: Record<TextInputProfileItemId, ProfileModalConfig> =
   };
 
 const ProfileEditPage = () => {
+  const { user, setUser } = useAuth();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [profileImage, setProfileImage] = useState<string | null>(
+    user?.profileImage ?? null,
+  );
+  const [nickName, setNickName] = useState(user?.nickname ?? '');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
   const [showTravelStamps, setShowTravelStamps] = useState(false);
   const [isInterestModalOpen, setIsInterestModalOpen] = useState(false);
   const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
@@ -191,9 +211,48 @@ const ProfileEditPage = () => {
     favorites: '',
   });
 
-  const user = {
-    name: '예은',
-    initial: '예',
+  const initial = user?.nickname?.[0] ?? '?';
+
+  const handleSave = async () => {
+    if (nickName.length < 1 || nickName.length > 30) {
+      setSaveMessage({
+        type: 'error',
+        text: '닉네임은 1~30자 사이여야 합니다.',
+      });
+      return;
+    }
+
+    const payload: UpdateMyProfileRequest = {};
+    if (nickName !== user?.nickname) payload.nickName = nickName;
+    const imageUrl = profileImage?.startsWith('http')
+      ? profileImage
+      : undefined;
+    if (imageUrl && imageUrl !== user?.profileImage)
+      payload.profileImageUrl = imageUrl;
+
+    if (!payload.nickName && !payload.profileImageUrl) {
+      setSaveMessage({ type: 'error', text: '변경된 내용이 없습니다.' });
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveMessage(null);
+    try {
+      const updated = await updateMyProfile(payload);
+      setUser({
+        ...user!,
+        nickname: updated.nickName,
+        profileImage: updated.profileImageUrl || undefined,
+      });
+      setSaveMessage({ type: 'success', text: '프로필이 수정되었습니다.' });
+    } catch {
+      setSaveMessage({
+        type: 'error',
+        text: '저장 중 오류가 발생했습니다. 다시 시도해 주세요.',
+      });
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   // 관심사 라벨 매핑 (나중에 API 연동 시 대체)
@@ -331,7 +390,7 @@ const ProfileEditPage = () => {
               {profileImage ? (
                 <img src={profileImage} alt="프로필 이미지" />
               ) : (
-                user.initial
+                initial
               )}
             </AvatarCircle>
             <AddPhotoButton onClick={handleAddPhotoClick}>
@@ -350,6 +409,48 @@ const ProfileEditPage = () => {
 
         {/* 오른쪽: 메인 콘텐츠 */}
         <MainContent>
+          {/* 기본 프로필 섹션 */}
+          <Section>
+            <SectionHeader>
+              <SectionTitle>기본 프로필</SectionTitle>
+            </SectionHeader>
+
+            <FormRow>
+              <FormLabel htmlFor="nickname">닉네임</FormLabel>
+              <FormInput
+                id="nickname"
+                value={nickName}
+                onChange={(e) => {
+                  setNickName(e.target.value);
+                  setSaveMessage(null);
+                }}
+                placeholder="닉네임을 입력하세요"
+                maxLength={30}
+              />
+            </FormRow>
+
+            <FormRow>
+              <FormLabel>
+                이메일
+                <ReadonlyBadge>변경 불가</ReadonlyBadge>
+              </FormLabel>
+              <ReadonlyField>{user?.email ?? '-'}</ReadonlyField>
+            </FormRow>
+
+            <FormFooter>
+              <SaveProfileButton onClick={handleSave} disabled={isSaving}>
+                {isSaving ? '저장 중...' : '저장'}
+              </SaveProfileButton>
+              {saveMessage && (
+                <SaveMessage $type={saveMessage.type}>
+                  {saveMessage.text}
+                </SaveMessage>
+              )}
+            </FormFooter>
+          </Section>
+
+          <Divider />
+
           {/* 프로필 섹션 */}
           <Section>
             <SectionHeader>
@@ -387,14 +488,9 @@ const ProfileEditPage = () => {
               <SectionTitle>자기소개</SectionTitle>
             </SectionHeader>
 
-            <IntroBox
-              onClick={() => setIsIntroModalOpen(true)}
-              style={{ cursor: 'pointer' }}
-            >
+            <IntroBox onClick={() => setIsIntroModalOpen(true)}>
               {introduction ? (
-                <IntroPlaceholder style={{ color: 'inherit' }}>
-                  {introduction}
-                </IntroPlaceholder>
+                <IntroPlaceholder $filled>{introduction}</IntroPlaceholder>
               ) : (
                 <>
                   <IntroPlaceholder>

--- a/src/pages/profile/edit/ProfileEditPage.tsx
+++ b/src/pages/profile/edit/ProfileEditPage.tsx
@@ -42,6 +42,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { updateMyProfile } from '@/api/user';
 import type { UpdateMyProfileRequest } from '@/api/types';
+import axios from 'axios';
 import {
   Camera,
   Briefcase,
@@ -239,16 +240,35 @@ const ProfileEditPage = () => {
     setSaveMessage(null);
     try {
       const updated = await updateMyProfile(payload);
-      setUser({
-        ...user!,
-        nickname: updated.nickName,
-        profileImage: updated.profileImageUrl || undefined,
-      });
+      if (user) {
+        setUser({
+          ...user,
+          nickname: updated.nickName,
+          profileImage: updated.profileImageUrl || undefined,
+        });
+      }
       setSaveMessage({ type: 'success', text: '프로필이 수정되었습니다.' });
-    } catch {
+    } catch (error: unknown) {
+      let errorMessage = '저장 중 오류가 발생했습니다. 다시 시도해 주세요.';
+
+      if (axios.isAxiosError<{ message?: string }>(error)) {
+        const status = error.response?.status;
+        const serverMessage = error.response?.data?.message;
+
+        if (status === 401) {
+          errorMessage = '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+        } else if (status === 403) {
+          errorMessage = serverMessage || '프로필 수정 권한이 없습니다.';
+        } else if (status === 400) {
+          errorMessage = serverMessage || '입력값이 올바르지 않습니다.';
+        } else if (serverMessage) {
+          errorMessage = serverMessage;
+        }
+      }
+
       setSaveMessage({
         type: 'error',
-        text: '저장 중 오류가 발생했습니다. 다시 시도해 주세요.',
+        text: errorMessage,
       });
     } finally {
       setIsSaving(false);

--- a/src/pages/profile/edit/profileEdit.styles.ts
+++ b/src/pages/profile/edit/profileEdit.styles.ts
@@ -1,5 +1,5 @@
-import styled from "styled-components";
-import { media } from "@/styles/media";
+import styled from 'styled-components';
+import { media } from '@/styles/media';
 
 export {
   PageContainer,
@@ -19,16 +19,16 @@ export {
   SectionHeader,
   SectionTitle,
   SectionDescription,
-} from "@/styles/shared/pageLayout.styles";
+} from '@/styles/shared/pageLayout.styles';
 
-export { SaveButton as CompleteButton } from "@/styles/shared/modal.styles";
+export { SaveButton as CompleteButton } from '@/styles/shared/modal.styles';
 
 export const ContentWrapper = styled.div`
   display: flex;
   max-width: 1100px;
   margin: 0 auto;
-  padding: ${({ theme }) => `${theme.spacing["3xl"]} ${theme.spacing["2xl"]}`};
-  gap: ${({ theme }) => theme.spacing["6xl"]};
+  padding: ${({ theme }) => `${theme.spacing['3xl']} ${theme.spacing['2xl']}`};
+  gap: ${({ theme }) => theme.spacing['6xl']};
 
   ${media.tablet} {
     flex-direction: column;
@@ -56,7 +56,6 @@ export const AvatarWrapper = styled.div`
   position: relative;
   margin-bottom: ${({ theme }) => theme.spacing.md};
 `;
-
 
 export const AddPhotoButton = styled.button`
   position: absolute;
@@ -87,7 +86,6 @@ export const MainContent = styled.main`
   flex: 1;
   min-width: 0;
 `;
-
 
 export const LearnMoreLink = styled.button`
   padding: 0;
@@ -155,11 +153,13 @@ export const IntroBox = styled.div`
   padding: ${({ theme }) => theme.spacing.xl};
   border: 1px dashed ${({ theme }) => theme.colors.border.primary};
   border-radius: ${({ theme }) => theme.radius.md};
+  cursor: pointer;
 `;
 
-export const IntroPlaceholder = styled.p`
+export const IntroPlaceholder = styled.p<{ $filled?: boolean }>`
   font-size: ${({ theme }) => theme.font.size.sm};
-  color: ${({ theme }) => theme.colors.text.secondary};
+  color: ${({ $filled, theme }) =>
+    $filled ? theme.colors.text.primary : theme.colors.text.secondary};
   margin-bottom: ${({ theme }) => theme.spacing.sm};
 `;
 
@@ -187,7 +187,6 @@ export const TravelHeader = styled.div`
   margin-bottom: ${({ theme }) => theme.spacing.xl};
 `;
 
-
 export const TravelStamps = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spacing.md};
@@ -213,7 +212,9 @@ export const StampCard = styled.div`
   flex-shrink: 0;
 `;
 
-export const StampIcon = styled.div<{ $shape?: "square" | "rounded" | "hexagon" | "circle" }>`
+export const StampIcon = styled.div<{
+  $shape?: 'square' | 'rounded' | 'hexagon' | 'circle';
+}>`
   width: 120px;
   height: 100px;
   border: 2px solid ${({ theme }) => theme.colors.border.primary};
@@ -224,16 +225,16 @@ export const StampIcon = styled.div<{ $shape?: "square" | "rounded" | "hexagon" 
 
   ${({ $shape, theme }) => {
     switch ($shape) {
-      case "rounded":
+      case 'rounded':
         return `border-radius: ${theme.radius.xl};`;
-      case "hexagon":
+      case 'hexagon':
         return `
           clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
           border: none;
           background: ${theme.colors.border.primary};
           color: ${theme.colors.common.white};
         `;
-      case "circle":
+      case 'circle':
         return `border-radius: ${theme.radius.full};`;
       default:
         return `border-radius: ${theme.radius.md};`;
@@ -323,10 +324,80 @@ export const AddInterestTextButton = styled.button`
 export const Footer = styled.footer`
   display: flex;
   justify-content: flex-end;
-  padding: ${({ theme }) => `${theme.spacing.xl} ${theme.spacing["2xl"]}`};
+  padding: ${({ theme }) => `${theme.spacing.xl} ${theme.spacing['2xl']}`};
   border-top: 1px solid ${({ theme }) => theme.colors.border.light};
   background: ${({ theme }) => theme.colors.background.default};
   position: sticky;
   bottom: 0;
 `;
 
+// 기본 프로필 폼
+export const FormRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing.xs};
+  margin-bottom: ${({ theme }) => theme.spacing.lg};
+`;
+
+export const FormLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.sm};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.colors.text.secondary};
+`;
+
+export const ReadonlyBadge = styled.span`
+  font-size: ${({ theme }) => theme.font.size.xs};
+  font-weight: ${({ theme }) => theme.font.weight.regular};
+  color: ${({ theme }) => theme.colors.text.tertiary};
+  background: ${({ theme }) => theme.colors.background.hover};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.sm};
+  padding: 1px ${({ theme }) => theme.spacing.xs};
+`;
+
+export const FormInput = styled.input`
+  width: 100%;
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  border: 1px solid ${({ theme }) => theme.colors.border.primary};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.primary};
+  background: ${({ theme }) => theme.colors.common.white};
+  transition: ${({ theme }) => theme.transition.normal};
+  outline: none;
+
+  &:focus {
+    border-color: ${({ theme }) => theme.colors.primary.main};
+  }
+`;
+
+export const ReadonlyField = styled.div`
+  padding: ${({ theme }) => `${theme.spacing.sm} ${theme.spacing.md}`};
+  background: ${({ theme }) => theme.colors.background.hover};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.md};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  word-break: break-all;
+`;
+
+export const FormFooter = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg};
+  margin-top: ${({ theme }) => theme.spacing.lg};
+`;
+
+// 저장 결과 메시지
+export const SaveMessage = styled.p<{ $type: 'success' | 'error' }>`
+  font-size: ${({ theme }) => theme.font.size.sm};
+  color: ${({ $type, theme }) =>
+    $type === 'success'
+      ? theme.colors.status.success
+      : theme.colors.status.error};
+`;
+
+export { SaveButton as SaveProfileButton } from '@/styles/shared/modal.styles';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -17,6 +17,7 @@ import PaymentSuccessPage from '../pages/payment/PaymentSuccessPage';
 import PaymentFailPage from '../pages/payment/PaymentFailPage';
 import WishlistPage from '../pages/wishlist/WishlistPage';
 import WishlistDetailPage from '../pages/wishlist/WishlistDetailPage';
+import RequireAuth from '@/components/auth/RequireAuth';
 
 export const router = createBrowserRouter([
   {
@@ -43,11 +44,19 @@ export const router = createBrowserRouter([
   },
   {
     path: '/hosting',
-    element: <HostingPage />,
+    element: (
+      <RequireAuth>
+        <HostingPage />
+      </RequireAuth>
+    ),
   },
   {
     path: '/hosting/become-a-host',
-    element: <BecomeHostPage />,
+    element: (
+      <RequireAuth>
+        <BecomeHostPage />
+      </RequireAuth>
+    ),
   },
 ]);
 

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -88,7 +88,8 @@ export const defaultListing: Omit<Listing, 'id' | 'createdAt'> = {
   extraAmenities: [],
   photos: [],
   pricing: {
-    basePrice: 50000,
+    basePrice: 0,
+    cleaningFee: 0,
   },
   bookingSettings: 'review',
   checkInTime: '15:00',


### PR DESCRIPTION
## 🔗 반영 브랜치
```
closed #199
`feature/profile-api → dev`
```

## 📝 작업 내용
- UpdateMyProfileRequest, MyProfileResponse 타입 추가
- updateMyProfile (PATCH `/api/users/me/profile`) API 함수 추가
- /profile/edit 기본 프로필 섹션 추가 (닉네임 수정, 이메일 읽기 전용)
- 닉네임 1~30자 검증, 저장 성공 시 `AuthContext` 동기화
<img width="1694" height="882" alt="스크린샷 2026-05-04 오후 8 48 10" src="https://github.com/user-attachments/assets/3f642fa2-754f-43b1-b43b-5021ff2ea058" />

<img width="549" height="716" alt="스크린샷 2026-05-18 오후 11 18 56" src="https://github.com/user-attachments/assets/06fecb96-1d37-4def-a0e8-5e8aa61aa45f" />


## 💬 리뷰 요구사항(선택 사항)
.
