### PR TITLE
feat: 동반자 초대 및 인연/예약 연동 개선

### DIFF
--- a/src/api/booking.ts
+++ b/src/api/booking.ts
@@ -7,6 +7,7 @@ import type {
   InviteGuestResponse,
   PageResponse,
   MyInvitationResponse,
+  BookingGuestConnectionResponse,
 } from './types';
 
 export type {
@@ -17,6 +18,7 @@ export type {
   InviteGuestResponse,
   PageResponse,
   MyInvitationResponse,
+  BookingGuestConnectionResponse,
 };
 
 /**
@@ -79,6 +81,18 @@ export async function getMyInvitations(
   const response = (await client.get(`/api/booking-guests/me`, {
     params,
   })) as PageResponse<MyInvitationResponse>;
+  return response;
+}
+
+/**
+ * 내 인연 목록 조회
+ */
+export async function getBookingGuestConnections(): Promise<
+  BookingGuestConnectionResponse[]
+> {
+  const response = (await client.get(
+    `/api/booking-guests/connections`,
+  )) as BookingGuestConnectionResponse[];
   return response;
 }
 

--- a/src/api/booking.ts
+++ b/src/api/booking.ts
@@ -35,6 +35,16 @@ export async function fetchUserBookings(
 }
 
 /**
+ * 내가 동반자로 참여한 예약 목록 조회
+ */
+export async function fetchCompanionBookings(): Promise<BookingResponse[]> {
+  const response = (await client.get(
+    `/api/booking-guests/me/bookings`,
+  )) as BookingResponse[];
+  return response;
+}
+
+/**
  * 호스트의 내 숙소 예약 목록 조회
  */
 export async function fetchHostBookings(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -333,11 +333,7 @@ export type ReviewSummryDTO = {
 };
 
 export interface InviteGuestRequest {
-  guestUserId?: number;
-  guestName?: string;
   guestEmail: string;
-  guestPhone?: string;
-  guestIdentityValid?: boolean;
 }
 
 export interface InviteGuestResponse {
@@ -362,6 +358,12 @@ export interface MyInvitationResponse {
   invitationStatus: string;
   invitedAt: string;
   respondedAt?: string;
+}
+
+export interface BookingGuestConnectionResponse {
+  userId: number;
+  nickName: string;
+  profileImageUrl: string | null;
 }
 // --- Favorite (즐겨찾기) API ---
 export type FavoriteResponseDTO = {

--- a/src/components/InviteFriendModal/InviteFriendModal.tsx
+++ b/src/components/InviteFriendModal/InviteFriendModal.tsx
@@ -1,18 +1,19 @@
-import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { inviteGuest, type InviteGuestRequest } from '@/api/booking';
 import {
-  ModalOverlay,
-  ModalContainer,
-  ModalHeader,
-  ModalCloseButton,
-  ModalTitle,
-  ModalBody,
-  SaveButton,
+  ErrorText,
   FooterRight,
   InputGroup,
-  ErrorText,
+  ModalBody,
+  ModalCloseButton,
+  ModalContainer,
+  ModalHeader,
+  ModalOverlay,
+  ModalTitle,
+  SaveButton,
 } from './InviteFriendModal.styles';
 
 interface InviteFriendModalProps {
@@ -21,6 +22,12 @@ interface InviteFriendModalProps {
   bookingId: number | null;
   onSuccess?: () => void;
 }
+
+type InviteErrorResponse = {
+  message?: string;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const InviteFriendModal = ({
   isOpen,
@@ -36,9 +43,7 @@ const InviteFriendModal = ({
 
   useEffect(() => {
     if (isOpen) {
-      setFormData({
-        guestEmail: '',
-      });
+      setFormData({ guestEmail: '' });
       setError(null);
       setLoading(false);
     }
@@ -49,25 +54,42 @@ const InviteFriendModal = ({
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
     if (!bookingId) return;
 
-    // 간단한 유효성 검사
-    if (!formData.guestEmail.trim()) {
+    const guestEmail = formData.guestEmail.trim();
+
+    if (!guestEmail) {
       setError('이메일을 입력해주세요.');
+      return;
+    }
+
+    if (!EMAIL_PATTERN.test(guestEmail)) {
+      setError('올바른 이메일 형식으로 입력해주세요.');
       return;
     }
 
     try {
       setLoading(true);
       setError(null);
-      await inviteGuest(bookingId, formData);
-      alert('친구 초대가 완료되었습니다.');
-      if (onSuccess) onSuccess();
+      await inviteGuest(bookingId, { guestEmail });
+      alert('동반자 초대가 전송되었습니다.');
+      onSuccess?.();
       onClose();
     } catch (err) {
       console.error(err);
-      setError('친구 초대에 실패했습니다. 잠시 후 다시 시도해주세요.');
+
+      if (axios.isAxiosError<InviteErrorResponse>(err)) {
+        setError(
+          err.response?.data?.message ||
+            '가입된 회원의 이메일만 초대할 수 있습니다.',
+        );
+        return;
+      }
+
+      setError('동반자 초대에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setLoading(false);
     }
@@ -79,27 +101,28 @@ const InviteFriendModal = ({
     <ModalOverlay onClick={onClose}>
       <ModalContainer onClick={(e) => e.stopPropagation()}>
         <ModalHeader>
-          <ModalCloseButton onClick={onClose}>
+          <ModalCloseButton onClick={onClose} aria-label="닫기">
             <X size={20} />
           </ModalCloseButton>
           <div />
         </ModalHeader>
 
-        <ModalBody>
+        <ModalBody as="form" id="invite-friend-form" onSubmit={handleSubmit}>
           <ModalTitle style={{ marginBottom: '24px' }}>
             동반 게스트 초대
           </ModalTitle>
 
           <InputGroup>
-            <label htmlFor="guestEmail">초대할 친구 이메일</label>
+            <label htmlFor="guestEmail">초대할 회원 이메일</label>
             <input
               id="guestEmail"
               name="guestEmail"
               type="email"
-              placeholder="예: friend@example.com"
+              placeholder="friend@example.com"
               value={formData.guestEmail}
               onChange={handleChange}
               disabled={loading}
+              autoFocus
             />
           </InputGroup>
 
@@ -107,7 +130,11 @@ const InviteFriendModal = ({
         </ModalBody>
 
         <FooterRight>
-          <SaveButton onClick={handleSubmit} disabled={loading}>
+          <SaveButton
+            type="submit"
+            form="invite-friend-form"
+            disabled={loading}
+          >
             {loading ? '초대 중...' : '초대하기'}
           </SaveButton>
         </FooterRight>

--- a/src/pages/payment/PaymentFailPage.tsx
+++ b/src/pages/payment/PaymentFailPage.tsx
@@ -125,7 +125,7 @@ export default function PaymentFailPage() {
         <PaymentFailLinkButton to="/">홈으로</PaymentFailLinkButton>
 
         {bookingId && (
-          <PaymentFailLinkButton to={`/bookings/${bookingId}`}>
+          <PaymentFailLinkButton to="/profile?menu=trips">
             예약 상세 보기
           </PaymentFailLinkButton>
         )}

--- a/src/pages/payment/PaymentSuccessPage.tsx
+++ b/src/pages/payment/PaymentSuccessPage.tsx
@@ -138,7 +138,7 @@ export default function PaymentSuccessPage() {
 
       <PaymentSuccessButtonGroup>
         {bookingId && (
-          <PaymentSuccessLink to={`/bookings/${bookingId}`}>
+          <PaymentSuccessLink to="/profile?menu=trips">
             예약 상세보기
           </PaymentSuccessLink>
         )}

--- a/src/pages/profile/sections/ConnectionsSection.tsx
+++ b/src/pages/profile/sections/ConnectionsSection.tsx
@@ -1,12 +1,18 @@
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import {
+  getBookingGuestConnections,
+  type BookingGuestConnectionResponse,
+} from '@/api/booking';
+import { media } from '@/styles/media';
 import {
   ContentTitle,
+  EmptyLink,
   EmptyState,
   EmptyText,
-  EmptyLink,
   PrimaryButton,
-} from "../profile.styles";
-import styled from "styled-components";
+} from '../profile.styles';
 
 const ConnectionImage = styled.div`
   width: 200px;
@@ -15,30 +21,160 @@ const ConnectionImage = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 100px;
+  font-size: 64px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.primary.main};
+`;
+
+const ConnectionList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: ${({ theme }) => theme.spacing.lg};
+
+  ${media.mobile} {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ConnectionItem = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.md};
+  padding: ${({ theme }) => theme.spacing.lg};
+  border: 1px solid ${({ theme }) => theme.colors.border.light};
+  border-radius: ${({ theme }) => theme.radius.lg};
+  background: ${({ theme }) => theme.colors.common.white};
+  text-align: left;
+`;
+
+const ProfileImage = styled.img`
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+`;
+
+const ProfileFallback = styled.div`
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: ${({ theme }) => theme.colors.text.primary};
+  color: ${({ theme }) => theme.colors.common.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: ${({ theme }) => theme.font.size.lg};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+`;
+
+const ConnectionName = styled.span`
+  min-width: 0;
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size.md};
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const ConnectionsSection = () => {
   const navigate = useNavigate();
+  const [connections, setConnections] = useState<
+    BookingGuestConnectionResponse[]
+  >([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchConnections = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getBookingGuestConnections();
+        setConnections(data || []);
+      } catch (err) {
+        console.error('Failed to fetch booking guest connections:', err);
+        setError('인연 목록을 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchConnections();
+  }, []);
 
   const handleBookTrip = () => {
-    navigate("/");
+    navigate('/');
   };
+
+  const renderAvatar = (connection: BookingGuestConnectionResponse) => {
+    if (connection.profileImageUrl) {
+      return (
+        <ProfileImage
+          src={connection.profileImageUrl}
+          alt={`${connection.nickName} 프로필`}
+        />
+      );
+    }
+
+    return <ProfileFallback>{connection.nickName.charAt(0)}</ProfileFallback>;
+  };
+
+  if (loading) {
+    return (
+      <>
+        <ContentTitle>인연</ContentTitle>
+        <EmptyState>
+          <EmptyText>인연 목록을 불러오는 중입니다...</EmptyText>
+        </EmptyState>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <ContentTitle>인연</ContentTitle>
+        <EmptyState>
+          <EmptyText>{error}</EmptyText>
+        </EmptyState>
+      </>
+    );
+  }
+
+  if (connections.length === 0) {
+    return (
+      <>
+        <ContentTitle>인연</ContentTitle>
+
+        <EmptyState>
+          <ConnectionImage>0</ConnectionImage>
+          <EmptyText>
+            여행에 동반자를 초대하고 상대방이 수락하면
+            <br />
+            이곳에 함께한 게스트의 프로필이 표시됩니다.
+          </EmptyText>
+          <EmptyLink>자세히 알아보기</EmptyLink>
+          <PrimaryButton onClick={handleBookTrip}>여행 예약</PrimaryButton>
+        </EmptyState>
+      </>
+    );
+  }
 
   return (
     <>
       <ContentTitle>인연</ContentTitle>
 
-      <EmptyState>
-        <ConnectionImage>👥</ConnectionImage>
-        <EmptyText>
-          체험에 참여하거나 여행에 일행을 초대하면, 다른
-          <br />
-          게스트의 프로필이 여기에 표시됩니다.
-        </EmptyText>
-        <EmptyLink>자세히 알아보기</EmptyLink>
-        <PrimaryButton onClick={handleBookTrip}>여행 예약</PrimaryButton>
-      </EmptyState>
+      <ConnectionList>
+        {connections.map((connection) => (
+          <ConnectionItem key={connection.userId}>
+            {renderAvatar(connection)}
+            <ConnectionName>{connection.nickName}</ConnectionName>
+          </ConnectionItem>
+        ))}
+      </ConnectionList>
     </>
   );
 };

--- a/src/pages/profile/sections/ConnectionsSection.tsx
+++ b/src/pages/profile/sections/ConnectionsSection.tsx
@@ -6,77 +6,99 @@ import {
   type BookingGuestConnectionResponse,
 } from '@/api/booking';
 import { media } from '@/styles/media';
-import {
-  ContentTitle,
-  EmptyLink,
-  EmptyState,
-  EmptyText,
-  PrimaryButton,
-} from '../profile.styles';
+import { EmptyState, EmptyText, PrimaryButton } from '../profile.styles';
 
-const ConnectionImage = styled.div`
-  width: 200px;
-  height: 150px;
-  margin-bottom: ${({ theme }) => theme.spacing.xl};
+const SectionHeader = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 64px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${({ theme }) => theme.spacing.lg};
+  margin-bottom: ${({ theme }) => theme.spacing['2xl']};
+
+  ${media.mobile} {
+    align-items: stretch;
+    flex-direction: column;
+  }
+`;
+
+const HeaderText = styled.div`
+  min-width: 0;
+`;
+
+const Title = styled.h2`
+  color: ${({ theme }) => theme.colors.text.primary};
+  font-size: ${({ theme }) => theme.font.size['2xl']};
   font-weight: ${({ theme }) => theme.font.weight.bold};
-  color: ${({ theme }) => theme.colors.primary.main};
+  margin: 0 0 ${({ theme }) => theme.spacing.sm};
+`;
+
+const Description = styled.p`
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.sm};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
+  margin: 0;
 `;
 
 const ConnectionList = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: ${({ theme }) => theme.spacing.lg};
+  grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+  gap: ${({ theme }) => theme.spacing.md};
+  max-width: 640px;
 
   ${media.mobile} {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 `;
 
-const ConnectionItem = styled.div`
-  display: flex;
-  align-items: center;
-  gap: ${({ theme }) => theme.spacing.md};
-  padding: ${({ theme }) => theme.spacing.lg};
+const ConnectionCard = styled.div`
+  min-height: 160px;
+  padding: ${({ theme }) => `${theme.spacing.xl} ${theme.spacing.md}`};
   border: 1px solid ${({ theme }) => theme.colors.border.light};
   border-radius: ${({ theme }) => theme.radius.lg};
   background: ${({ theme }) => theme.colors.common.white};
-  text-align: left;
+  box-shadow: ${({ theme }) => theme.shadow.sm};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 `;
 
 const ProfileImage = styled.img`
-  width: 56px;
-  height: 56px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
   object-fit: cover;
-  flex-shrink: 0;
+  margin-bottom: ${({ theme }) => theme.spacing.md};
 `;
 
 const ProfileFallback = styled.div`
-  width: 56px;
-  height: 56px;
+  width: 72px;
+  height: 72px;
   border-radius: 50%;
-  background: ${({ theme }) => theme.colors.text.primary};
-  color: ${({ theme }) => theme.colors.common.white};
+  background: ${({ theme }) => theme.colors.primary.light};
+  color: ${({ theme }) => theme.colors.primary.main};
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
-  font-size: ${({ theme }) => theme.font.size.lg};
+  margin-bottom: ${({ theme }) => theme.spacing.md};
+  font-size: ${({ theme }) => theme.font.size.md};
   font-weight: ${({ theme }) => theme.font.weight.bold};
 `;
 
-const ConnectionName = styled.span`
-  min-width: 0;
+const ConnectionName = styled.strong`
+  width: 100%;
   color: ${({ theme }) => theme.colors.text.primary};
   font-size: ${({ theme }) => theme.font.size.md};
   font-weight: ${({ theme }) => theme.font.weight.bold};
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+const TripText = styled.span`
+  margin-top: ${({ theme }) => theme.spacing.xs};
+  color: ${({ theme }) => theme.colors.text.secondary};
+  font-size: ${({ theme }) => theme.font.size.xs};
 `;
 
 const ConnectionsSection = () => {
@@ -119,62 +141,64 @@ const ConnectionsSection = () => {
       );
     }
 
-    return <ProfileFallback>{connection.nickName.charAt(0)}</ProfileFallback>;
+    return <ProfileFallback>{connection.nickName}</ProfileFallback>;
   };
 
-  if (loading) {
-    return (
-      <>
-        <ContentTitle>인연</ContentTitle>
+  const renderContent = () => {
+    if (loading) {
+      return (
         <EmptyState>
           <EmptyText>인연 목록을 불러오는 중입니다...</EmptyText>
         </EmptyState>
-      </>
-    );
-  }
+      );
+    }
 
-  if (error) {
-    return (
-      <>
-        <ContentTitle>인연</ContentTitle>
+    if (error) {
+      return (
         <EmptyState>
           <EmptyText>{error}</EmptyText>
         </EmptyState>
-      </>
-    );
-  }
+      );
+    }
 
-  if (connections.length === 0) {
-    return (
-      <>
-        <ContentTitle>인연</ContentTitle>
-
+    if (connections.length === 0) {
+      return (
         <EmptyState>
-          <ConnectionImage>0</ConnectionImage>
           <EmptyText>
-            여행에 동반자를 초대하고 상대방이 수락하면
+            아직 표시할 인연이 없습니다.
             <br />
-            이곳에 함께한 게스트의 프로필이 표시됩니다.
+            여행에 동반자를 초대하고 상대방이 수락하면 여기에 표시됩니다.
           </EmptyText>
-          <EmptyLink>자세히 알아보기</EmptyLink>
           <PrimaryButton onClick={handleBookTrip}>여행 예약</PrimaryButton>
         </EmptyState>
-      </>
+      );
+    }
+
+    return (
+      <ConnectionList>
+        {connections.map((connection) => (
+          <ConnectionCard key={connection.userId}>
+            {renderAvatar(connection)}
+            <ConnectionName>{connection.nickName}</ConnectionName>
+            <TripText>함께한 여행 1회</TripText>
+          </ConnectionCard>
+        ))}
+      </ConnectionList>
     );
-  }
+  };
 
   return (
     <>
-      <ContentTitle>인연</ContentTitle>
+      <SectionHeader>
+        <HeaderText>
+          <Title>인연</Title>
+          <Description>
+            숙소, 체험, 서비스를 함께 예약했던 사람이 여기에 표시됩니다.
+          </Description>
+        </HeaderText>
+      </SectionHeader>
 
-      <ConnectionList>
-        {connections.map((connection) => (
-          <ConnectionItem key={connection.userId}>
-            {renderAvatar(connection)}
-            <ConnectionName>{connection.nickName}</ConnectionName>
-          </ConnectionItem>
-        ))}
-      </ConnectionList>
+      {renderContent()}
     </>
   );
 };

--- a/src/pages/profile/sections/PastTripsSection.tsx
+++ b/src/pages/profile/sections/PastTripsSection.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
+import { fetchAccommodationDetail } from '@/api/accommodation';
+import {
+  fetchCompanionBookings,
+  fetchHostBookings,
+  fetchUserBookings,
+  type BookingResponse,
+  type HostBookingListItemResponse,
+} from '@/api/booking';
+import InviteFriendModal from '@/components/InviteFriendModal';
+import { useAuth } from '@/contexts/AuthContext';
 import { media } from '@/styles/media';
 import {
   ContentTitle,
@@ -8,15 +18,6 @@ import {
   EmptyText,
   PrimaryButton,
 } from '../profile.styles';
-import {
-  fetchHostBookings,
-  fetchUserBookings,
-  type HostBookingListItemResponse,
-  type BookingResponse,
-} from '@/api/booking';
-import { fetchAccommodationDetail } from '@/api/accommodation';
-import InviteFriendModal from '@/components/InviteFriendModal';
-import { useAuth } from '@/contexts/AuthContext';
 
 const ReservationList = styled.div`
   display: flex;
@@ -69,11 +70,11 @@ const ReservationHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: ${({ theme }) => theme.spacing.sm};
   margin-bottom: ${({ theme }) => theme.spacing.sm};
 
   ${media.mobile} {
     flex-direction: column;
-    gap: ${({ theme }) => theme.spacing.xs};
   }
 `;
 
@@ -81,6 +82,17 @@ const AccommodationName = styled.h3`
   font-size: ${({ theme }) => theme.font.size.xl};
   font-weight: ${({ theme }) => theme.font.weight.bold};
   color: ${({ theme }) => theme.colors.text.primary};
+`;
+
+const StatusGroup = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.spacing.xs};
+  justify-content: flex-end;
+
+  ${media.mobile} {
+    justify-content: flex-start;
+  }
 `;
 
 const ReservationStatus = styled.span`
@@ -145,7 +157,9 @@ const TripImage = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 120px;
+  font-size: 72px;
+  font-weight: ${({ theme }) => theme.font.weight.bold};
+  color: ${({ theme }) => theme.colors.primary.main};
 `;
 
 const SectionTitle = styled.h2`
@@ -162,6 +176,9 @@ const PastTripsSection = () => {
   const isHost = user?.role === 'HOST';
 
   const [guestBookings, setGuestBookings] = useState<BookingResponse[]>([]);
+  const [companionBookings, setCompanionBookings] = useState<BookingResponse[]>(
+    [],
+  );
   const [hostBookings, setHostBookings] = useState<
     HostBookingListItemResponse[]
   >([]);
@@ -181,35 +198,53 @@ const PastTripsSection = () => {
     const loadBookings = async () => {
       try {
         setLoading(true);
+        setError(null);
 
-        // 게스트의 내가 예약한 목록 조회
-        const gBookings = await fetchUserBookings('CONFIRMED');
+        const [gBookings, cBookings, hBookings] = await Promise.all([
+          fetchUserBookings('CONFIRMED'),
+          fetchCompanionBookings(),
+          isHost
+            ? fetchHostBookings('CONFIRMED')
+            : Promise.resolve<HostBookingListItemResponse[]>([]),
+        ]);
+
         setGuestBookings(gBookings || []);
+        setCompanionBookings(cBookings || []);
+        setHostBookings(hBookings || []);
 
-        // 내가 예약한 숙소의 이름 정보를 가져오기 위해 숙소 디테일 조회 (ReviewPage 참조)
-        if (gBookings && gBookings.length > 0) {
-          const accIds = [...new Set(gBookings.map((b) => b.accommodationId))];
-          const newNames: Record<number, string> = {};
-          const detailPromises = accIds.map(async (id) => {
+        const accommodationIds = [
+          ...new Set([
+            ...(gBookings || []).map((booking) => booking.accommodationId),
+            ...(cBookings || []).map((booking) => booking.accommodationId),
+          ]),
+        ];
+
+        if (accommodationIds.length === 0) {
+          setAccommodationNames({});
+          return;
+        }
+
+        const nextNames: Record<number, string> = {};
+        await Promise.all(
+          accommodationIds.map(async (accommodationId) => {
             try {
-              const detail = await fetchAccommodationDetail(String(id));
-              newNames[id] = detail.title;
+              const detail = await fetchAccommodationDetail(
+                String(accommodationId),
+              );
+              nextNames[accommodationId] = detail.title;
             } catch (e) {
-              console.error(`Failed to fetch title for accommodation ${id}`, e);
+              console.error(
+                `Failed to fetch title for accommodation ${accommodationId}`,
+                e,
+              );
             }
-          });
-          await Promise.all(detailPromises);
-          setAccommodationNames(newNames);
-        }
+          }),
+        );
 
-        // 사용자가 호스트인 경우, 호스트의 예약 목록도 조회
-        if (isHost) {
-          const hBookings = await fetchHostBookings('CONFIRMED');
-          setHostBookings(hBookings || []);
-        }
+        setAccommodationNames(nextNames);
       } catch (err) {
         console.error('Failed to fetch bookings:', err);
-        setError('예약 목록을 불러오는데 실패했습니다.');
+        setError('예약 목록을 불러오지 못했습니다.');
       } finally {
         setLoading(false);
       }
@@ -246,9 +281,67 @@ const PastTripsSection = () => {
       CONFIRMED: '예약 확정',
       CANCELLED: '예약 취소',
       COMPLETED: '이용 완료',
+      REJECTED: '예약 거절',
     };
     return statusMap[status] || status;
   };
+
+  const getAccommodationName = (accommodationId: number) => {
+    return accommodationNames[accommodationId] || `숙소 ID: ${accommodationId}`;
+  };
+
+  const renderBookingCard = (
+    booking: BookingResponse,
+    keyPrefix: string,
+    options?: {
+      companion?: boolean;
+      inviteEnabled?: boolean;
+    },
+  ) => (
+    <ReservationCard key={`${keyPrefix}-${booking.bookingId}`}>
+      <ReservationImage>집</ReservationImage>
+      <ReservationInfo>
+        <ReservationHeader>
+          <AccommodationName>
+            {getAccommodationName(booking.accommodationId)}
+          </AccommodationName>
+          <StatusGroup>
+            {options?.companion && (
+              <ReservationStatus>동반자 예약</ReservationStatus>
+            )}
+            <ReservationStatus>
+              {getStatusText(booking.bookingStatus || 'CONFIRMED')}
+            </ReservationStatus>
+          </StatusGroup>
+        </ReservationHeader>
+        <ReservationDetails>
+          <DetailText>
+            일정: {booking.checkInDate} ~ {booking.checkOutDate}
+          </DetailText>
+          <DetailText>인원: 게스트 {booking.numberOfGuests}명</DetailText>
+          <DetailText>
+            총 결제 금액: {formatPrice(booking.totalPrice)}
+          </DetailText>
+        </ReservationDetails>
+
+        <ButtonGroup>
+          <ActionButton
+            onClick={() => handleViewDetails(booking.accommodationId)}
+          >
+            숙소 상세보기
+          </ActionButton>
+          {options?.inviteEnabled && (
+            <ActionButton
+              $primary
+              onClick={() => handleInviteFriend(booking.bookingId)}
+            >
+              친구 초대
+            </ActionButton>
+          )}
+        </ButtonGroup>
+      </ReservationInfo>
+    </ReservationCard>
+  );
 
   if (loading) {
     return (
@@ -276,14 +369,14 @@ const PastTripsSection = () => {
   }
 
   const renderGuestBookings = () => {
-    if (guestBookings.length === 0) {
+    if (guestBookings.length === 0 && companionBookings.length === 0) {
       return (
         <EmptyState>
-          <TripImage>🧳</TripImage>
+          <TripImage>0</TripImage>
           <EmptyText>
-            CozyStay에서 첫 예약 내역이 없습니다.
+            CozyStay에서 아직 예약 내역이 없습니다.
             <br />
-            원하는 숙소를 예약하여 멋진 여행을 시작해보세요!
+            마음에 드는 숙소를 예약하고 멋진 여행을 시작해보세요.
           </EmptyText>
           <PrimaryButton onClick={handleBookTrip}>여행 예약하기</PrimaryButton>
         </EmptyState>
@@ -291,47 +384,29 @@ const PastTripsSection = () => {
     }
 
     return (
-      <ReservationList>
-        {guestBookings.map((booking) => (
-          <ReservationCard key={`guest-${booking.bookingId}`}>
-            <ReservationImage>🏠</ReservationImage>
-            <ReservationInfo>
-              <ReservationHeader>
-                <AccommodationName>
-                  {accommodationNames[booking.accommodationId] ||
-                    `숙소 ID: ${booking.accommodationId}`}
-                </AccommodationName>
-                <ReservationStatus>
-                  {getStatusText(booking.bookingStatus || 'CONFIRMED')}
-                </ReservationStatus>
-              </ReservationHeader>
-              <ReservationDetails>
-                <DetailText>
-                  일정: {booking.checkInDate} ~ {booking.checkOutDate}
-                </DetailText>
-                <DetailText>인원: 게스트 {booking.numberOfGuests}명</DetailText>
-                <DetailText>
-                  총 결제 금액: {formatPrice(booking.totalPrice)}
-                </DetailText>
-              </ReservationDetails>
+      <>
+        {guestBookings.length > 0 && (
+          <>
+            <SectionTitle>내가 예약한 리스트</SectionTitle>
+            <ReservationList>
+              {guestBookings.map((booking) =>
+                renderBookingCard(booking, 'guest', { inviteEnabled: true }),
+              )}
+            </ReservationList>
+          </>
+        )}
 
-              <ButtonGroup>
-                <ActionButton
-                  onClick={() => handleViewDetails(booking.accommodationId)}
-                >
-                  숙소 상세보기
-                </ActionButton>
-                <ActionButton
-                  $primary
-                  onClick={() => handleInviteFriend(booking.bookingId)}
-                >
-                  친구 초대
-                </ActionButton>
-              </ButtonGroup>
-            </ReservationInfo>
-          </ReservationCard>
-        ))}
-      </ReservationList>
+        {companionBookings.length > 0 && (
+          <>
+            <SectionTitle>동반자로 참여한 예약</SectionTitle>
+            <ReservationList>
+              {companionBookings.map((booking) =>
+                renderBookingCard(booking, 'companion', { companion: true }),
+              )}
+            </ReservationList>
+          </>
+        )}
+      </>
     );
   };
 
@@ -343,9 +418,7 @@ const PastTripsSection = () => {
         <>
           <SectionTitle>호스트 예약 내역</SectionTitle>
           <EmptyState>
-            <EmptyText>
-              아직 호스트님의 숙소에 예약된 내역이 없습니다.
-            </EmptyText>
+            <EmptyText>아직 호스트 숙소에 대한 예약 내역이 없습니다.</EmptyText>
           </EmptyState>
         </>
       );
@@ -357,7 +430,7 @@ const PastTripsSection = () => {
         <ReservationList>
           {hostBookings.map((booking) => (
             <ReservationCard key={`host-${booking.bookingId}`}>
-              <ReservationImage>🏠</ReservationImage>
+              <ReservationImage>집</ReservationImage>
               <ReservationInfo>
                 <ReservationHeader>
                   <AccommodationName>
@@ -398,7 +471,6 @@ const PastTripsSection = () => {
     <>
       <ContentTitle>예약</ContentTitle>
 
-      <SectionTitle>내가 예약한 리스트</SectionTitle>
       {renderGuestBookings()}
 
       {renderHostBookings()}

--- a/src/pages/profile/sections/PastTripsSection.tsx
+++ b/src/pages/profile/sections/PastTripsSection.tsx
@@ -201,7 +201,7 @@ const PastTripsSection = () => {
         setError(null);
 
         const [gBookings, cBookings, hBookings] = await Promise.all([
-          fetchUserBookings('CONFIRMED'),
+          fetchUserBookings(),
           fetchCompanionBookings(),
           isHost
             ? fetchHostBookings('CONFIRMED')


### PR DESCRIPTION
## 🔗 반영 브랜치

(#64) refactor/invitation -> dev


## 📝 작업 내용

- 동반자 초대 요청 타입을 회원 이메일 기반으로 정리했습니다.
- 동반자 초대 모달의 이메일 검증, 성공/실패 문구, 백엔드 에러 메시지 표시를 개선했습니다.
- 인연 목록 API를 연동하고, 마이페이지 인연 탭에 프로필 카드 UI를 추가했습니다.
  - 프로필 이미지가 있으면 이미지 표시
  - 없으면 기본 프로필 카드 표시
- 결제 성공/실패 페이지의 `예약 상세보기` 링크를 존재하지 않는 `/bookings/:id` 대신 마이페이지 예약 탭으로 연결했습니다.
- 마이페이지 예약 탭에서 내가 직접 예약한 예약과 동반자로 참여한 예약을 함께 조회하도록 수정했습니다.
- 예약 탭에서 `CONFIRMED`만 조회하던 문제를 수정해 전체 내 예약이 표시되도록 변경했습니다.

<img width="1012" height="933" alt="스크린샷 2026-05-20 015724" src="https://github.com/user-attachments/assets/e44b7a56-cf2b-4cc1-acf5-9c2b5b87a0c6" />

<img width="859" height="668" alt="스크린샷 2026-05-20 020100" src="https://github.com/user-attachments/assets/f8a01483-72c3-487f-808d-b25a4d7eef73" />

<img width="665" height="346" alt="스크린샷 2026-05-20 024637" src="https://github.com/user-attachments/assets/1b08ff2a-8357-4f7b-adec-352606d6d075" />


<img width="697" height="714" alt="스크린샷 2026-05-20 023543" src="https://github.com/user-attachments/assets/e1d8e225-1c13-45fa-9246-b04cd91608b2" />


## 변경 파일

- `src/api/booking.ts`


- `src/api/types.ts`
- `src/components/InviteFriendModal/InviteFriendModal.tsx`
- `src/pages/payment/PaymentFailPage.tsx`
- `src/pages/payment/PaymentSuccessPage.tsx`
- `src/pages/profile/sections/ConnectionsSection.tsx`
- `src/pages/profile/sections/PastTripsSection.tsx`



## 💬 리뷰 요구사항(선택 사항)

리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
