### PR TITLE
Refactor: 로그인 리다이렉트 및 회원가입 오류 메시지 개선

### DIFF
--- a/src/pages/auth/SignupModal.tsx
+++ b/src/pages/auth/SignupModal.tsx
@@ -148,7 +148,7 @@ const SignupModal = ({ open, onClose }: SignupModalProps) => {
         nickName: formData.nickName,
       })) as { success?: boolean; message?: string } | null;
 
-      if (result?.success || result) {
+      if (result?.success !== false) {
         alert('회원가입이 완료되었습니다!');
         onClose();
       } else {

--- a/src/pages/auth/SignupModal.tsx
+++ b/src/pages/auth/SignupModal.tsx
@@ -2,286 +2,343 @@ import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import client from '@/api/client';
 import {
-    Page,
-    SignupCard,
-    CloseButton,
-    ModalHeader,
-    ModalTitle,
-    ModalSubtitle,
-    Form,
-    FormGroup,
-    Label,
-    Input,
-    InputGroup,
-    ActionButton,
-    SubmitButton,
-    ErrorText,
-    SuccessText,
+  Page,
+  SignupCard,
+  CloseButton,
+  ModalHeader,
+  ModalTitle,
+  ModalSubtitle,
+  Form,
+  FormGroup,
+  Label,
+  Input,
+  InputGroup,
+  ActionButton,
+  SubmitButton,
+  ErrorText,
+  SuccessText,
 } from './signup.styles';
 
 type SignupModalProps = {
-    open: boolean;
-    onClose: () => void;
+  open: boolean;
+  onClose: () => void;
 };
 
 const SignupModal = ({ open, onClose }: SignupModalProps) => {
-    const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState({
+    username: '',
+    password: '',
+    passwordConfirm: '',
+    nickName: '',
+    email: '',
+    verificationCode: '',
+  });
+
+  const [emailStatus, setEmailStatus] = useState<'idle' | 'sending' | 'sent'>(
+    'idle',
+  );
+  const [verificationStatus, setVerificationStatus] = useState<
+    'idle' | 'verifying' | 'success' | 'failed'
+  >('idle');
+  const [emailError, setEmailError] = useState('');
+  const [verificationError, setVerificationError] = useState('');
+  const [submitError, setSubmitError] = useState('');
+
+  useEffect(() => {
+    if (!open) {
+      setFormData({
         username: '',
         password: '',
         passwordConfirm: '',
         nickName: '',
         email: '',
         verificationCode: '',
-    });
+      });
+      setEmailStatus('idle');
+      setVerificationStatus('idle');
+      setEmailError('');
+      setVerificationError('');
+      setSubmitError('');
+    }
+  }, [open]);
 
-    const [emailStatus, setEmailStatus] = useState<'idle' | 'sending' | 'sent'>('idle');
-    const [verificationStatus, setVerificationStatus] = useState<'idle' | 'verifying' | 'success' | 'failed'>('idle');
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
 
-    useEffect(() => {
-        if (!open) {
-            setFormData({
-                username: '',
-                password: '',
-                passwordConfirm: '',
-                nickName: '',
-                email: '',
-                verificationCode: '',
-            });
-            setEmailStatus('idle');
-            setVerificationStatus('idle');
-        }
-    }, [open]);
+    // 입력 값 변경 시 기존 관련 오류 메시지 클리어
+    if (name === 'email') {
+      setEmailError('');
+    } else if (name === 'verificationCode') {
+      setVerificationError('');
+    }
+    setSubmitError('');
+  };
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        setFormData((prev) => ({ ...prev, [name]: value }));
-    };
+  const handleSendVerification = async () => {
+    if (!formData.email) {
+      setEmailError('이메일을 입력해주세요.');
+      return;
+    }
+    setEmailError('');
+    setEmailStatus('sending');
+    try {
+      // client defaults to stripping out {data}, so if response doesn't throw it's 2xx
+      await client.post(
+        `/api/auth/email-verification/request?email=${formData.email}`,
+      );
+      setEmailStatus('sent');
+    } catch (error: unknown) {
+      console.error('Send verification error:', error);
+      setEmailStatus('idle');
+      let errorMessage = '인증번호 발송에 실패했습니다. 다시 시도해주세요.';
+      if (axios.isAxiosError(error)) {
+        errorMessage = error.response?.data?.message || errorMessage;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      setEmailError(errorMessage);
+    }
+  };
 
-    const handleSendVerification = async () => {
-        if (!formData.email) {
-            alert('이메일을 입력해주세요.');
-            return;
-        }
-        setEmailStatus('sending');
-        try {
-            // client defaults to stripping out {data}, so if response doesn't throw it's 2xx
-            await client.post(`/api/auth/email-verification/request?email=${formData.email}`);
-            setEmailStatus('sent');
-            alert('인증번호가 발송되었습니다. 이메일을 확인해주세요.');
-        } catch (error: unknown) {
-            console.error('Send verification error:', error);
-            setEmailStatus('idle');
-            let errorMessage = '인증번호 발송에 실패했습니다. 다시 시도해주세요.';
-            if (axios.isAxiosError(error)) {
-                errorMessage = error.response?.data?.message || errorMessage;
-            } else if (error instanceof Error) {
-                errorMessage = error.message;
-            }
-            alert(errorMessage);
-        }
-    };
+  const handleVerifyCode = async () => {
+    if (!formData.verificationCode) {
+      setVerificationError('인증번호를 입력해주세요.');
+      return;
+    }
+    setVerificationError('');
+    setVerificationStatus('verifying');
+    try {
+      await client.post('/api/auth/verify', {
+        email: formData.email,
+        code: formData.verificationCode,
+      });
+      setVerificationStatus('success');
+    } catch (error: unknown) {
+      console.error('Verify code error:', error);
+      setVerificationStatus('failed');
+      let errorMessage = '인증에 실패했습니다. 코드를 다시 확인해주세요.';
+      if (axios.isAxiosError(error)) {
+        errorMessage = error.response?.data?.message || errorMessage;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      setVerificationError(errorMessage);
+    }
+  };
 
-    const handleVerifyCode = async () => {
-        if (!formData.verificationCode) {
-            alert('인증번호를 입력해주세요.');
-            return;
-        }
-        setVerificationStatus('verifying');
-        try {
-            await client.post('/api/auth/verify', {
-                email: formData.email,
-                code: formData.verificationCode,
-            });
-            setVerificationStatus('success');
-            alert('인증이 완료되었습니다.');
-        } catch (error: unknown) {
-            console.error('Verify code error:', error);
-            setVerificationStatus('failed');
-            let errorMessage = '인증에 실패했습니다. 코드를 다시 확인해주세요.';
-            if (axios.isAxiosError(error)) {
-                errorMessage = error.response?.data?.message || errorMessage;
-            } else if (error instanceof Error) {
-                errorMessage = error.message;
-            }
-            alert(errorMessage);
-        }
-    };
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setSubmitError('');
 
-    const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault();
-        if (formData.password !== formData.passwordConfirm) {
-            alert('비밀번호가 일치하지 않습니다.');
-            return;
-        }
-        if (verificationStatus !== 'success') {
-            alert('이메일 인증을 완료해주세요.');
-            return;
-        }
+    if (formData.password !== formData.passwordConfirm) {
+      setSubmitError('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+    if (verificationStatus !== 'success') {
+      setSubmitError('이메일 인증을 완료해주세요.');
+      return;
+    }
 
-        try {
-            const result: any = await client.post('/api/auth/signup', {
-                username: formData.username,
-                password: formData.password,
-                email: formData.email,
-                nickName: formData.nickName,
-            });
+    try {
+      const result = (await client.post('/api/auth/signup', {
+        username: formData.username,
+        password: formData.password,
+        email: formData.email,
+        nickName: formData.nickName,
+      })) as { success?: boolean; message?: string } | null;
 
-            if (result?.success || result) {
-                alert('회원가입이 완료되었습니다!');
-                onClose();
-            } else {
-                throw new Error(result?.message || '회원가입 실패');
-            }
-        } catch (error: unknown) {
-            console.error('Signup error:', error);
-            let errorMessage = '회원가입 중 오류가 발생했습니다.';
-            if (axios.isAxiosError(error)) {
-                errorMessage = error.response?.data?.message || error.message || errorMessage;
-            } else if (error instanceof Error) {
-                errorMessage = error.message;
-            }
-            alert(errorMessage);
-        }
-    };
+      if (result?.success || result) {
+        alert('회원가입이 완료되었습니다!');
+        onClose();
+      } else {
+        throw new Error(result?.message || '회원가입 실패');
+      }
+    } catch (error: unknown) {
+      console.error('Signup error:', error);
+      let errorMessage = '회원가입 중 오류가 발생했습니다.';
+      if (axios.isAxiosError(error)) {
+        errorMessage =
+          error.response?.data?.message || error.message || errorMessage;
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+      setSubmitError(errorMessage);
+    }
+  };
 
-    if (!open) return null;
+  if (!open) return null;
 
-    return (
-        <Page onClick={onClose}>
-            <SignupCard
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby="signup-modal-title"
-                onClick={(e) => e.stopPropagation()}
+  return (
+    <Page onClick={onClose}>
+      <SignupCard
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="signup-modal-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CloseButton type="button" aria-label="닫기" onClick={onClose}>
+          ×
+        </CloseButton>
+        <ModalHeader>
+          <ModalTitle id="signup-modal-title">코지스테이 회원가입</ModalTitle>
+          <ModalSubtitle>
+            여정을 시작하기 위해 계정을 만들어주세요.
+          </ModalSubtitle>
+        </ModalHeader>
+
+        <Form onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label htmlFor="username">아이디</Label>
+            <Input
+              id="username"
+              name="username"
+              type="text"
+              placeholder="사용할 아이디를 입력하세요"
+              value={formData.username}
+              onChange={handleChange}
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="password">비밀번호</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              placeholder="비밀번호를 입력하세요 (8자 이상)"
+              value={formData.password}
+              onChange={handleChange}
+              minLength={8}
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
+            <Input
+              id="passwordConfirm"
+              name="passwordConfirm"
+              type="password"
+              placeholder="비밀번호를 다시 한 번 입력하세요"
+              value={formData.passwordConfirm}
+              onChange={handleChange}
+              required
+            />
+            {formData.passwordConfirm &&
+              formData.password !== formData.passwordConfirm && (
+                <ErrorText>비밀번호가 일치하지 않습니다.</ErrorText>
+              )}
+            {formData.passwordConfirm &&
+              formData.password === formData.passwordConfirm && (
+                <SuccessText>비밀번호가 일치합니다.</SuccessText>
+              )}
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="nickName">닉네임</Label>
+            <Input
+              id="nickName"
+              name="nickName"
+              type="text"
+              placeholder="사용할 닉네임을 입력하세요"
+              value={formData.nickName}
+              onChange={handleChange}
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label htmlFor="email">이메일</Label>
+            <InputGroup>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                placeholder="이메일 주소를 입력하세요"
+                value={formData.email}
+                onChange={handleChange}
+                disabled={emailStatus === 'sent'}
+                required
+              />
+              <ActionButton
+                type="button"
+                $variant="secondary"
+                onClick={handleSendVerification}
+                disabled={
+                  emailStatus === 'sending' ||
+                  emailStatus === 'sent' ||
+                  !formData.email
+                }
+              >
+                {emailStatus === 'sending'
+                  ? '발송 중...'
+                  : emailStatus === 'sent'
+                    ? '발송됨'
+                    : '인증번호 발송'}
+              </ActionButton>
+            </InputGroup>
+            {emailError && <ErrorText>{emailError}</ErrorText>}
+            {emailStatus === 'sent' && !emailError && (
+              <SuccessText>
+                인증번호가 발송되었습니다. 이메일을 확인해주세요.
+              </SuccessText>
+            )}
+          </FormGroup>
+
+          {emailStatus === 'sent' && (
+            <FormGroup>
+              <Label htmlFor="verificationCode">인증번호</Label>
+              <InputGroup>
+                <Input
+                  id="verificationCode"
+                  name="verificationCode"
+                  type="text"
+                  placeholder="인증번호 6자리 입력"
+                  value={formData.verificationCode}
+                  onChange={handleChange}
+                  disabled={verificationStatus === 'success'}
+                  maxLength={6}
+                />
+                <ActionButton
+                  type="button"
+                  $variant="secondary"
+                  onClick={handleVerifyCode}
+                  disabled={
+                    verificationStatus === 'success' ||
+                    verificationStatus === 'verifying' ||
+                    !formData.verificationCode
+                  }
+                >
+                  {verificationStatus === 'success' ? '인증완료' : '인증확인'}
+                </ActionButton>
+              </InputGroup>
+              {verificationError && <ErrorText>{verificationError}</ErrorText>}
+              {verificationStatus === 'success' && (
+                <SuccessText>이메일 인증이 완료되었습니다.</SuccessText>
+              )}
+            </FormGroup>
+          )}
+
+          {submitError && (
+            <ErrorText
+              style={{
+                marginBottom: '1rem',
+                textAlign: 'center',
+                display: 'block',
+              }}
             >
-                <CloseButton type="button" aria-label="닫기" onClick={onClose}>
-                    ×
-                </CloseButton>
-                <ModalHeader>
-                    <ModalTitle id="signup-modal-title">코지스테이 회원가입</ModalTitle>
-                    <ModalSubtitle>여정을 시작하기 위해 계정을 만들어주세요.</ModalSubtitle>
-                </ModalHeader>
-
-                <Form onSubmit={handleSubmit}>
-                    <FormGroup>
-                        <Label htmlFor="username">아이디</Label>
-                        <Input
-                            id="username"
-                            name="username"
-                            type="text"
-                            placeholder="사용할 아이디를 입력하세요"
-                            value={formData.username}
-                            onChange={handleChange}
-                            required
-                        />
-                    </FormGroup>
-
-                    <FormGroup>
-                        <Label htmlFor="password">비밀번호</Label>
-                        <Input
-                            id="password"
-                            name="password"
-                            type="password"
-                            placeholder="비밀번호를 입력하세요 (8자 이상)"
-                            value={formData.password}
-                            onChange={handleChange}
-                            minLength={8}
-                            required
-                        />
-                    </FormGroup>
-
-                    <FormGroup>
-                        <Label htmlFor="passwordConfirm">비밀번호 확인</Label>
-                        <Input
-                            id="passwordConfirm"
-                            name="passwordConfirm"
-                            type="password"
-                            placeholder="비밀번호를 다시 한 번 입력하세요"
-                            value={formData.passwordConfirm}
-                            onChange={handleChange}
-                            required
-                        />
-                        {formData.passwordConfirm && formData.password !== formData.passwordConfirm && (
-                            <ErrorText>비밀번호가 일치하지 않습니다.</ErrorText>
-                        )}
-                        {formData.passwordConfirm && formData.password === formData.passwordConfirm && (
-                            <SuccessText>비밀번호가 일치합니다.</SuccessText>
-                        )}
-                    </FormGroup>
-
-                    <FormGroup>
-                        <Label htmlFor="nickName">닉네임</Label>
-                        <Input
-                            id="nickName"
-                            name="nickName"
-                            type="text"
-                            placeholder="사용할 닉네임을 입력하세요"
-                            value={formData.nickName}
-                            onChange={handleChange}
-                            required
-                        />
-                    </FormGroup>
-
-                    <FormGroup>
-                        <Label htmlFor="email">이메일</Label>
-                        <InputGroup>
-                            <Input
-                                id="email"
-                                name="email"
-                                type="email"
-                                placeholder="이메일 주소를 입력하세요"
-                                value={formData.email}
-                                onChange={handleChange}
-                                disabled={emailStatus === 'sent'}
-                                required
-                            />
-                            <ActionButton
-                                type="button"
-                                $variant="secondary"
-                                onClick={handleSendVerification}
-                                disabled={emailStatus === 'sending' || emailStatus === 'sent' || !formData.email}
-                            >
-                                {emailStatus === 'sending' ? '발송 중...' : emailStatus === 'sent' ? '발송됨' : '인증번호 발송'}
-                            </ActionButton>
-                        </InputGroup>
-                    </FormGroup>
-
-                    {emailStatus === 'sent' && (
-                        <FormGroup>
-                            <Label htmlFor="verificationCode">인증번호</Label>
-                            <InputGroup>
-                                <Input
-                                    id="verificationCode"
-                                    name="verificationCode"
-                                    type="text"
-                                    placeholder="인증번호 6자리 입력"
-                                    value={formData.verificationCode}
-                                    onChange={handleChange}
-                                    disabled={verificationStatus === 'success'}
-                                    maxLength={6}
-                                />
-                                <ActionButton
-                                    type="button"
-                                    $variant="secondary"
-                                    onClick={handleVerifyCode}
-                                    disabled={verificationStatus === 'success' || verificationStatus === 'verifying' || !formData.verificationCode}
-                                >
-                                    {verificationStatus === 'success' ? '인증완료' : '인증확인'}
-                                </ActionButton>
-                            </InputGroup>
-                            {verificationStatus === 'success' && (
-                                <SuccessText>이메일 인증이 완료되었습니다.</SuccessText>
-                            )}
-                        </FormGroup>
-                    )}
-
-                    <SubmitButton type="submit" $variant="primary">
-                        가입하기
-                    </SubmitButton>
-                </Form>
-            </SignupCard>
-        </Page>
-    );
+              {submitError}
+            </ErrorText>
+          )}
+          <SubmitButton type="submit" $variant="primary">
+            가입하기
+          </SubmitButton>
+        </Form>
+      </SignupCard>
+    </Page>
+  );
 };
 
 export default SignupModal;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, Outlet } from 'react-router-dom';
 import PublicLayout from '../layouts/PublicLayout/PublicLayout';
 import LandingPage from '../pages/landing/LandingPage';
 import MainPage from '../pages/main/MainPage';
@@ -26,113 +26,41 @@ export const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: 'landing', element: <LandingPage /> },
       { path: 'accommodation/:id', element: <AccommodationDetailPage /> },
-      {
-        path: 'payment/:id',
-        element: (
-          <RequireAuth>
-            <PaymentPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'payment/retry/:id',
-        element: (
-          <RequireAuth>
-            <PaymentPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'payment/success',
-        element: (
-          <RequireAuth>
-            <PaymentSuccessPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'payment/fail',
-        element: (
-          <RequireAuth>
-            <PaymentFailPage />
-          </RequireAuth>
-        ),
-      },
       { path: 'search', element: <SearchPage /> },
-      {
-        path: 'wishlist',
-        element: (
-          <RequireAuth>
-            <WishlistPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'wishlist/:favoriteId',
-        element: (
-          <RequireAuth>
-            <WishlistDetailPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'messages',
-        element: (
-          <RequireAuth>
-            <MessagePage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'account',
-        element: (
-          <RequireAuth>
-            <AccountPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'profile',
-        element: (
-          <RequireAuth>
-            <ProfilePage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'profile/edit',
-        element: (
-          <RequireAuth>
-            <ProfileEditPage />
-          </RequireAuth>
-        ),
-      },
-      {
-        path: 'profile/reviews',
-        element: (
-          <RequireAuth>
-            <ProfilePage />
-          </RequireAuth>
-        ),
-      },
       { path: 'users/:id', element: <UserPage /> },
+      {
+        element: (
+          <RequireAuth>
+            <Outlet />
+          </RequireAuth>
+        ),
+        children: [
+          { path: 'payment/:id', element: <PaymentPage /> },
+          { path: 'payment/retry/:id', element: <PaymentPage /> },
+          { path: 'payment/success', element: <PaymentSuccessPage /> },
+          { path: 'payment/fail', element: <PaymentFailPage /> },
+          { path: 'wishlist', element: <WishlistPage /> },
+          { path: 'wishlist/:favoriteId', element: <WishlistDetailPage /> },
+          { path: 'messages', element: <MessagePage /> },
+          { path: 'account', element: <AccountPage /> },
+          { path: 'profile', element: <ProfilePage /> },
+          { path: 'profile/edit', element: <ProfileEditPage /> },
+          { path: 'profile/reviews', element: <ProfilePage /> },
+        ],
+      },
     ],
   },
   {
     path: '/hosting',
     element: (
       <RequireAuth>
-        <HostingPage />
+        <Outlet />
       </RequireAuth>
     ),
-  },
-  {
-    path: '/hosting/become-a-host',
-    element: (
-      <RequireAuth>
-        <BecomeHostPage />
-      </RequireAuth>
-    ),
+    children: [
+      { index: true, element: <HostingPage /> },
+      { path: 'become-a-host', element: <BecomeHostPage /> },
+    ],
   },
 ]);
 

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -26,18 +26,95 @@ export const router = createBrowserRouter([
       { index: true, element: <MainPage /> },
       { path: 'landing', element: <LandingPage /> },
       { path: 'accommodation/:id', element: <AccommodationDetailPage /> },
-      { path: 'payment/:id', element: <PaymentPage /> },
-      { path: 'payment/retry/:id', element: <PaymentPage /> },
-      { path: 'payment/success', element: <PaymentSuccessPage /> },
-      { path: 'payment/fail', element: <PaymentFailPage /> },
+      {
+        path: 'payment/:id',
+        element: (
+          <RequireAuth>
+            <PaymentPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'payment/retry/:id',
+        element: (
+          <RequireAuth>
+            <PaymentPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'payment/success',
+        element: (
+          <RequireAuth>
+            <PaymentSuccessPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'payment/fail',
+        element: (
+          <RequireAuth>
+            <PaymentFailPage />
+          </RequireAuth>
+        ),
+      },
       { path: 'search', element: <SearchPage /> },
-      { path: 'wishlist', element: <WishlistPage /> },
-      { path: 'wishlist/:favoriteId', element: <WishlistDetailPage /> },
-      { path: 'messages', element: <MessagePage /> },
-      { path: 'account', element: <AccountPage /> },
-      { path: 'profile', element: <ProfilePage /> },
-      { path: 'profile/edit', element: <ProfileEditPage /> },
-      { path: 'profile/reviews', element: <ProfilePage /> },
+      {
+        path: 'wishlist',
+        element: (
+          <RequireAuth>
+            <WishlistPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'wishlist/:favoriteId',
+        element: (
+          <RequireAuth>
+            <WishlistDetailPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'messages',
+        element: (
+          <RequireAuth>
+            <MessagePage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'account',
+        element: (
+          <RequireAuth>
+            <AccountPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'profile',
+        element: (
+          <RequireAuth>
+            <ProfilePage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'profile/edit',
+        element: (
+          <RequireAuth>
+            <ProfileEditPage />
+          </RequireAuth>
+        ),
+      },
+      {
+        path: 'profile/reviews',
+        element: (
+          <RequireAuth>
+            <ProfilePage />
+          </RequireAuth>
+        ),
+      },
       { path: 'users/:id', element: <UserPage /> },
     ],
   },

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## 🔗 반영 브랜치

refactor/login -> dev

## 주요 변경 사항

### 1. 로그아웃 시 프라이빗 페이지 ➡️ 홈 리다이렉트 처리 (`router/index.tsx`)
* **기존 문제점:** 마이페이지, 위시리스트, 결제창 등 회원 정보 기반의 전용 페이지에서 로그아웃을 해도 화면이 메인으로 이동하지 않고 기본 데이터(예: 임시 닉네임)를 보여주며 페이지에 그대로 머무르는 현상이 있었습니다.
* **개선 사항:** 아래의 회원 전용 경로들을 인증 체크 컴포넌트인 `<RequireAuth>`로 래핑했습니다.
  * **대상 경로:** `/payment/**`, `/wishlist/**`, `/messages`, `/account`, `/profile/**`
  * **결과:** 위 페이지에서 로그아웃하거나 세션이 만료될 경우 즉시 안전하게 메인 페이지(`/`)로 리다이렉트됩니다.

### 2. 회원가입 에러 메시지 인라인화 및 린트 에러 해결 (`SignupModal.tsx`)
* **기존 문제점:** 
  1. 중복 이메일 가입 등 회원가입 도중 에러가 나면 브라우저의 기본 `alert()` 창이 실행되어 부자연스러웠습니다.
  2. 기존 코드에 포함되어 있던 `: any` 타입 때문에 커밋 시 ESLint 검사(`no-explicit-any`)가 실패하여 배포 자동화에 빌드 장애가 생길 우려가 있었습니다.
* **개선 사항:**
  * **인라인 에러 표시:** `alert()` 알림을 걷어내고, 이메일 입력창 하단 및 가입 버튼 위에 빨간색 인라인 텍스트(`<ErrorText>`)로 실시간 에러를 표시합니다.
  * **입력 흐름 개선:** 에러가 노출된 상태에서 사용자가 다시 타이핑(수정)을 시작하면 띄워져 있던 인라인 에러 문구가 자동으로 투명하게 가려지도록 처리했습니다.
  * **타입 안전성 보완:** `: any` 코드를 명확한 객체 타입 정의(`as { success?: boolean; message?: string } | null`)로 캐스팅하여 빌드 경고 및 린트 검사 오류를 완벽히 해결했습니다.
  
<img width="407" height="620" alt="image" src="https://github.com/user-attachments/assets/f36f0752-b56c-4d44-946a-2943279cc602" />

