### PR TITLE
Fix: 백엔드 DTO에 맞춘 API 호출 로직 수정 및 필드 명칭 통일

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -17,6 +17,7 @@ export type CreateAccommodationRequest = {
   accommodationType: AccommodationTypeAPI;
   address: string;
   city: string;
+  district: string;
   state?: string;
   country: string;
   postalCode?: string;
@@ -25,7 +26,6 @@ export type CreateAccommodationRequest = {
   maxGuests: number;
   pricePerNight: number;
   cleaningFee?: number;
-  serviceFeePercentage?: number;
   instantBooking: boolean;
   checkInTime?: string;
   checkOutTime?: string;

--- a/src/components/SearchBar/RegionPopup.tsx
+++ b/src/components/SearchBar/RegionPopup.tsx
@@ -72,27 +72,27 @@ const Divider = styled.div`
 `;
 
 interface RegionPopupProps {
-  onSelect: (province: string, city: string, district?: string) => void;
-  selectedProvince?: string;
+  onSelect: (state: string, city: string, district?: string) => void;
+  selectedState?: string;
   selectedCity?: string;
   selectedDistrict?: string;
 }
 
 const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
-  ({ onSelect, selectedProvince, selectedCity, selectedDistrict }, ref) => {
-    const defaultProvince = selectedProvince || '서울';
+  ({ onSelect, selectedState, selectedCity, selectedDistrict }, ref) => {
+    const defaultState = selectedState || '서울';
     const defaultCity = selectedCity || '';
 
-    const [province, setProvince] = useState<string>(defaultProvince);
+    const [state, setState] = useState<string>(defaultState);
     const [city, setCity] = useState<string>(defaultCity);
 
-    const provinces = Object.keys(REGIONS);
-    const cities = Object.keys(REGIONS[province] || {});
-    const districts = city ? REGIONS[province]?.[city] || [] : [];
+    const statesList = Object.keys(REGIONS);
+    const cities = Object.keys(REGIONS[state] || {});
+    const districts = city ? REGIONS[state]?.[city] || [] : [];
 
-    const handleProvinceClick = (e: React.MouseEvent, p: string) => {
+    const handleStateClick = (e: React.MouseEvent, p: string) => {
       e.stopPropagation();
-      setProvince(p);
+      setState(p);
       setCity('');
     };
 
@@ -100,10 +100,10 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
       e.stopPropagation();
       setCity(c);
 
-      const cityDistricts = REGIONS[province]?.[c] || [];
+      const cityDistricts = REGIONS[state]?.[c] || [];
       // If there are no districts, selecting the city completes the action
       if (cityDistricts.length === 0) {
-        onSelect(province, c);
+        onSelect(state, c);
       }
     };
 
@@ -111,9 +111,9 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
       e.stopPropagation();
       // '전체' 옵션 처리
       if (d === '전체') {
-        onSelect(province, city);
+        onSelect(state, city);
       } else {
-        onSelect(province, city, d);
+        onSelect(state, city, d);
       }
     };
 
@@ -121,11 +121,11 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
       <PopupContainer ref={ref} onClick={(e) => e.stopPropagation()}>
         <Column>
           <ColumnTitle>시/도</ColumnTitle>
-          {provinces.map((p) => (
+          {statesList.map((p) => (
             <ListItem
               key={p}
-              $isSelected={p === province}
-              onClick={(e) => handleProvinceClick(e, p)}
+              $isSelected={p === state}
+              onClick={(e) => handleStateClick(e, p)}
             >
               {p}
             </ListItem>
@@ -138,7 +138,7 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
             <ListItem
               key={c}
               $isSelected={
-                province === selectedProvince &&
+                state === selectedState &&
                 c === selectedCity &&
                 !selectedDistrict
               }
@@ -155,7 +155,7 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
               <ColumnTitle>동/읍/면</ColumnTitle>
               <ListItem
                 $isSelected={
-                  province === selectedProvince &&
+                  state === selectedState &&
                   city === selectedCity &&
                   !selectedDistrict
                 }
@@ -167,7 +167,7 @@ const RegionPopup = React.forwardRef<HTMLDivElement, RegionPopupProps>(
                 <ListItem
                   key={d}
                   $isSelected={
-                    province === selectedProvince &&
+                    state === selectedState &&
                     city === selectedCity &&
                     d === selectedDistrict
                   }

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -85,7 +85,7 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
   const [dateFieldRect, setDateFieldRect] = useState<DOMRect | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedLocation, setSelectedLocation] = useState<{
-    province: string;
+    state: string;
     city: string;
     district?: string;
   } | null>(null);
@@ -238,7 +238,7 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
           {!isCompact && (
             <span>
               {selectedLocation
-                ? `${selectedLocation.province} ${selectedLocation.city} ${selectedLocation.district || ''}`.trim()
+                ? `${selectedLocation.state} ${selectedLocation.city} ${selectedLocation.district || ''}`.trim()
                 : '여행지 검색'}
             </span>
           )}
@@ -253,11 +253,11 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
         {showRegionPopup && (
           <RegionPopup
             ref={regionPopupRef}
-            selectedProvince={selectedLocation?.province}
+            selectedState={selectedLocation?.state}
             selectedCity={selectedLocation?.city}
             selectedDistrict={selectedLocation?.district}
-            onSelect={(province, city, district) => {
-              setSelectedLocation({ province, city, district });
+            onSelect={(state, city, district) => {
+              setSelectedLocation({ state, city, district });
               setShowRegionPopup(false);
               if (dateFieldRef.current) {
                 setDateFieldRect(dateFieldRef.current.getBoundingClientRect());
@@ -343,8 +343,8 @@ const SearchBar = ({ isCompact = false }: SearchBarProps) => {
           if (searchQuery.trim()) {
             params.append('title', searchQuery.trim());
           }
-          if (selectedLocation?.province) {
-            params.append('state', selectedLocation.province);
+          if (selectedLocation?.state) {
+            params.append('state', selectedLocation.state);
           }
           if (selectedLocation?.city) {
             params.append('city', selectedLocation.city);

--- a/src/constants/regions.ts
+++ b/src/constants/regions.ts
@@ -1,5 +1,5 @@
 export interface RegionData {
-  [province: string]: {
+  [state: string]: {
     [city: string]: string[];
   };
 }

--- a/src/pages/hosting/BecomeHostPage.tsx
+++ b/src/pages/hosting/BecomeHostPage.tsx
@@ -180,7 +180,7 @@ const validateStep = (step: number, data: Partial<Listing>): string | null => {
 
 const getLocationDefaults = (): LocationData => ({
   country: '한국',
-  province: '',
+  state: '',
   city: '',
   district: '',
   streetAddress: '',
@@ -299,7 +299,8 @@ const BecomeHostPage = () => {
           accommodationType,
           address: `${location.streetAddress} ${location.detailAddress}`.trim(),
           city: resolvedCity,
-          state: location.province,
+          district: location.district?.trim() || resolvedCity,
+          state: location.state,
           country: location.country,
           postalCode: location.postalCode,
           latitude: location.latitude,
@@ -307,7 +308,6 @@ const BecomeHostPage = () => {
           maxGuests: listingData.guests || 1,
           pricePerNight: listingData.pricing?.basePrice || 50000,
           cleaningFee: listingData.pricing?.cleaningFee || 0,
-          serviceFeePercentage: 5.0,
           instantBooking: listingData.bookingSettings === 'instant',
           checkInTime: listingData.checkInTime || '15:00:00',
           checkOutTime: listingData.checkOutTime || '11:00:00',

--- a/src/pages/hosting/HostingPage.tsx
+++ b/src/pages/hosting/HostingPage.tsx
@@ -125,7 +125,7 @@ const HostingPage = () => {
                 <ListingInfo>
                   <ListingTitle>{listing.title}</ListingTitle>
                   <ListingLocation>
-                    {listing.location.province} {listing.location.district}
+                    {listing.location.state} {listing.location.district}
                   </ListingLocation>
                   <ListingPrice>
                     ₩{formatPrice(listing.pricing.basePrice)} <span>/ 박</span>

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -24,7 +24,7 @@ import type { StepProps } from '../BecomeHostPage';
 const HostDetails = ({ data, onDataChange }: StepProps) => {
   const location = data.location || {
     country: '한국',
-    province: '',
+    state: '',
     city: '',
     district: '',
     streetAddress: '',
@@ -119,7 +119,7 @@ const HostDetails = ({ data, onDataChange }: StepProps) => {
         location: {
           ...location,
           country: '한국',
-          province: addr.region_1depth_name,
+          state: addr.region_1depth_name,
           city: addr.region_2depth_name,
           district: addr.region_3depth_name,
           streetAddress: displayAddress,

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -115,33 +115,6 @@ const HostDetails = ({ data, onDataChange }: StepProps) => {
         markerRef.current?.setPosition(newLatLng);
       }
 
-      let parsedState = addr.region_1depth_name;
-      const stateMapping: { [key: string]: string } = {
-        서울특별시: '서울',
-        부산광역시: '부산',
-        대구광역시: '대구',
-        인천광역시: '인천',
-        광주광역시: '광주',
-        대전광역시: '대전',
-        울산광역시: '울산',
-        세종특별자치시: '세종',
-        경기도: '경기',
-        강원특별자치도: '강원',
-        강원도: '강원',
-        충청북도: '충북',
-        충청남도: '충남',
-        전북특별자치도: '전북',
-        전라북도: '전북',
-        전라남도: '전남',
-        경상북도: '경북',
-        경상남도: '경남',
-        제주특별자치도: '제주',
-        제주도: '제주',
-      };
-      if (stateMapping[parsedState]) {
-        parsedState = stateMapping[parsedState];
-      }
-
       let parsedCity = addr.region_2depth_name;
       let parsedDistrict = addr.region_3depth_name;
 
@@ -156,7 +129,7 @@ const HostDetails = ({ data, onDataChange }: StepProps) => {
         location: {
           ...location,
           country: '한국',
-          state: parsedState,
+          state: addr.region_1depth_name,
           city: parsedCity,
           district: parsedDistrict,
           streetAddress: displayAddress,

--- a/src/pages/hosting/steps/HostDetails.tsx
+++ b/src/pages/hosting/steps/HostDetails.tsx
@@ -115,13 +115,50 @@ const HostDetails = ({ data, onDataChange }: StepProps) => {
         markerRef.current?.setPosition(newLatLng);
       }
 
+      let parsedState = addr.region_1depth_name;
+      const stateMapping: { [key: string]: string } = {
+        서울특별시: '서울',
+        부산광역시: '부산',
+        대구광역시: '대구',
+        인천광역시: '인천',
+        광주광역시: '광주',
+        대전광역시: '대전',
+        울산광역시: '울산',
+        세종특별자치시: '세종',
+        경기도: '경기',
+        강원특별자치도: '강원',
+        강원도: '강원',
+        충청북도: '충북',
+        충청남도: '충남',
+        전북특별자치도: '전북',
+        전라북도: '전북',
+        전라남도: '전남',
+        경상북도: '경북',
+        경상남도: '경남',
+        제주특별자치도: '제주',
+        제주도: '제주',
+      };
+      if (stateMapping[parsedState]) {
+        parsedState = stateMapping[parsedState];
+      }
+
+      let parsedCity = addr.region_2depth_name;
+      let parsedDistrict = addr.region_3depth_name;
+
+      // '성남시 분당구'와 같이 시와 구가 함께 오는 경우 분리
+      if (addr.region_2depth_name.includes(' ')) {
+        const parts = addr.region_2depth_name.split(' ');
+        parsedCity = parts[0];
+        parsedDistrict = parts[1];
+      }
+
       onDataChange({
         location: {
           ...location,
           country: '한국',
-          state: addr.region_1depth_name,
-          city: addr.region_2depth_name,
-          district: addr.region_3depth_name,
+          state: parsedState,
+          city: parsedCity,
+          district: parsedDistrict,
           streetAddress: displayAddress,
           detailAddress: location.detailAddress || '',
           postalCode: roadAddr?.zone_no || '',

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -8,7 +8,7 @@ export interface Listing {
   spaceType: SpaceType;
   location: {
     country: string;
-    province: string;
+    state: string;
     city: string;
     district: string;
     streetAddress: string;
@@ -59,7 +59,7 @@ export const defaultListing: Omit<Listing, 'id' | 'createdAt'> = {
   spaceType: '',
   location: {
     country: '한국',
-    province: '',
+    state: '',
     city: '',
     district: '',
     streetAddress: '',


### PR DESCRIPTION
## 🔗 반영 브랜치
refactor/accommodation → dev

## 📝 작업 내용
**1. 숙소 생성 500 에러 해결 (필수 필드 매핑)**
- 백엔드에서 필수값(`@NotBlank`)으로 요구하는 `district` (구/군) 필드가 프론트엔드 전송 페이로드에서 누락되어 있던 문제를 수정했습니다.
- `src/api/types.ts`의 `CreateAccommodationRequest` 타입에 `district` 추가
- `BecomeHostPage.tsx`에서 숙소 등록 API 호출 시 `district` 값을 포함하여 전송하도록 수정 (검색 결과에 구/군이 없는 경우 시/도 정보로 대체되도록 방어 로직 추가)
- 백엔드 DTO에 존재하지 않는 불필요한 `serviceFeePercentage` 필드 제거


**2. 프론트엔드 전역 주소 명칭 통일 (province -> state)**
- 백엔드 엔티티 및 DTO 명칭(`state`)과의 일관성을 위해 프론트엔드 내부에서 사용되던 `province` 명칭을 모두 `state`로 일괄 변경했습니다.
- **적용 대상:** 
  - `listing.ts` (`Listing['location']`)
  - `regions.ts` (상수 데이터 구조)
  - `HostDetails.tsx` (숙소 등록 주소 입력)
  - `SearchBar.tsx`, `RegionPopup.tsx` (검색바 컴포넌트)
  - `HostingPage.tsx`, `BecomeHostPage.tsx` (숙소 관리 페이지)

## 💬 리뷰 요구사항(선택 사항)
